### PR TITLE
fix: add production-readiness skill to trigger metadata

### DIFF
--- a/.agentcortex/metadata/trigger-compact-index.json
+++ b/.agentcortex/metadata/trigger-compact-index.json
@@ -98,6 +98,11 @@
       "load_policy": "on-match",
       "cost_risk": "medium",
       "kind": "skill"
+    },
+    "production-readiness": {
+      "load_policy": "phase-entry",
+      "cost_risk": "low",
+      "kind": "skill"
     }
   },
   "entries": [
@@ -737,6 +742,41 @@
       },
       "load_policy": "on-match",
       "content_hash": "ade1544e"
+    },
+    {
+      "id": "production-readiness",
+      "kind": "skill",
+      "platforms": [
+        "claude",
+        "codex",
+        "antigravity"
+      ],
+      "phase_scope": [
+        "review",
+        "ship"
+      ],
+      "detect_by": {
+        "classification": [
+          "feature",
+          "architecture-change"
+        ],
+        "intent_patterns": [
+          "observability check",
+          "production readiness",
+          "error handling audit"
+        ],
+        "scope_signals": [
+          "error handling",
+          "catch blocks",
+          "logging",
+          "crash reporting"
+        ],
+        "phase_conditions": [
+          "enter-review-or-ship"
+        ]
+      },
+      "load_policy": "phase-entry",
+      "content_hash": "39c08f81"
     }
   ]
 }

--- a/.agentcortex/metadata/trigger-registry.yaml
+++ b/.agentcortex/metadata/trigger-registry.yaml
@@ -500,3 +500,28 @@ entries:
     block_if_missed: false
     fallback_behavior: >
       Use the stable bootstrap or worktree-first workflow before changing branches.
+
+  - id: production-readiness
+    kind: skill
+    canonical_ref: .agent/skills/production-readiness
+    mirror_ref: .agents/skills/production-readiness/agents/openai.yaml
+    detail_ref: .agents/skills/production-readiness/SKILL.md
+    platforms: [claude, codex, antigravity]
+    phase_scope: [review, ship]
+    trigger_priority: soft
+    detect_by:
+      classification: [feature, architecture-change]
+      intent_patterns: ["observability check", "production readiness", "error handling audit"]
+      scope_signals: [error handling, catch blocks, logging, crash reporting]
+      failure_signals: []
+      phase_conditions: [enter-review-or-ship]
+    load_policy: phase-entry
+    cost_type: output
+    cost_risk: low
+    runtime_anchor:
+      - "engineering_guardrails.md#5.2a"
+      - ".agent/workflows/review.md#Error Observability Compliance"
+      - ".agent/workflows/ship.md#Observability Readiness Check"
+    block_if_missed: false
+    fallback_behavior: >
+      Use the stable review/ship flow and rely on engineering_guardrails.md §5.2a for error observability checks.

--- a/.agents/skills/production-readiness/agents/openai.yaml
+++ b/.agents/skills/production-readiness/agents/openai.yaml
@@ -1,0 +1,20 @@
+version: 1
+display_name: production-readiness
+short_description: Pre-ship observability readiness — verify error reporting uses production-observable sinks, log strategy is documented, and rollback telemetry is defined.
+icon_small: shield
+agentcortex:
+  summary_ref: .agent/skills/production-readiness
+  detail_ref: .agents/skills/production-readiness/SKILL.md
+  trigger_priority: soft
+  phase_scope: ["review", "ship"]
+  load_policy: phase-entry
+  cost_type: output
+  cost_risk: low
+  runtime_anchor: ["engineering_guardrails.md#5.2a", ".agent/workflows/review.md#Error Observability Compliance", ".agent/workflows/ship.md#Observability Readiness Check"]
+  detect_by:
+    classification: ["feature", "architecture-change"]
+    intent_patterns: ["observability check", "production readiness", "error handling audit"]
+    scope_signals: ["error handling", "catch blocks", "logging", "crash reporting"]
+    failure_signals: []
+    phase_conditions: ["enter-review-or-ship"]
+  fallback_behavior: Use the stable review/ship flow and rely on engineering_guardrails.md 5.2a for error observability checks.


### PR DESCRIPTION
## Summary

- Added `production-readiness` entry to `trigger-registry.yaml` with correct metadata (trigger_priority: soft, load_policy: phase-entry, cost_risk: low)
- Regenerated `trigger-compact-index.json` via `generate_compact_index.py`
- Created missing `agents/openai.yaml` mirror file for validation parity with other skills

Closes #7

## Evidence

```
Summary: pass=62 warn=1 fail=0 skip=2
Agentic OS integrity check passed
```

All 20 trigger entries validated, including the new `production-readiness` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)