### PR TITLE
chore: add CODEOWNERS + repo protection setup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Agentic OS — Code Ownership
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default: maintainer owns everything
+* @KbWen
+
+# Governance core — changes here affect all downstream repos
+AGENTS.md @KbWen
+CLAUDE.md @KbWen
+.agent/rules/ @KbWen
+.agent/workflows/ @KbWen
+.agent/config.yaml @KbWen
+
+# Deploy infrastructure — high blast radius
+.agentcortex/bin/ @KbWen
+installers/ @KbWen
+
+# CI/CD
+.github/ @KbWen


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` — routes review requests to @KbWen for governance core, deploy infra, and CI
- Branch protection already configured via API (separate from this PR):
  - Required status checks: Framework Validation, ShellCheck, Check Markdown Links
  - Require branches to be up-to-date before merge
  - Block force push and branch deletion on main
  - Require conversation resolution
  - Admin bypass enabled (solo maintainer workflow)
- Repo settings updated: delete-branch-on-merge, auto-merge enabled, squash PR title
- 7 framework-specific labels created (governance, ci/cd, skill, deploy, breaking, platform, security)

## Protection Summary

| Setting | Value |
|---------|-------|
| Required status checks | ✅ 3 CI jobs must pass |
| Up-to-date before merge | ✅ Strict |
| Force push to main | ❌ Blocked |
| Delete main | ❌ Blocked |
| Conversation resolution | ✅ Required |
| Admin bypass | ✅ Enabled (solo maintainer) |
| Delete branch on merge | ✅ Auto |
| Secret scanning | ✅ Enabled |
| Push protection | ✅ Enabled |
| CODEOWNERS | ✅ @KbWen |

## Test plan
- [x] Branch protection verified via `gh api`
- [x] CI passes on this PR (validates CODEOWNERS doesn't break anything)
- [x] Labels created and visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)