### PR TITLE
fix: resolve lifecycle flow inconsistencies

### DIFF
--- a/.agent/rules/state_machine.md
+++ b/.agent/rules/state_machine.md
@@ -20,7 +20,7 @@ AI MUST self-enforce this phase order. Users may trigger transitions via slash c
 - `IMPLEMENTING` --(review pass)--> `REVIEWED`
 - `REVIEWED` --(test pass)--> `TESTED`
 - `TESTED` --(ship executed)--> `SHIPPED`
-- `IMPLEMENTING` --(evidence provided, quick-win/hotfix only)--> `SHIPPED`  [fast-path: skip REVIEWED/TESTED states when classification permits]
+- `IMPLEMENTING` --(evidence provided, quick-win only)--> `SHIPPED`  [fast-path: skip REVIEWED/TESTED states; quick-win only — hotfix MUST go through REVIEWED + TESTED]
 
 ## Spec Gate (Hard)
 
@@ -31,6 +31,14 @@ AI MUST self-enforce this phase order. Users may trigger transitions via slash c
 ## Read-Only Actions (No State Change)
 
 - Listing help, available commands, generating test skeletons, producing handoff summaries
+
+## Classification Escalation Rules
+
+These rules override the initial classification. AI MUST apply them during `/bootstrap` and re-check during `/implement` Mid-Execution Guard.
+
+- **Auth Escalation**: If a `quick-win` touches authentication, authorization, session management, or token handling → escalate to `hotfix` minimum. Hotfix requires REVIEWED + TESTED gates.
+- **Governance File Escalation**: If a `tiny-fix` modifies `.agent/rules/*`, `.agent/config.yaml`, or `AGENTS.md` → escalate to `quick-win` minimum.
+- **Scope Escalation**: If actual changes exceed classification threshold (e.g., `quick-win` touching >2 modules) → recommend rollback to `CLASSIFIED` and re-classify at higher tier.
 
 ## Hard Gates
 

--- a/.agent/workflows/bootstrap.md
+++ b/.agent/workflows/bootstrap.md
@@ -238,6 +238,8 @@ Every non-`tiny-fix` workflow MUST maintain two header fields in the active Work
 
 This costs < 10 tokens per phase entry and eliminates phase-tracking hallucination.
 
+**Session Caching**: If the agent transitions between phases within the SAME conversation (not resuming from handoff), it MAY trust its in-memory phase state and skip re-reading the Work Log header. The file read is only mandatory when: (a) resuming a Work Log from a prior session, or (b) the agent is uncertain about the current phase. The `Current Phase` header MUST still be written on every phase entry regardless of caching.
+
 ## 3. Expected Output Format
 
 1. Classification (with justification)

--- a/.agent/workflows/review.md
+++ b/.agent/workflows/review.md
@@ -9,6 +9,10 @@ Conduct strict review of current changes.
 
 **Phase Verification** (per bootstrap §2b): Read `Current Phase` from Work Log header. Verify transition to `review` is legal. If illegal, STOP. Otherwise update `Current Phase: review`. If a new commit was created since the last `Checkpoint SHA`, SHOULD refresh it.
 
+## Work Log Compaction Check
+
+Before review, check the active Work Log size. If it exceeds compaction thresholds (see `.agent/config.yaml` §worklog), compact per `/handoff` §6 BEFORE proceeding. This prevents bloated logs from inflating token costs during the review phase.
+
 ## Skill-Aware Review (Pre-Check)
 
 Apply the Phase-Entry Skill-Loading Protocol (AGENTS.md §Phase-Entry Skill Loading) for all skills listing `/review` in their phases. Read `Recommended Skills` from the active Work Log before selecting which skill guidance to apply in this phase. Then apply each skill's **"During /review:"** checklist items as additional review criteria. Explicitly state: "Reviewing with [skill-name] checklist applied."


### PR DESCRIPTION
## Summary
- Fix hotfix fast-path contradiction: `state_machine.md` allowed hotfix to skip review/test, contradicting `engineering_guardrails.md` §10
- Add Classification Escalation Rules to `state_machine.md` (auth, governance files, scope) — previously hidden in bootstrap.md only
- Add Work Log compaction check to `review.md` entry (was missing; implement.md already had it)
- Add session caching optimization for phase verification in `bootstrap.md` §2b

## Test plan
- [ ] Run a hotfix classification flow and verify review+test phases are enforced
- [ ] Run a quick-win touching auth code and verify escalation to hotfix
- [ ] Verify review.md triggers compaction on bloated Work Logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)