### PR TITLE
feat: enhance skills with anti-rationalization and quality standards

### DIFF
--- a/.agentcortex/metadata/trigger-compact-index.json
+++ b/.agentcortex/metadata/trigger-compact-index.json
@@ -450,7 +450,7 @@
         ]
       },
       "load_policy": "on-match",
-      "content_hash": "1eaa7879"
+      "content_hash": "da759b65"
     },
     {
       "id": "dispatching-parallel-agents",
@@ -534,7 +534,7 @@
         ]
       },
       "load_policy": "on-match",
-      "content_hash": "92fac37d"
+      "content_hash": "c0330735"
     },
     {
       "id": "using-git-worktrees",
@@ -574,7 +574,7 @@
         ]
       },
       "load_policy": "phase-entry",
-      "content_hash": "7e65dd99"
+      "content_hash": "177dacdf"
     },
     {
       "id": "production-readiness",

--- a/.agents/skills/doc-lookup/SKILL.md
+++ b/.agents/skills/doc-lookup/SKILL.md
@@ -115,6 +115,32 @@ During /review:
 - [ ] All `// TODO: verify against official docs` caveat comments from /implement are resolved
 - [ ] Pinned version in dependency manifest matches the doc version that was consulted
 
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I'm confident about this API" | Confidence is not evidence. Training data contains outdated patterns that look correct but break against current versions. Verify. |
+| "Fetching docs wastes tokens" | Hallucinating an API wastes more. One fetch prevents hours of debugging a wrong function signature. |
+| "The docs won't have what I need" | If the docs don't cover it, that's valuable information — the pattern may not be officially recommended. |
+| "I'll just mention it might be outdated" | A disclaimer doesn't help. Either verify and cite, or clearly flag it as unverified. Hedging is the worst option. |
+| "This is a simple task, no need to check" | Simple tasks with wrong patterns become templates. The user copies your deprecated handler into ten components before discovering the modern approach. |
+
+## Conflict Detection Template
+
+When docs conflict with existing project code, surface the discrepancy — don't silently pick one:
+
+```
+CONFLICT DETECTED:
+The existing codebase uses [old pattern],
+but [framework version] docs recommend [new pattern].
+(Source: [doc URL])
+
+Options:
+A) Use the modern pattern — consistent with current docs
+B) Match existing code — consistent with codebase
+→ Which approach do you prefer?
+```
+
 ## Anti-Patterns
 
 - **"I know this API"**: Assuming training data is correct without verification. Framework APIs change between versions — always check.
@@ -122,8 +148,10 @@ During /review:
 - **Ignoring version**: Checking docs for v5 when the project uses v4. Always match the project's pinned version.
 - **Hallucinating parameters**: Inventing function parameters or config keys that don't exist. If you can't find it in the docs, it probably doesn't exist.
 - **One-and-done**: Checking docs once at the start and never again. Re-check when you encounter unexpected behavior.
+- **Silent conflict resolution**: Choosing between docs and existing code without telling the user.
 
 ## References
 
+- Source enrichment: [addyosmani/agent-skills — source-driven-development](https://github.com/addyosmani/agent-skills) (MIT)
 - Project ADR: `docs/adr/ADR-002-project-architecture.md` § Tech Stack
 - Engineering guardrails: `.agent/rules/engineering_guardrails.md`

--- a/.agents/skills/karpathy-principles/SKILL.md
+++ b/.agents/skills/karpathy-principles/SKILL.md
@@ -91,15 +91,43 @@ During /review:
 - [ ] Orphaned imports/variables from THIS change are cleaned up
 - [ ] Pre-existing dead code mentioned but not deleted
 
+## Code Simplification Checklist
+
+When reviewing or refactoring, apply Chesterton's Fence — understand WHY before removing:
+
+- [ ] Deep nesting (>3 levels) → extract to named functions
+- [ ] Long functions (>50 lines) → split by responsibility
+- [ ] Poor naming → rename to reveal intent
+- [ ] Speculative abstractions → remove if only one caller exists
+- [ ] Duplicate logic → extract only if 3+ occurrences (not 2)
+
+**Simplification rules:**
+- Preserve behavior exactly — simplification is NOT a feature change
+- Fewer lines is not always simpler — a 1-line nested ternary is worse than a 5-line if/else
+- Separate simplification commits from feature commits — never mix
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "It works, that's good enough" | Working code that's unreadable or architecturally wrong creates debt that compounds. |
+| "We'll clean it up later" | Later never comes. The current phase is the quality gate — use it. |
+| "I'm confident about this approach" | Confidence is not evidence. State your assumptions explicitly or verify against docs. |
+| "This abstraction might be useful later" | Don't preserve speculative abstractions. If there's only one caller, inline it. |
+| "I'll just quickly improve this unrelated code too" | Unscoped changes create noisy diffs and obscure the actual intent. Touch only what you must. |
+| "The tests pass, so it's good" | Tests are necessary but not sufficient. They don't catch architecture problems, security issues, or readability. |
+
 ## Anti-Patterns
 
 - **Silent assumption**: Picking one interpretation without surfacing alternatives
 - **Speculative flexibility**: Adding config/abstraction layers "for the future"
 - **Drive-by cleanup**: "Improving" adjacent code that wasn't part of the request
 - **Vague completion**: Claiming "done" without verifiable success criteria
+- **Rationalizing shortcuts**: Using plausible-sounding excuses to skip verification steps
 
 ## References
 
 - Source: [forrestchang/andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills) (MIT)
+- Simplification enrichment: [addyosmani/agent-skills — code-simplification](https://github.com/addyosmani/agent-skills) (MIT)
 - Complements: `writing-plans` (Think Before Coding), `verification-before-completion` (Goal-Driven Execution)
 - Guardrails: `.agent/rules/engineering_guardrails.md` §7 Scope Discipline

--- a/.agents/skills/receiving-code-review/SKILL.md
+++ b/.agents/skills/receiving-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: receiving-code-review
-description: Effectively process reviewer feedback; categorize blocking vs. advisory items.
+description: Effectively process reviewer feedback; categorize blocking vs. advisory items; apply 5-axis quality standard for self-review.
 ---
 
 # Receiving Code Review
@@ -8,6 +8,22 @@ description: Effectively process reviewer feedback; categorize blocking vs. advi
 ## Overview
 
 Review feedback requires structured handling to quickly converge into a mergeable state.
+When self-reviewing (AI reviewing its own output), apply the 5-axis quality standard below.
+
+## 5-Axis Quality Standard
+
+When conducting or receiving review, evaluate changes across ALL five axes:
+
+| Axis | Key Questions | Severity if Missed |
+|---|---|---|
+| **Correctness** | Does it do what it claims? Edge cases handled? Error paths covered? | Critical |
+| **Security** | Input validation? Auth checks? Injection vectors? Secrets exposure? | Critical |
+| **Performance** | N+1 queries? Unbounded loops? Missing pagination? Memory leaks? | High |
+| **Readability** | Clear naming? Reasonable function length? Comments where non-obvious? | Medium |
+| **Architecture** | Right abstraction level? Consistent with existing patterns? Coupling minimized? | Medium |
+
+**Change sizing guideline**: Review effectiveness drops sharply above ~100 changed lines.
+If a diff exceeds 100 lines, consider splitting into smaller reviewable units.
 
 ## Feedback Categorization
 
@@ -20,3 +36,16 @@ Review feedback requires structured handling to quickly converge into a mergeabl
 1. Reply iteratively to avoid omissions.
 2. Re-run related tests after changes.
 3. Report "Fixes + Verification Evidence + Reason for non-adoption (if any)".
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "It works, that's good enough" | Working code that's unreadable, insecure, or architecturally wrong creates debt that compounds. |
+| "The tests pass, so it's good" | Tests are necessary but not sufficient. They don't catch architecture problems, security issues, or readability. |
+| "AI-generated code is probably fine" | AI code needs more scrutiny, not less. It's confident and plausible, even when wrong. |
+| "We'll clean it up later" | Later never comes. The review is the quality gate — use it. |
+
+## References
+
+- Quality standard enrichment: [addyosmani/agent-skills — code-review-and-quality](https://github.com/addyosmani/agent-skills) (MIT)

--- a/docs/specs/_product-backlog.md
+++ b/docs/specs/_product-backlog.md
@@ -29,6 +29,9 @@ Governance file bloat review (2026-04-12) identified 10 findings across P0–P2:
 | 11 | Shipped specs accumulation — status-driven filtering | F-10 (P2) | — | quick-win | Pending | #1 |
 | 12 | validate.sh: add archive size + Global Lessons count checks | F-02,F-01 | — | quick-win | Pending | #2, #3 |
 | 13 | Warm→Cold LLM summarization pass in /ship | Design | — | feature | Pending | #1, #3 |
+| 14 | External Skill Research & Integration (Phase A: 3 core skills) | Gap Analysis | docs/specs/skill-research-integration.md | feature | Pending | — |
+| 15 | Anti-Rationalization Pattern (framework-wide enhancement) | Gap Analysis | docs/specs/skill-research-integration.md §4C | quick-win | Pending | #14 |
+| 16 | Skill Validation Pipeline (meta-governance) | Gap Analysis | docs/specs/skill-research-integration.md §4D | feature | Pending | #14 |
 
 ## Status Key
 

--- a/docs/specs/skill-research-integration.md
+++ b/docs/specs/skill-research-integration.md
@@ -1,0 +1,128 @@
+---
+status: draft
+title: "External Skill Research & Integration"
+created: 2026-04-13
+goal: "Mine open-source repos for behavioral/procedural skills that strengthen AI agent self-governance"
+---
+
+# External Skill Research & Integration
+
+## 1. Objective
+
+Systematically evaluate high-quality open-source repos and extract skills that fill
+governance gaps in Agentic OS. End goal: AI agents become better at self-discipline,
+not just following gates.
+
+## 2. Governance Gap Analysis
+
+Current inventory: 19 skills. Coverage is strong on **gates & workflows** but weak
+on **behavioral discipline** and **quality depth**.
+
+| Gap | Severity | Description |
+|---|---|---|
+| Anti-Rationalization | HIGH | No mechanism to counter agent excuses ("I'll add tests later") |
+| Change Sizing | HIGH | No upfront scope-estimation gate — agents underestimate then sprawl |
+| Code Review Depth | MEDIUM | Request/receive skills exist, but no *quality standard* for conducting reviews |
+| Performance Awareness | MEDIUM | No measure-first mindset; production-readiness covers logging but not perf |
+| Source-Grounded Decisions | MEDIUM | Agents hallucinate API usage instead of checking official docs first |
+| Documentation Discipline | LOW | No enforcement for doc-as-contract or ADR creation triggers |
+| Technical Debt Tracking | LOW | No periodic debt assessment or "shortcut → debt ticket" enforcement |
+| Testing Strategy Selection | LOW | TDD covers one pattern; no "match test type to risk level" guidance |
+
+## 3. Source Repos (Verified)
+
+| Priority | Repo | Stars | Format Compatibility | Integration Effort |
+|---|---|---|---|---|
+| P0 | `addyosmani/agent-skills` | 14.6k | SKILL.md + frontmatter (identical) | Low |
+| P1 | `tech-leads-club/agent-skills` | 2.1k | Antigravity-native | Low |
+| P2 | `VoltAgent/awesome-claude-code-subagents` | 17.2k | Markdown + YAML (similar) | Medium |
+| P3 | `hesreallyhim/awesome-claude-code` | 38.5k | Hub/index (curation source) | N/A |
+| P3 | `VoltAgent/awesome-agent-skills` | 15.5k | Mixed (catalog mining) | Medium |
+
+## 4. Skill Candidates — Detailed Selection
+
+### 4.1 From `addyosmani/agent-skills` (P0)
+
+Each skill includes anti-rationalization tables + evidence gates — a pattern
+we should adopt framework-wide.
+
+| Candidate Skill | Fills Gap | Phase Scope | Type | Priority |
+|---|---|---|---|---|
+| `code-review-and-quality` | Code Review Depth + Change Sizing | review | Procedural | P0 |
+| `performance-optimization` | Performance Awareness | review, implement | Procedural | P0 |
+| `source-driven-development` | Source-Grounded Decisions | implement, review | Behavioral | P0 |
+| `code-simplification` | Technical Debt + Anti-Rationalization | review | Behavioral | P1 |
+| `incremental-implementation` | Change Sizing (reinforcement) | implement | Behavioral | P1 |
+| `documentation-and-adrs` | Documentation Discipline | ship, handoff | Procedural | P2 |
+
+**Cross-cutting extraction**: Anti-rationalization table pattern → add to
+`engineering_guardrails.md` or create a meta-skill `anti-rationalization`.
+
+### 4.2 From `tech-leads-club/agent-skills` (P1)
+
+| Candidate | Value | Priority |
+|---|---|---|
+| Skill validation pipeline (Snyk) | Meta-governance: validate skills themselves | P1 |
+| Security-audited skill patterns | Enhance `auth-security` skill | P2 |
+
+### 4.3 From `VoltAgent/awesome-claude-code-subagents` (P2)
+
+| Candidate | Value | Priority |
+|---|---|---|
+| Security auditor subagent patterns | Reference for `red-team-adversarial` enhancement | P2 |
+| Multi-agent coordination patterns | Reference for `dispatching-parallel-agents` | P2 |
+
+## 5. Integration Phases (Revised — Integration-Only)
+
+After detailed analysis, `doc-lookup` already covers 70% of `source-driven-development`.
+All candidates are integrated into existing skills — zero new skills added.
+
+### Phase A: Enhance Existing Skills (P0) ✅ DONE
+
+| Target Skill | Enhancement | Source |
+|---|---|---|
+| `doc-lookup` | Anti-rationalization table + Conflict Detection Template | addyosmani/source-driven-development |
+| `karpathy-principles` | Anti-rationalization table + Code Simplification Checklist | addyosmani/code-simplification |
+| `receiving-code-review` | 5-Axis Quality Standard + Anti-rationalization table | addyosmani/code-review-and-quality |
+
+### Phase B: Future Candidates (P2, not yet started)
+
+| Candidate | Value | Source |
+|---|---|---|
+| Skill validation pipeline (Snyk) | Meta-governance | tech-leads-club/agent-skills |
+| Security auditor subagent patterns | Enhance red-team-adversarial | VoltAgent/awesome-claude-code-subagents |
+
+### Phase C: Reference Mining (Ongoing, P3)
+
+Use `hesreallyhim/awesome-claude-code` and `VoltAgent/awesome-agent-skills`
+as ongoing discovery sources. Check monthly for new community skills worth
+evaluating.
+
+## 6. Evaluation Criteria (per candidate skill)
+
+| Criterion | Weight | Question |
+|---|---|---|
+| Gap Coverage | 30% | Does it fill an identified governance gap? |
+| Phase Fit | 20% | Does it map to existing workflow phases? |
+| Token Cost | 15% | Is the SKILL.md ≤ 150 lines? (cost_risk: low preferred) |
+| Conflict Risk | 15% | Does it conflict with existing skills? |
+| Behavioral vs Procedural | 10% | Behavioral skills are scarcer — slight preference |
+| Community Signal | 10% | Star count, author credibility, maintenance status |
+
+## 7. Success Metrics
+
+- [x] 3 existing skills enhanced with anti-rationalization tables (Phase A)
+- [x] Code simplification checklist integrated into karpathy-principles
+- [x] 5-axis quality standard integrated into receiving-code-review
+- [x] Conflict detection template integrated into doc-lookup
+- [ ] `validate.sh` passes with all changes
+- [ ] Zero governance gaps rated HIGH remaining
+
+## 8. References
+
+- [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills)
+- [tech-leads-club/agent-skills](https://github.com/tech-leads-club/agent-skills)
+- [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents)
+- [hesreallyhim/awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code)
+- [VoltAgent/awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills)
+- [forrestchang/andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills) (already integrated as karpathy-principles)


### PR DESCRIPTION
## Summary

- Researched 5 open-source repos (addyosmani/agent-skills, tech-leads-club, VoltAgent, etc.) for AI agent self-governance patterns
- Instead of adding new skills, **enriched 3 existing skills** from addyosmani/agent-skills (14.6k stars, MIT):
  - `doc-lookup`: anti-rationalization table + conflict detection template
  - `karpathy-principles`: anti-rationalization table + code simplification checklist (Chesterton's Fence)
  - `receiving-code-review`: 5-axis quality standard (correctness/security/performance/readability/architecture)
- Added research spec (`docs/specs/skill-research-integration.md`) with gap analysis and future roadmap
- Updated product backlog with 3 new items (#14-#16)

**Key insight**: All enhancements are for AI self-governance — the anti-rationalization tables counter the agent's own tendency to cut corners (e.g., "I'm confident about this API" → "Confidence is not evidence").

## Test plan

- [x] `validate.sh`: 62 pass / 0 fail / 0 skip-relevant
- [x] No new skills added — zero change to bootstrap rule table, conflict matrix, or trigger-registry structure
- [x] Compact index regenerated (content hashes updated for 3 modified skills)

🤖 Generated with [Claude Code](https://claude.com/claude-code)