### PR TITLE
feat: user-level skill preferences (pin/disable)

### DIFF
--- a/.agent/config.yaml
+++ b/.agent/config.yaml
@@ -56,3 +56,24 @@ domain_doc:
   # Advisory lock timeout for Domain Doc L2 writes.
   # Same schema as worklog_lock: .agentcortex/context/domain/<domain>.lock.json
   lock_stale_timeout_minutes: 15
+
+# User Skill Preferences — per-user persistent skill pinning/disabling.
+# Capability-by-presence: if the preferences file does not exist, this
+# entire feature is inert. Zero cost.
+# See: AGENTS.md §Skill Safety & Precedence item 8.
+user_preferences:
+  # Path (relative to repo root) where the user's personal preferences
+  # file is read. This path MUST be gitignored.
+  path: .agentcortex/context/private/user-preferences.yaml
+
+  # Skills that CANNOT be disabled by user preferences.
+  # In addition to this explicit list, any skill with
+  # trigger_priority: hard AND block_if_missed: true in the
+  # trigger-registry is implicitly protected.
+  protected_skills:
+    - verification-before-completion
+    - auth-security
+
+  # When a user pins more than this many skills with cost_risk: high,
+  # bootstrap emits an advisory (not blocking) about token cost.
+  high_cost_pin_advisory_threshold: 2

--- a/.agent/workflows/bootstrap.md
+++ b/.agent/workflows/bootstrap.md
@@ -289,6 +289,29 @@ This costs < 10 tokens per phase entry and eliminates phase-tracking hallucinati
 
    **Rule**: Do NOT limit to "0-2 skills". Recommend ALL skills whose conditions are met. A typical `feature` task should activate 4-8 skills.
    **Conflict Pass**: After choosing `Recommended Skills`, read `.agent/rules/skill_conflict_matrix.md` ONCE. If any recommended pair is marked `partial-conflict` or `conflict`, write the chosen precedence or scoping strategy to `## Conflict Resolution` in the Work Log. Later phases reuse that note instead of re-reading the matrix.
+
+### 3.6a. User Skill Preference Merge (Capability-by-Presence)
+
+> **Scope**: Non-`tiny-fix` only. Runs AFTER rule table + conflict pass, BEFORE writing `Recommended Skills` to Work Log.
+> **Config**: `.agent/config.yaml §user_preferences`
+
+1. Check if the file at `.agent/config.yaml §user_preferences.path` (default: `.agentcortex/context/private/user-preferences.yaml`) exists. If not, skip this subsection entirely. **Zero cost.**
+2. Parse the file as YAML. If malformed or empty: warn once (`"⚠️ User preferences file exists but is malformed. Skipping."`), skip. **NEVER block bootstrap.**
+3. **Validate skill IDs** against the bootstrap rule table (§3.6) or, when available, `.agentcortex/metadata/trigger-compact-index.json`. Warn on unknown IDs; ignore them.
+4. **For each `pinned` skill**:
+   a. If already in `auto_skills` → no-op (already recommended via auto-detection).
+   b. If its `Skip when` / classification column excludes the current classification AND entry does NOT have `force: true` → skip with note: `"Pinned skill [X] skipped: skip-when active for [classification]."`
+   c. If its `Skip when` excludes the current classification AND entry has `force: true` → add with provenance `(pin+forced)`. **Hard ceiling**: even with `force`, a skill CANNOT activate in a phase outside its `phase_scope` (from trigger-compact-index or rule table `Phases` column).
+   d. Otherwise → add with provenance `(pin)`.
+   e. For each newly added pinned skill, check `.agent/rules/skill_conflict_matrix.md` against all existing recommended skills. If `partial-conflict`: apply guidance and record in `## Conflict Resolution` with `[pinned by user preference]`. If `conflict`: warn user and ask which takes priority — do NOT silently resolve.
+5. **For each `disabled` skill**:
+   a. If skill has `trigger_priority: hard` AND `block_if_missed: true` in the trigger registry, OR is listed in `.agent/config.yaml §user_preferences.protected_skills` → ignore the disable, warn once: `"⚠️ Cannot disable protected skill [X]. Ignored."`
+   b. Otherwise → remove from recommended skills with provenance `(disabled by user-pref)`.
+6. **Token advisory**: If the final pinned set adds more than `high_cost_pin_advisory_threshold` skills with `cost_risk: high` (per compact index), emit: `"Note: [N] pinned high-cost skills may increase token usage."`
+7. Write the final merged set to `Recommended Skills` with provenance tags: `(auto)`, `(pin)`, `(pin+forced)`, `(disabled by user-pref)`, `(protected, disable ignored)`.
+
+**A skill in both `pinned` and `disabled`**: pin wins (explicit request > explicit removal). Warn: `"Skill [X] is both pinned and disabled. Pin takes precedence."`
+
 7. Context Read Receipt: MUST output:
    - `current_state.md` → [last modified date or key field you read]
    - Work Log → [status: existing|created|resumed]

--- a/.agent/workflows/routing.md
+++ b/.agent/workflows/routing.md
@@ -142,6 +142,8 @@ It does NOT contain governance rules — those remain in `AGENTS.md`.
 
 5. **Skill manual activation block**: Even when a user explicitly requests a skill, the bootstrap rule table's `Skip when` column governs. If the rule table says skip for the current classification, manual activation is blocked.
 
+6. **Pinned skill vs skip-when precedence**: Pinned skills from user preferences (`.agentcortex/context/private/user-preferences.yaml`) follow the same skip-when rules as manually activated skills UNLESS the pin entry includes `force: true`. Force-pinned skills override skip-when but still respect `phase_scope` boundaries — a skill cannot activate in a phase it was never designed for. This is the ONLY mechanism that can override skip-when; manual activation (rule 5) cannot. See bootstrap §3.6a.
+
 ---
 
 ## 5. Command Discovery Notes

--- a/.agentcortex/metadata/trigger-compact-index.json
+++ b/.agentcortex/metadata/trigger-compact-index.json
@@ -7,102 +7,122 @@
     "bootstrap-recommended-skills": {
       "load_policy": "always",
       "cost_risk": "medium",
-      "kind": "workflow"
+      "kind": "workflow",
+      "user_disableable": false
     },
     "phase-entry-skill-loading": {
       "load_policy": "always",
       "cost_risk": "medium",
-      "kind": "policy"
+      "kind": "policy",
+      "user_disableable": false
     },
     "test-driven-development": {
       "load_policy": "on-match",
       "cost_risk": "high",
-      "kind": "skill"
+      "kind": "skill",
+      "user_disableable": true
     },
     "verification-before-completion": {
       "load_policy": "phase-entry",
       "cost_risk": "medium",
-      "kind": "skill"
+      "kind": "skill",
+      "user_disableable": false
     },
     "systematic-debugging": {
       "load_policy": "on-failure",
       "cost_risk": "high",
-      "kind": "skill"
+      "kind": "skill",
+      "user_disableable": true
     },
     "red-team-adversarial": {
       "load_policy": "on-match",
       "cost_risk": "high",
-      "kind": "skill"
+      "kind": "skill",
+      "user_disableable": true
     },
     "writing-plans": {
       "load_policy": "phase-entry",
       "cost_risk": "low",
-      "kind": "skill"
+      "kind": "skill",
+      "user_disableable": true
     },
     "executing-plans": {
       "load_policy": "phase-entry",
       "cost_risk": "medium",
-      "kind": "skill"
+      "kind": "skill",
+      "user_disableable": true
     },
     "finishing-a-development-branch": {
       "load_policy": "on-match",
       "cost_risk": "medium",
-      "kind": "skill"
+      "kind": "skill",
+      "user_disableable": true
     },
     "api-design": {
       "load_policy": "on-match",
       "cost_risk": "medium",
-      "kind": "skill"
+      "kind": "skill",
+      "user_disableable": true
     },
     "database-design": {
       "load_policy": "on-match",
       "cost_risk": "high",
-      "kind": "skill"
+      "kind": "skill",
+      "user_disableable": true
     },
     "frontend-patterns": {
       "load_policy": "on-match",
       "cost_risk": "medium",
-      "kind": "skill"
+      "kind": "skill",
+      "user_disableable": true
     },
     "auth-security": {
       "load_policy": "on-match",
       "cost_risk": "high",
-      "kind": "skill"
+      "kind": "skill",
+      "user_disableable": false
     },
     "doc-lookup": {
       "load_policy": "on-match",
       "cost_risk": "low",
-      "kind": "skill"
+      "kind": "skill",
+      "user_disableable": true
     },
     "dispatching-parallel-agents": {
       "load_policy": "on-match",
       "cost_risk": "high",
-      "kind": "skill"
+      "kind": "skill",
+      "user_disableable": true
     },
     "subagent-driven-development": {
       "load_policy": "on-match",
       "cost_risk": "high",
-      "kind": "skill"
+      "kind": "skill",
+      "user_disableable": true
     },
     "requesting-code-review": {
       "load_policy": "on-match",
       "cost_risk": "low",
-      "kind": "skill"
+      "kind": "skill",
+      "user_disableable": true
     },
     "receiving-code-review": {
       "load_policy": "on-match",
       "cost_risk": "low",
-      "kind": "skill"
+      "kind": "skill",
+      "user_disableable": true
     },
     "using-git-worktrees": {
       "load_policy": "on-match",
       "cost_risk": "medium",
-      "kind": "skill"
+      "kind": "skill",
+      "user_disableable": true
     },
     "production-readiness": {
       "load_policy": "phase-entry",
       "cost_risk": "low",
-      "kind": "skill"
+      "kind": "skill",
+      "user_disableable": true
     }
   },
   "entries": [

--- a/.agentcortex/metadata/trigger-compact-index.json
+++ b/.agentcortex/metadata/trigger-compact-index.json
@@ -169,7 +169,7 @@
         ]
       },
       "load_policy": "always",
-      "content_hash": "0122bbab"
+      "content_hash": "0221268f"
     },
     {
       "id": "test-driven-development",

--- a/.agentcortex/metadata/trigger-registry.yaml
+++ b/.agentcortex/metadata/trigger-registry.yaml
@@ -11,6 +11,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [bootstrap]
     trigger_priority: hard
+    user_disableable: false
     detect_by:
       classification: [quick-win, feature, architecture-change, hotfix]
       intent_patterns: []
@@ -36,6 +37,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [plan, implement, review, test, handoff, ship]
     trigger_priority: hard
+    user_disableable: false
     detect_by:
       classification: [quick-win, feature, architecture-change, hotfix]
       intent_patterns: []
@@ -67,6 +69,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [implement, test]
     trigger_priority: contextual
+    user_disableable: true
     detect_by:
       classification: [feature, architecture-change]
       intent_patterns: ["用 TDD", "test first", "先寫測試", "red green refactor"]
@@ -94,6 +97,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [implement, test, ship]
     trigger_priority: hard
+    user_disableable: false
     detect_by:
       classification: [quick-win, feature, architecture-change, hotfix]
       intent_patterns: []
@@ -121,6 +125,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [implement, review, test, hotfix]
     trigger_priority: contextual
+    user_disableable: true
     detect_by:
       classification: [quick-win, feature, architecture-change, hotfix]
       intent_patterns: ["debug", "除錯", "找 bug"]
@@ -148,6 +153,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [review, test]
     trigger_priority: contextual
+    user_disableable: true
     detect_by:
       classification: [hotfix, feature, architecture-change]
       intent_patterns: ["red team", "adversarial test", "攻擊面分析", "紅隊測試"]
@@ -173,6 +179,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [plan]
     trigger_priority: advisory
+    user_disableable: true
     detect_by:
       classification: [quick-win, feature, architecture-change, hotfix]
       intent_patterns: ["幫我規劃", "write plan", "規劃怎麼做"]
@@ -198,6 +205,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [implement]
     trigger_priority: contextual
+    user_disableable: true
     detect_by:
       classification: [quick-win, feature, architecture-change, hotfix]
       intent_patterns: ["執行計畫", "execute the plan", "follow the plan"]
@@ -222,6 +230,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [ship, handoff]
     trigger_priority: advisory
+    user_disableable: true
     detect_by:
       classification: [quick-win, feature, architecture-change, hotfix]
       intent_patterns: ["finish branch", "merge 準備", "完成分支"]
@@ -247,6 +256,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [implement, review, test]
     trigger_priority: contextual
+    user_disableable: true
     detect_by:
       classification: [feature, architecture-change, hotfix]
       intent_patterns: ["API 設計", "endpoint conventions", "REST design"]
@@ -274,6 +284,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [plan, implement, review, test]
     trigger_priority: contextual
+    user_disableable: true
     detect_by:
       classification: [feature, architecture-change, hotfix]
       intent_patterns: ["資料庫設計", "schema design", "migration safety"]
@@ -301,6 +312,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [implement, review, test]
     trigger_priority: contextual
+    user_disableable: true
     detect_by:
       classification: [feature, architecture-change]
       intent_patterns: ["前端模式", "component patterns", "UI conventions"]
@@ -328,6 +340,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [plan, implement, review, test]
     trigger_priority: hard
+    user_disableable: false
     detect_by:
       classification: [tiny-fix, quick-win, feature, architecture-change, hotfix]
       intent_patterns: ["安全檢查", "auth check", "security review", "權限檢查"]
@@ -355,6 +368,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [implement, review]
     trigger_priority: contextual
+    user_disableable: true
     detect_by:
       classification: [quick-win, feature, architecture-change, hotfix]
       intent_patterns: ["查文件", "check docs", "查官方文檔", "read the docs", "看文件再做"]
@@ -382,6 +396,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [implement]
     trigger_priority: advisory
+    user_disableable: true
     detect_by:
       classification: [feature, architecture-change]
       intent_patterns: ["平行開發", "parallel agents", "dispatch subtasks"]
@@ -407,6 +422,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [implement]
     trigger_priority: advisory
+    user_disableable: true
     detect_by:
       classification: [feature, architecture-change]
       intent_patterns: ["subagent", "分派 agent", "multi-agent"]
@@ -432,6 +448,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [review, handoff]
     trigger_priority: advisory
+    user_disableable: true
     detect_by:
       classification: [quick-win, feature, architecture-change, hotfix]
       intent_patterns: ["請求 review", "request code review", "送 review", "要 review"]
@@ -458,6 +475,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [review]
     trigger_priority: contextual
+    user_disableable: true
     detect_by:
       classification: [quick-win, feature, architecture-change, hotfix]
       intent_patterns: ["接收 review", "review feedback", "收到 review 意見"]
@@ -483,6 +501,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [bootstrap, implement]
     trigger_priority: contextual
+    user_disableable: true
     detect_by:
       classification: [feature, architecture-change]
       intent_patterns: ["用 worktree", "git worktree", "worktree 隔離"]
@@ -509,6 +528,7 @@ entries:
     platforms: [claude, codex, antigravity]
     phase_scope: [review, ship]
     trigger_priority: contextual
+    user_disableable: true
     detect_by:
       classification: [feature, architecture-change]
       intent_patterns: ["observability check", "production readiness", "觀測性檢查"]

--- a/.agentcortex/templates/user-preferences.yaml
+++ b/.agentcortex/templates/user-preferences.yaml
@@ -1,0 +1,23 @@
+# Agentic OS — User Skill Preferences
+# Copy this file to: .agentcortex/context/private/user-preferences.yaml
+# This file is gitignored and personal to your environment.
+#
+# Docs: AGENTS.md §Skill Safety & Precedence item 8
+# Bootstrap merge: .agent/workflows/bootstrap.md §3.6a
+
+skill_preferences:
+  # Skills to always include in Recommended Skills (on top of auto-detected).
+  # - Plain skill ID → respects skip-when rules from the bootstrap rule table.
+  # - { skill-id: { force: true } } → overrides skip-when for that skill only,
+  #   but still respects phase_scope boundaries (a skill cannot activate in a
+  #   phase it was never designed for).
+  pinned: []
+  #   - test-driven-development
+  #   - api-design: { force: true }
+
+  # Skills to exclude from Recommended Skills.
+  # Protected skills (verification-before-completion, auth-security, and any
+  # skill with trigger_priority: hard + block_if_missed: true) cannot be
+  # disabled — the disable is silently ignored with a warning.
+  disabled: []
+  #   - dispatching-parallel-agents

--- a/.agentcortex/tools/trigger_runtime_core.py
+++ b/.agentcortex/tools/trigger_runtime_core.py
@@ -734,11 +734,14 @@ def _build_summary(registry: dict[str, Any]) -> dict[str, Any]:
     }
     for entry in registry.get("entries", []):
         entry_id = entry.get("id", "")
-        summary[entry_id] = {
+        item: dict[str, Any] = {
             "load_policy": entry.get("load_policy", "on-match"),
             "cost_risk": entry.get("cost_risk", "medium"),
             "kind": entry.get("kind", "skill"),
         }
+        if "user_disableable" in entry:
+            item["user_disableable"] = entry["user_disableable"]
+        summary[entry_id] = item
     return summary
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,8 @@ Global directives for all AI agents. Loaded automatically every turn
    - one `#### <phase>` block per phase already entered
    - each phase block must contain at least 2 `- Checklist:` bullets and 1 `- Constraint:` bullet. Compaction MUST preserve `## Skill Notes` verbatim.
 
-8. **Verification-Before-Completion 5-Gate Contract**: canonical contract is in `## Shared Phase Contracts — Verification Before Completion (5-Gate Sequence)` below. Apply it whenever the agent claims phase completion for any non-`tiny-fix` task.
+8. **User Skill Preferences (Capability-by-Presence)**: If `.agentcortex/context/private/user-preferences.yaml` exists, bootstrap merges its `pinned` and `disabled` lists into the recommended skill set AFTER auto-detection and conflict resolution. Protected skills (defined in `.agent/config.yaml §user_preferences.protected_skills` plus any skill with `trigger_priority: hard` AND `block_if_missed: true`) cannot be disabled by user preferences. Pinned skills respect `skip-when` rules by default; only entries with `force: true` can override `skip-when`, but never override `phase_scope` boundaries. See bootstrap §3.6a for the full merge algorithm. Template: `.agentcortex/templates/user-preferences.yaml`.
+9. **Verification-Before-Completion 5-Gate Contract**: canonical contract is in `## Shared Phase Contracts — Verification Before Completion (5-Gate Sequence)` below. Apply it whenever the agent claims phase completion for any non-`tiny-fix` task.
 
 ## Shared Phase Contracts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,38 +1,51 @@
 # Claude Integration Entry
 
-**MANDATORY**: Read `AGENTS.md` first — it contains all governance rules, gates, and state model.
-This file is the Claude-specific loader only. All rules live in `AGENTS.md` and `.agent/`.
+**MANDATORY**: Read and follow `AGENTS.md` before any action. It contains the governance rules, delivery gates, and state model that apply to ALL work in this repository.
 
-## Startup (every conversation)
+This repository uses **Agentic OS** — a governance-first AI agent framework.
+All rules live in `AGENTS.md` and `.agent/`. This file is the Claude-specific loader only.
 
-1. **Read `AGENTS.md`** — canonical governance. Follow exactly.
-2. **Assess scope** → tiny-fix (< 3 files, no semantic change): skip to Step 5. quick-win: read SSoT (Step 3), skip Step 4. feature/architecture-change/hotfix/uncertain: all steps.
-3. **Read `.agentcortex/context/current_state.md`** (SSoT). *(Skip for tiny-fix.)*
-4. **Read `.agent/rules/engineering_guardrails.md`**. *(Skip for tiny-fix and quick-win.)*
-5. Resume from Work Log at `.agentcortex/context/work/<worklog-key>.md` if exists. *(Skip for tiny-fix.)*
+## Startup (REQUIRED — every conversation)
 
-Do NOT invent workflows. Do NOT skip gates. Every response MUST end with `⚡ ACX`.
+1. **Read `AGENTS.md`** — this is the canonical governance document. Follow it exactly.
+2. **Assess task scope** from the user's message:
+   - **tiny-fix** (< 3 files, no semantic change, typo/rename/config) → **skip to Step 5**.
+   - **quick-win** (1-2 modules, clear scope, no cross-module impact) → read SSoT (Step 3), **skip Step 4** (guardrails). Essential quick-win rules are in `.agent/workflows/bootstrap.md` §7.
+   - **feature / architecture-change / hotfix / uncertain** → continue to Step 3.
+3. **Read `.agentcortex/context/current_state.md`** — Single Source of Truth (SSoT). *(Skip for tiny-fix.)*
+4. **Read `.agent/rules/engineering_guardrails.md`** — constitution for all engineering work. *(Skip for tiny-fix and quick-win.)*
+5. If a Work Log exists at `.agentcortex/context/work/<worklog-key>.md`, read it to resume context. *(Skip for tiny-fix.)*
+
+> **Why conditional loading?** AGENTS.md alone provides sentinel check, intent routing, and core directives — sufficient for small tasks. SSoT and full guardrails are loaded only when the task warrants them. This saves ~5,000 tokens for tiny-fix and ~3,500 tokens for quick-win.
+
+Do NOT invent your own workflow. Do NOT skip gates.
+Every response MUST end with `⚡ ACX` (sentinel check per AGENTS.md §11).
 
 ## Slash Commands
 
-`/command` → read `.claude/commands/<command>.md` for dispatch → execute `.agent/workflows/<command>.md`.
+All `/command` behavior is defined in `.agent/workflows/<command>.md`.
+When a user invokes a command, read `.claude/commands/<command>.md` for dispatch, then execute the canonical workflow.
 
 ## Skills
 
-Defined in `.agents/skills/*/SKILL.md` (full) and `.agent/skills/*` (metadata).
-- **Auto**: bootstrap §3.6 rule table recommends ALL matching skills.
-- **Manual**: user requests via natural language → activate in current phase.
-- **User pinned**: `.agentcortex/context/private/user-preferences.yaml` → bootstrap §3.6a merges after auto-detection.
+Skills are defined in `.agents/skills/*/SKILL.md` (full instructions) and `.agent/skills/*` (metadata summaries).
 
-Skills extend phases, never override governance. See `AGENTS.md` §Skill Safety & Precedence.
+- **Auto**: During `/bootstrap`, the rule table (bootstrap.md §3.6) recommends ALL matching skills. Do NOT limit to 0-2.
+- **Manual**: User requests a skill via natural language (e.g., "用 TDD"). Activate in the current phase.
+- **Phase entry**: Re-check Work Log `Recommended Skills` and apply cache policy per `.agent/config.yaml §skill_cache_policy`. Only on cache miss re-read `SKILL.md`.
 
-## Hard Rules
+Skills never override governance or gates — they extend the active workflow phase.
+Full cache/conflict mechanics: see `AGENTS.md` §Skill Safety & Precedence and §Shared Phase Contracts.
 
-- **Phase order is mandatory** — NEVER skip, even if user asks.
-- **No Evidence = No Completion** — tiny-fix: diff + 1-line. quick-win+: test logs or terminal output.
-- **SSoT protection** — Only `/ship` writes to SSoT (via `guard_context_write.py`). Exception: `/retro` Global Lessons.
-- **Installation**: Use `installers/deploy_brain.sh` or `deploy_brain.ps1`. NEVER manually copy framework files.
+## Hard Rules (Claude-specific reminders)
+
+All governance rules are in `AGENTS.md` and `engineering_guardrails.md`. Key reminders:
+
+- **Phase order is mandatory** — NEVER skip required phases, even if user asks. See `engineering_guardrails.md` §10.
+- **No Evidence = No Completion** — `tiny-fix`: diff + 1-line. `quick-win`+: test logs or terminal output.
+- **SSoT protection** — Only `/ship` writes to `.agentcortex/context/current_state.md` (via `guard_context_write.py`). Exception: `/retro` may append Global Lessons.
+- **Installation**: NEVER manually copy framework files. Use `installers/deploy_brain.sh` or `deploy_brain.ps1`.
 
 ## Validate
 
-Run `.agentcortex/bin/validate.ps1` (Windows) or `.agentcortex/bin/validate.sh` to verify integrity.
+Run `./.agentcortex/bin/validate.sh` (or `.agentcortex/bin/validate.ps1` on Windows) to verify structural integrity.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,51 +1,38 @@
 # Claude Integration Entry
 
-**MANDATORY**: Read and follow `AGENTS.md` before any action. It contains the governance rules, delivery gates, and state model that apply to ALL work in this repository.
+**MANDATORY**: Read `AGENTS.md` first — it contains all governance rules, gates, and state model.
+This file is the Claude-specific loader only. All rules live in `AGENTS.md` and `.agent/`.
 
-This repository uses **Agentic OS** — a governance-first AI agent framework.
-All rules live in `AGENTS.md` and `.agent/`. This file is the Claude-specific loader only.
+## Startup (every conversation)
 
-## Startup (REQUIRED — every conversation)
+1. **Read `AGENTS.md`** — canonical governance. Follow exactly.
+2. **Assess scope** → tiny-fix (< 3 files, no semantic change): skip to Step 5. quick-win: read SSoT (Step 3), skip Step 4. feature/architecture-change/hotfix/uncertain: all steps.
+3. **Read `.agentcortex/context/current_state.md`** (SSoT). *(Skip for tiny-fix.)*
+4. **Read `.agent/rules/engineering_guardrails.md`**. *(Skip for tiny-fix and quick-win.)*
+5. Resume from Work Log at `.agentcortex/context/work/<worklog-key>.md` if exists. *(Skip for tiny-fix.)*
 
-1. **Read `AGENTS.md`** — this is the canonical governance document. Follow it exactly.
-2. **Assess task scope** from the user's message:
-   - **tiny-fix** (< 3 files, no semantic change, typo/rename/config) → **skip to Step 5**.
-   - **quick-win** (1-2 modules, clear scope, no cross-module impact) → read SSoT (Step 3), **skip Step 4** (guardrails). Essential quick-win rules are in `.agent/workflows/bootstrap.md` §7.
-   - **feature / architecture-change / hotfix / uncertain** → continue to Step 3.
-3. **Read `.agentcortex/context/current_state.md`** — Single Source of Truth (SSoT). *(Skip for tiny-fix.)*
-4. **Read `.agent/rules/engineering_guardrails.md`** — constitution for all engineering work. *(Skip for tiny-fix and quick-win.)*
-5. If a Work Log exists at `.agentcortex/context/work/<worklog-key>.md`, read it to resume context. *(Skip for tiny-fix.)*
-
-> **Why conditional loading?** AGENTS.md alone provides sentinel check, intent routing, and core directives — sufficient for small tasks. SSoT and full guardrails are loaded only when the task warrants them. This saves ~5,000 tokens for tiny-fix and ~3,500 tokens for quick-win.
-
-Do NOT invent your own workflow. Do NOT skip gates.
-Every response MUST end with `⚡ ACX` (sentinel check per AGENTS.md §11).
+Do NOT invent workflows. Do NOT skip gates. Every response MUST end with `⚡ ACX`.
 
 ## Slash Commands
 
-All `/command` behavior is defined in `.agent/workflows/<command>.md`.
-When a user invokes a command, read `.claude/commands/<command>.md` for dispatch, then execute the canonical workflow.
+`/command` → read `.claude/commands/<command>.md` for dispatch → execute `.agent/workflows/<command>.md`.
 
 ## Skills
 
-Skills are defined in `.agents/skills/*/SKILL.md` (full instructions) and `.agent/skills/*` (metadata summaries).
+Defined in `.agents/skills/*/SKILL.md` (full) and `.agent/skills/*` (metadata).
+- **Auto**: bootstrap §3.6 rule table recommends ALL matching skills.
+- **Manual**: user requests via natural language → activate in current phase.
+- **User pinned**: `.agentcortex/context/private/user-preferences.yaml` → bootstrap §3.6a merges after auto-detection.
 
-- **Auto**: During `/bootstrap`, the rule table (bootstrap.md §3.6) recommends ALL matching skills. Do NOT limit to 0-2.
-- **Manual**: User requests a skill via natural language (e.g., "用 TDD"). Activate in the current phase.
-- **Phase entry**: Re-check Work Log `Recommended Skills` and apply cache policy per `.agent/config.yaml §skill_cache_policy`. Only on cache miss re-read `SKILL.md`.
+Skills extend phases, never override governance. See `AGENTS.md` §Skill Safety & Precedence.
 
-Skills never override governance or gates — they extend the active workflow phase.
-Full cache/conflict mechanics: see `AGENTS.md` §Skill Safety & Precedence and §Shared Phase Contracts.
+## Hard Rules
 
-## Hard Rules (Claude-specific reminders)
-
-All governance rules are in `AGENTS.md` and `engineering_guardrails.md`. Key reminders:
-
-- **Phase order is mandatory** — NEVER skip required phases, even if user asks. See `engineering_guardrails.md` §10.
-- **No Evidence = No Completion** — `tiny-fix`: diff + 1-line. `quick-win`+: test logs or terminal output.
-- **SSoT protection** — Only `/ship` writes to `.agentcortex/context/current_state.md` (via `guard_context_write.py`). Exception: `/retro` may append Global Lessons.
-- **Installation**: NEVER manually copy framework files. Use `installers/deploy_brain.sh` or `deploy_brain.ps1`.
+- **Phase order is mandatory** — NEVER skip, even if user asks.
+- **No Evidence = No Completion** — tiny-fix: diff + 1-line. quick-win+: test logs or terminal output.
+- **SSoT protection** — Only `/ship` writes to SSoT (via `guard_context_write.py`). Exception: `/retro` Global Lessons.
+- **Installation**: Use `installers/deploy_brain.sh` or `deploy_brain.ps1`. NEVER manually copy framework files.
 
 ## Validate
 
-Run `./.agentcortex/bin/validate.sh` (or `.agentcortex/bin/validate.ps1` on Windows) to verify structural integrity.
+Run `.agentcortex/bin/validate.ps1` (Windows) or `.agentcortex/bin/validate.sh` to verify integrity.


### PR DESCRIPTION
## Summary
- Users can persistently pin or disable skills via a gitignored personal file (`.agentcortex/context/private/user-preferences.yaml`), eliminating the need to repeat preferences every conversation
- Protected skills (`verification-before-completion`, `auth-security`) cannot be disabled — governance integrity preserved
- Per-skill `force: true` option allows overriding skip-when rules without a blanket global toggle
- Compressed `CLAUDE.md` from 52 → 38 lines with user-pinned skill reference added

## Changed files
| File | Change |
|------|--------|
| `.agent/config.yaml` | `user_preferences` section (path, protected_skills, threshold) |
| `.agent/workflows/bootstrap.md` | §3.6a — 7-step merge algorithm after auto-detection |
| `.agent/workflows/routing.md` | §6 — force-pin precedence rule |
| `AGENTS.md` | Skill Safety §8 — user preferences documentation |
| `trigger-compact-index.json` | `user_disableable` field on all 20 entries |
| `trigger-registry.yaml` | `user_disableable` field on all 20 entries |
| `.agentcortex/templates/user-preferences.yaml` | Template for users to copy |
| `CLAUDE.md` | Compressed + skill pin reference |

## Design decisions
- **File location**: `.agentcortex/context/private/` (already gitignored, bootstrap already scans it)
- **Merge timing**: After rule table + conflict matrix, before Work Log write — auto governance runs first
- **No global override**: Per-skill `force: true` instead of blanket `pin_override_skip` flag
- **Protected skills**: Dual protection — explicit config list + implicit `trigger_priority: hard` + `block_if_missed: true`

## Test plan
- [x] 127 existing tests pass (1 pre-existing failure unrelated)
- [x] JSON/YAML validity verified for all metadata files
- [ ] Manual: copy template to private/, bootstrap a task, verify pin/disable provenance tags appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)