### PR TITLE
fix: treat missing Python as FAIL in validate.sh

### DIFF
--- a/.agentcortex/bin/validate.sh
+++ b/.agentcortex/bin/validate.sh
@@ -244,7 +244,7 @@ fi
 
 run_python_check \
   "text integrity check" \
-  WARN \
+  FAIL \
   "$TEXT_INTEGRITY_CHECK_PY" \
   --root "$ROOT" \
   --baseline "$TEXT_INTEGRITY_BASELINE"
@@ -277,7 +277,7 @@ else
   record_result SKIP "metadata checks -- no trigger registry found"
 fi
 
-run_python_check "command sync check" WARN "$COMMAND_SYNC_CHECK" --root "$ROOT"
+run_python_check "command sync check" FAIL "$COMMAND_SYNC_CHECK" --root "$ROOT"
 
 if [[ -f "$ROOT/tools/audit_ai_paths.sh" ]]; then
   record_result FAIL "legacy audit helper should move under .agentcortex/tools/: $ROOT/tools/audit_ai_paths.sh"


### PR DESCRIPTION
## Summary
- `text integrity check` and `command sync check` in `validate.sh` used `WARN` when Python was unavailable, silently passing CI while skipping critical validation
- Changed both `run_python_check` calls from `WARN` to `FAIL` so missing Python surfaces as a blocking error
- `metadata deep validation` and `compact index freshness` already used `FAIL` — this makes the other Python-dependent checks consistent

## Evidence
```
Summary: pass=62 warn=1 fail=0 skip=2
Agentic OS integrity check passed
```

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)