### PR TITLE
chore(governance): compress phase outputs + add Response Budget hard cap

### DIFF
--- a/.agent/workflows/audit.md
+++ b/.agent/workflows/audit.md
@@ -25,15 +25,19 @@ tasks:
 
 ## Expected Output Format
 
-After scanning the repository, output the following structured report:
+Apply `AGENTS.md §Phase Output Compression`. Chat response is the compact block below; full multi-section detail (system_map breakdown, per-module dependency graph, full file inventory) is written to an audit report file at `docs/reviews/<date>-audit.md` and referenced by path.
 
-1. **`existing_files`**: High-level summary of the file structure.
-2. **`system_map`**: Core modules and their dependencies.
-3. **`entry_points`**: How the application starts or is built.
-4. **`test_coverage`**: Status of existing tests.
-5. **`missing_docs`**: Critical documentation gaps that should be addressed first.
-6. **`recommended_next`**: The suggested next step (typically `/spec` or `/plan` to begin formalizing an area of the codebase).
-7. **`routing_actions`** (AC-29): For each significant finding that constitutes a design decision, constraint, or architectural gap, output a structured routing action block (MANDATORY — omit only if no actionable findings exist):
+```
+Files: <count> files across <N> top-level dirs
+System: <primary stack + key modules, 1 line>
+Entry: <entry-point command or "(see audit report)">
+Tests: <coverage summary, 1 line>
+Missing docs: <top 3 gaps>
+Next: <slash-command recommendation>
+Report: docs/reviews/<date>-audit.md
+```
+
+1. **`routing_actions`** (AC-29): For each significant finding that constitutes a design decision, constraint, or architectural gap, output a structured routing action block to the audit report file (MANDATORY — omit only if no actionable findings exist). In chat, report only `routing_actions: <N> pending` — do NOT paste the full blocks unless the user asks.
    ```yaml
    routing_actions:
      - finding: "<1-line summary of the finding>"

--- a/.agent/workflows/bootstrap.md
+++ b/.agent/workflows/bootstrap.md
@@ -242,12 +242,24 @@ This costs < 10 tokens per phase entry and eliminates phase-tracking hallucinati
 
 ## 3. Expected Output Format
 
-1. Classification (with justification)
-2. Goal
-3. Paths
-4. Constraints & AC
-5. Non-goals
-6. Recommended Skills: Use the deterministic rule table below to select skills. Write ALL matched skills (with one-line reason) to Work Log. **Skip for `tiny-fix`.** No file reads required at this stage — skill metadata is already in context. This embedded rule table is the canonical low-token trigger source during bootstrap; repos MAY layer registry / compact-index metadata on top later, but bootstrap does not depend on those files.
+> **Compact block, not a dashboard.** Apply `AGENTS.md §Phase Output Compression → /bootstrap`. The chat response is a summary pointer; the full record lives in the Work Log file. Do NOT reprint `Constraints`, `AC`, `Non-goals`, `Known Risk`, or `Read Plan` detail in chat — write them to the Work Log and reference by section name.
+
+Chat response template (≤ 10 lines for quick-win, ≤ 15 for feature/architecture):
+
+```
+Classification: <tier> — <1-line why>
+Goal: <1-line>
+Paths: <comma list or "(see Work Log §Task Description)">
+Skills: <comma list> (Ref: Work Log §Recommended Skills)
+Read: SSoT(<date>) · WorkLog(<new|resumed>) · Guardrails(<Full|Quick|Lite>)
+Next: <slash-command>
+```
+
+Everything below — Classification justification, Recommended Skills rule table, skill conflict pass, user preference merge, Context Read Receipt, Read Plan, Next Step options — is written to the Work Log sections. It is the AI's working notes, NOT the chat response. If the user needs detail, they will ask.
+
+### 3.6 Recommended Skills Rule Table
+
+Write the result to Work Log `## Recommended Skills` (provenance tags as per §3.6a). Chat response shows only the comma list per §3 template. Skip for `tiny-fix`. No file reads required at this stage — skill metadata is already in context. This embedded rule table is the canonical low-token trigger source during bootstrap; repos MAY layer registry / compact-index metadata on top later, but bootstrap does not depend on those files.
 
    **Mandatory Skills (always activate when condition met):**
 
@@ -313,22 +325,21 @@ This costs < 10 tokens per phase entry and eliminates phase-tracking hallucinati
 
 **A skill in both `pinned` and `disabled`**: pin wins (explicit request > explicit removal). Warn: `"Skill [X] is both pinned and disabled. Pin takes precedence."`
 
-7. Context Read Receipt: MUST output:
-   - `current_state.md` → [last modified date or key field you read]
-   - Work Log → [status: existing|created|resumed]
-   - Spec Scope → [list of determined-relevant spec files, or "none"]
-8. Read Plan (per `.agentcortex/docs/guides/context-budget.md`):
-   - Classification: [tier]
-   - Guardrails Mode: [Full|Quick|Lite] — determines which sections of `engineering_guardrails.md` apply
-   - Files to read: [list with sections]
-   - Files explicitly skipped: [list with reason]
-   - Estimated governance reads: [N files]
-9. Next Step Recommendation (based on classification):
-   - `tiny-fix`: → Proceed directly with inline plan.
-   - `quick-win`: → `/plan`
-   - `feature`: → `/brainstorm` or `/spec` (spec required before `/plan`)
-   - `architecture-change`: → `/brainstorm` → `/spec` (ADR + spec required before `/plan`)
-   - `hotfix`: → `/research` (systematic debugging)
+### 3.7 Work Log Content (written to the Work Log file, NOT emitted in chat)
+
+These items are the AI's working notes. They live in the Work Log sections listed in `AGENTS.md §Work Log Contract` and are NOT repeated in the chat response. Chat only shows the compact block in §3.
+
+- **Context Read Receipt** (→ Work Log `## Session Info` or `## Task Description`):
+  - `current_state.md` → [last modified date or key field read]
+  - Work Log → [status: existing|created|resumed]
+  - Spec Scope → [list of determined-relevant spec files, or "none"]
+- **Read Plan** (→ Work Log `## Task Description` or header): Classification, Guardrails Mode (Full|Quick|Lite), Files to read (with sections), Files explicitly skipped (with reason), Estimated governance reads.
+- **Next Step Recommendation** — the chat block's `Next:` field uses this map:
+  - `tiny-fix` → proceed directly with inline plan
+  - `quick-win` → `/plan`
+  - `feature` → `/brainstorm` or `/spec` (spec required before `/plan`)
+  - `architecture-change` → `/brainstorm` → `/spec` (ADR + spec required before `/plan`)
+  - `hotfix` → `/research` (systematic debugging)
 
 ## 4. Hard Checkpoints
 

--- a/.agent/workflows/govern-docs.md
+++ b/.agent/workflows/govern-docs.md
@@ -77,18 +77,14 @@ Restructure threshold is configurable via `.agent/config.yaml` `domain_doc.restr
 
 ### Output Summary
 
+Apply `AGENTS.md §Phase Output Compression`. Chat response is the compact block below; the full diff preview (shown pre-apply per Execution Steps §5) is not repeated in the post-apply summary.
+
 ```
-/govern-docs --restructure <domain> complete
-
-## Changes Applied
-- L1: docs/architecture/<domain>.md — rewritten (N lines, was M lines)
-- L2: docs/architecture/<domain>.log.md — N entries marked [superseded], M entries still active
-
-## Restructure Summary
-[1-2 sentence summary of what design state was captured in L1]
-
-## Next Step
-Domain doc is current. L2 continues to accumulate new entries from /ship.
+Restructure: <domain>
+L1: <path> — <M> → <N> lines
+L2: <path> — <X> superseded, <Y> active
+Summary: <1-line — what design state L1 now captures>
+Next: /ship continues to append new L2 entries
 ```
 
 ---

--- a/.agent/workflows/handoff.md
+++ b/.agent/workflows/handoff.md
@@ -29,21 +29,19 @@ Read-only logic. DOES NOT change state. Hard completion gate for non-`tiny-fix` 
 
 ## 3. Required Output Blocks
 
-- **Layer 1 (Handoff TL;DR, <= 10 lines)**:
-  - Goal
-  - Current State
-  - Next Action
-  - Blocker (or `none`)
-  - Owner
-  - Last Verified Command
-- **Layer 2 (Traceability)**:
-  - Done
-  - In Progress
-  - Blockers
-  - Next
-  - Risks
-  - References
-- **Resume Block**: MUST also write the following to the Work Log file:
+Apply `AGENTS.md §Phase Output Compression → /handoff`.
+
+**Chat response is Layer 1 ONLY (≤ 10 lines). Layer 2 and the Resume Block are written to the Work Log file — do NOT emit them in chat.**
+
+- **Layer 1 (Handoff TL;DR, chat output, ≤ 10 lines)**:
+  - Goal — 1 line
+  - Current State — 1 line
+  - Next Action — 1 line
+  - Blocker — 1 line or `none`
+  - Owner — name / agent id
+  - Last Verified Command — 1 line
+- **Layer 2 (Traceability, Work Log only — NOT chat)**: Done, In Progress, Blockers, Next, Risks, References. Append to Work Log `## Phase Summary` and related sections. If the user asks for the full traceability, expand.
+- **Resume Block**: MUST be written to the Work Log file:
 
 ```markdown
 ## Resume

--- a/.agent/workflows/implement.md
+++ b/.agent/workflows/implement.md
@@ -143,12 +143,21 @@ After implementation is complete and evidence is recorded, append one line to `#
 
 ## Post-Execution Report
 
-Apply the shared `Phase Output Compression` contract from `AGENTS.md`.
+Apply the shared `Phase Output Compression` contract from `AGENTS.md §Phase Output Compression → /implement`.
 
-- Summary of actual changes
-- Potential side-effects
-- Suggested verification/test commands
-- **Scope Divergence Check**: Compare actual modified files against planned target files. If extra files were touched, flag: "⚠️ Scope divergence: planned [N] files, touched [M] files. Extra: [list]. Confirm these are intentional? (yes/revert)"
+**Chat response is the compact block below. Do NOT re-narrate what each file changed — the diff is the evidence. Do NOT paste code that was just written.**
+
+```
+Files: <list of files touched> (planned: <N>, actual: <M>)
+Tests: <command> → <pass/fail>
+Checkpoint: <SHA or "(uncommitted)">
+Side-effects: <1-line or "none">
+```
+
+- **Scope Divergence Check**: If actual files ≠ planned files, add: `"⚠️ Scope divergence: planned [N], touched [M]. Extra: [list]. Intentional? (yes/revert)"`
+- Potential side-effects: 1 line max. Details go to Work Log `## Known Risk`.
+- Suggested verification commands: list them, do NOT run them here unless user asked.
+- If the user wants the per-file explanation, they will ask. Default is terse.
 
 ## Security Quick-Scan (Auto — No User Action Required)
 

--- a/.agent/workflows/plan.md
+++ b/.agent/workflows/plan.md
@@ -99,15 +99,28 @@ Apply the Phase-Entry Skill-Loading Protocol (AGENTS.md §Phase-Entry Skill Load
 
 ## Expected Output Format
 
-Apply the shared `Phase Output Compression` contract from `AGENTS.md`.
+Apply the shared `Phase Output Compression` contract from `AGENTS.md §Phase Output Compression → /plan`.
 
-1. Target Files
-2. Execution Steps (2-10 min granularity)
-   - Steps MUST be **Functionally Atomic** (a single logical unit of change, e.g., "Implement Data Schema").
-   - Each step MUST have a 1-line verification method (e.g., test command, logic check, or grep).
-3. Risks & Rollback Strategy
-4. Acceptance Criteria Coverage
-5. Non-goals
+**Chat response is the compact block below. NO section headers when the whole plan is < 15 lines. NO re-narration of the spec or task description.**
+
+```
+Target Files: <comma list>
+Steps:
+  1. <action> — verify: <1-line method>
+  2. <action> — verify: <1-line method>
+  ...
+Risk+Rollback: <1-line risk> / <1-line rollback>
+AC Coverage: AC-1→step-N, AC-2→step-M, ...
+Non-goals: <comma list or "none">
+Mode: Normal | Fast Lane
+```
+
+Rules:
+- Each step MUST be **Functionally Atomic** — one logical unit of change (e.g., "Implement Data Schema"), NOT a 2-paragraph explanation.
+- Each step MUST have a 1-line verification method (test command, grep, or logic check). No 3-bullet sub-checklists per step.
+- List ONLY files being modified (prevent scope creep).
+- Detail that belongs in the Work Log (cited spec sections, rejected alternatives, design doc links) goes to `## Risks` and `## External References` sections of the Work Log — NOT the chat block. Reference by `Ref: Work Log §<section>`.
+- If the user asks for more detail, expand. Default is terse.
 
 ## Quality Gates (ALL MUST PASS)
 

--- a/.agent/workflows/research.md
+++ b/.agent/workflows/research.md
@@ -9,7 +9,7 @@ Conduct autonomous exploratory research. AI investigates the codebase, external 
 
 1. **Investigate first, report after**: Read code, check git history, search for patterns, test hypotheses. Spend the effort upfront so the report is grounded in evidence, not speculation.
 
-2. **Structure findings** using this format:
+2. **Structure findings** using this format. Keep each bullet ≤ 1 line in chat. If a finding needs longer justification, write the detail to the Work Log `## Research Findings` section and reference it by section name — do NOT inline a paragraph in chat.
    - **Facts** (verified knowns): Things confirmed by reading code or running commands. Cite `file:line` references.
    - **Unknowns**: Things that need further investigation or require human input to resolve.
    - **Assumptions**: Things you believe to be true but haven't verified. Mark confidence level (High / Medium / Low).

--- a/.agent/workflows/retro.md
+++ b/.agent/workflows/retro.md
@@ -7,18 +7,28 @@ Conduct a retrospective for the current task.
 
 Output Format:
 
-1. Keep (What went well)
-2. Problem (What to improve)
-3. Try (Action items for next time)
-4. Doc Health: Did this task create or reference more than 1 spec file for the same feature?
+Apply `AGENTS.md §Phase Output Compression`. Chat response is the compact KPT block below (≤ 6 lines). Everything under items 4–7 is Work Log content — do NOT emit it in chat unless the user asks.
+
+```
+Keep: <1-line — what went well>
+Problem: <1-line — what to improve>
+Try: <1-line — action for next time>
+Lessons: <count appended to Work Log | none>
+Spec Seeds: <count | none>
+```
+
+Work Log content (NOT chat):
+
+1. Keep / Problem / Try — expanded bullets if the session had multiple themes.
+2. Doc Health: Did this task create or reference more than 1 spec file for the same feature?
    - If YES: record the proposed merge in the Work Log and let `/ship` update the Spec Index through guarded SSoT write.
-5. Lessons Append: If Problems exist, append to the current Work Log (max 3 bullets) AND convert repeatable lessons to structured Global Lessons format.
+3. Lessons Append: If Problems exist, append to the current Work Log (max 3 bullets) AND convert repeatable lessons to structured Global Lessons format.
    - Structured format: `- [Category: <tag>][Severity: <HIGH|MEDIUM|LOW>][Trigger: <normalized-trigger>] <lesson>`
    - **Cap enforcement**: Before appending, count existing entries in `current_state.md` `## Global Lessons`. If count ≥ `document_lifecycle.global_lessons_max_entries` (default: 20 from `.agent/config.yaml`), archive the oldest LOW-severity entries to `.agentcortex/context/archive/global-lessons-archive.md` until count is under the cap. HIGH-severity entries are pinned and exempt from archival — they can only be removed by explicit user request.
-- If a lesson should persist globally, append it to `current_state.md` via `.agentcortex/tools/guard_context_write.py` when Python is available. **Python-unavailable fallback**: write directly to `current_state.md` with equivalent intent. This is the only non-ship SSoT write exception. Stage 1 keeps missing guard receipts as a diagnostic warning only; see `.agentcortex/docs/guides/guarded-context-writes.md`.
-6. Spec Seeds: Did the AI make any architectural decisions or discover new feature requirements during development that are NOT currently written in any formal Spec?
+   - If a lesson should persist globally, append it to `current_state.md` via `.agentcortex/tools/guard_context_write.py` when Python is available. **Python-unavailable fallback**: write directly to `current_state.md` with equivalent intent. This is the only non-ship SSoT write exception. Stage 1 keeps missing guard receipts as a diagnostic warning only; see `.agentcortex/docs/guides/guarded-context-writes.md`.
+4. Spec Seeds: Did the AI make any architectural decisions or discover new feature requirements during development that are NOT currently written in any formal Spec?
    - If YES: Append these to the current Work Log under a `## Spec Seeds` heading, and proactively ask the user: "I recorded [N] undocumented design decisions. Would you like me to formally add them to the Specs now?"
-7. Spec Gap Check: Did this task modify code in a module/feature area that has NO Spec coverage at all in the Spec Index?
+5. Spec Gap Check: Did this task modify code in a module/feature area that has NO Spec coverage at all in the Spec Index?
    - If YES and the change was `quick-win` or higher: Append to `## Spec Seeds` with tag `[NEW-SPEC-NEEDED]` and notify: "⚠️ Module [name] has no Spec coverage. Recommend creating `docs/specs/<module-name>.md` to prevent future documentation decay."
    - Advisory for `quick-win`; MANDATORY action for `feature` and above.
 

--- a/.agent/workflows/review.md
+++ b/.agent/workflows/review.md
@@ -175,20 +175,23 @@ AI MUST verify its own review before outputting:
 
 ## Output Format
 
-Apply the shared `Phase Output Compression` contract from `AGENTS.md`.
+Apply the shared `Phase Output Compression` contract from `AGENTS.md §Phase Output Compression → /review`.
 
-- **Burden of Proof table** (mandatory — see above)
-- Issues found (with severity)
-- Security findings (per §5 format above)
-- Red Team findings (if triggered — per Red Team Report format)
-- External References verdict (verified / missing / stale)
-- Fix suggestions
-- Ready to commit? (Yes/No — blocked if: any AC is `✗ UNPROVEN` without `[NEEDS_HUMAN]` tag, OR unresolved CRITICAL/HIGH security findings, OR CRITICAL Red Team findings)
+**Chat response leads with the Burden of Proof table. Everything else is terse.**
 
-Compression rule:
-- Do not reprint the full task description, plan, or AC prose if it already exists in the Work Log.
-- Prefer delta-only references such as changed AC verdicts, newly discovered risks, or missing evidence since `/implement`.
-- If no issues are found, state that directly and keep residual-risk commentary to one short block.
+Required chat content (in this order):
+1. **Burden of Proof table** (mandatory — see §Burden of Proof Protocol). Table only; no prose preamble.
+2. **Issues** — 1 line per issue: `<severity>: <file:line> — <1-line>`. If none: `Issues: none`.
+3. **Security** — 1 line. If none: `Security: clean`. Findings detail goes to Work Log.
+4. **Red Team** — 1 line (only if triggered). Findings detail goes to Work Log.
+5. **External Refs** — `verified | missing | stale` with count.
+6. **Verdict** — `Ready to commit: yes | no`. If `no`, 1-line reason.
+
+Compression rules:
+- Do not reprint the full task description, plan, or AC prose — they are in the Work Log.
+- Do NOT include "Fix suggestions" in chat unless the user asks. Write them to Work Log `## Review Feedback` instead.
+- Delta-only: state what changed since `/implement`, not what the whole branch does.
+- If zero issues: one line (`Issues: none`) is sufficient. No "residual risk commentary" paragraph.
 
 ## Domain Decisions Tag Validation (AC-10, feature / architecture-change)
 

--- a/.agent/workflows/ship.md
+++ b/.agent/workflows/ship.md
@@ -109,17 +109,25 @@ If ANY condition fails, MUST reject `/ship` and output missing list.
 
 ## Output Format
 
-Apply the shared `Phase Output Compression` contract from `AGENTS.md`.
+Apply the shared `Phase Output Compression` contract from `AGENTS.md §Phase Output Compression → /ship`.
 
-- Commit message (Conventional Commits)
-- Change summary (bullet points)
-- Test results (Evidence)
-- Doc sync status (Did `current_state.md` update?)
-- Known risks and rollback strategy
+**Chat response is the compact block below. Do NOT replay full implementation, review, or test narratives — they are in the Work Log. Do NOT paste the full commit message body when the title line is enough.**
 
-Compression rule:
-- summarize final deltas and evidence references only
-- do not replay full implementation/review/test narratives that are already stored in the Work Log
+```
+Commit: <conventional-commits title>  (Ref: <SHA>)
+Changes: <1-line delta summary>
+Evidence: Ref: Work Log §Evidence
+SSoT: updated | skipped (reason)
+Risk: <1-line or "none">
+Archive: <path> | <pending>
+```
+
+Compression rules:
+- One line per field. No decorative headers when the whole block is < 10 lines.
+- Evidence goes by reference (`Ref: Work Log §Evidence`), never re-pasted in chat.
+- Rollback strategy: 1 line. Full rollback plan lives in Work Log `## Known Risk`.
+- Known risks: the **unresolved** count and 1-line summary. Resolved risks do not appear in chat.
+- If the user asks for the full commit body, change summary, or test output, expand. Default is terse.
 
 ## Phase Summary Update
 

--- a/.agent/workflows/test.md
+++ b/.agent/workflows/test.md
@@ -110,11 +110,22 @@ No evidence = no completion. This is non-negotiable.
 
 ## Output Compression Rule
 
-Apply the shared `Phase Output Compression` contract from `AGENTS.md`.
+Apply the shared `Phase Output Compression` contract from `AGENTS.md §Phase Output Compression → /test`.
 
-- Report test commands, pass/fail counts, AC coverage deltas, and unresolved risks only.
-- Do not reprint the full test skeleton or full AC list unless coverage changed or a failure requires it.
-- If adversarial testing ran, summarize new adversarial evidence rather than replaying the standard test narrative.
+**Chat response is the compact block below. NO full test log pasted in chat — the log lives in the Work Log `## Evidence` section.**
+
+```
+Commands: <comma list>
+Result: <passed>/<total> passed, <failed> failed
+AC coverage: <AC-N covered | delta since /implement>
+Adversarial: <pass | findings recorded in Work Log | n/a>
+Unresolved: <1-line or "none">
+```
+
+- Do not reprint the full test skeleton or the AC list — they are in the Work Log.
+- Do not paste the full pytest/junit output in chat. Summarize counts; persist the full output in the Work Log.
+- If a test fails, 1 line per failure: `<test_id>: <1-line cause>`. Full traceback goes to Work Log.
+- If the user asks for the full log or traceback, expand. Default is terse.
 
 ## Phase Summary Update
 

--- a/.agentcortex/docs/guides/token-governance.md
+++ b/.agentcortex/docs/guides/token-governance.md
@@ -93,3 +93,49 @@ Compaction procedure:
 2. Move older entries to `.agentcortex/context/archive/work/<worklog-key>-<YYYYMMDD>.md`.
 3. Add a pointer line in the active log: `Compacted: <date>, archive: <path>`.
 4. Never compact away the evidence required by `/ship` gate.
+
+## 8. Output Brevity (AI Response Token Discipline)
+
+Input-token optimization (reading strategy, context caching, file slimming) is undermined if AI *output* stays verbose. Output tokens cost the same as input tokens and compound every turn. This section is the canonical rule for AI response style; `AGENTS.md §Core Directives → Response Brevity` is its 1-line enforcement pointer.
+
+### Official Grounding
+
+- **Claude Code Best Practices** — [code.claude.com/docs/en/best-practices](https://code.claude.com/docs/en/best-practices):
+  > *"Keep it concise. For each line, ask: 'Would removing this cause Claude to make mistakes?' If not, cut it. Bloated CLAUDE.md files cause Claude to ignore your actual instructions!"*
+- **Anthropic Prompting Best Practices** — [platform.claude.com prompting-best-practices](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices):
+  > *"More direct and grounded: Provides fact-based progress reports rather than self-celebratory updates. Less verbose: May skip detailed summaries for tool calls, jumping directly to the next action. Respond directly without preamble. Do not start with phrases like 'Here is...', 'Based on...', etc."*
+
+### DO
+
+- **Default to terse.** When unsure between short and thorough, pick short.
+- **Lead with the answer.** The first line answers the user's question or states the outcome; reasoning comes after only if asked.
+- **Compress structure.** Single sentence > bullet list > table > multi-section dashboard. Use the lightest structure that fits.
+- **Trust the diff.** For code/doc edits, the diff itself is evidence — do not re-narrate what every hunk changed.
+- **Reference, don't re-quote.** Point to Work Log Evidence, file:line, or a URL instead of pasting content again.
+- **End when done.** A short response that ends after answering is correct, not lazy.
+
+### DON'T
+
+- ❌ **Preamble**: *"I'll now proceed to..."*, *"Let me check..."*, *"Based on the analysis..."*, *"Here is the requested..."*.
+- ❌ **Postamble self-summary**: *"I've now completed..."*, *"To summarize what I did..."*, *"In conclusion, the changes are..."*.
+- ❌ **Decorative framing**: emoji dividers, horizontal rules, section headers when the whole response is 3 lines.
+- ❌ **Multi-section dashboards** for simple results: a "Summary / Details / Next Steps" template when a sentence would do.
+- ❌ **Re-explaining the task** back to the user before answering.
+- ❌ **Unprompted recommendations** tacked on ("You might also want to consider...") unless directly risk-relevant.
+
+### When Verbosity IS Appropriate
+
+- **User explicitly asks** for a detailed report, audit, review, or explanation.
+- **Governance-required artifacts**: gate blocks, plan artifacts (target files + AC), ship evidence, handoff summaries. These have a prescribed minimum content by workflow — meet it, don't exceed it.
+- **Risk escalation**: when about to take a destructive or high-blast-radius action, explicitly list the blast radius and ask for confirmation. Brevity yields to safety.
+- **Correction of a prior mistake**: when the AI was wrong earlier, it's acceptable to spend extra lines naming the error and the correction so the user can verify.
+
+### Enforcement
+
+- Self-check before emitting any response longer than ~10 lines: "Did the user ask for this level of detail, or am I padding?"
+- Phase reports (bootstrap / plan / implement / review / ship) MUST still contain the governance-prescribed content, but trim every decorative surface not in that prescription.
+- If a user feedback memory exists (e.g., `feedback_response_brevity.md`), it outranks default behavior — honor the specific preference recorded there.
+
+### Rationale (Why this matters enough to be a rule)
+
+Every verbose response is an input-token tax on the *next* turn (the conversation history replays), plus the output-token cost of the current turn. A 500-token padded response over 10 turns = 5,000 output tokens + 5,000×N cumulative input as history replays. Tightening response style is the single highest-leverage optimization after input-file slimming — and unlike file slimming, it applies to every session of every task forever.

--- a/.agentcortex/metadata/lifecycle-scenarios.json
+++ b/.agentcortex/metadata/lifecycle-scenarios.json
@@ -15,13 +15,15 @@
         "executing-plans",
         "verification-before-completion",
         "systematic-debugging",
-        "finishing-a-development-branch"
+        "finishing-a-development-branch",
+        "karpathy-principles"
       ],
       "triggered_skills": [
         "writing-plans",
         "executing-plans",
         "verification-before-completion",
-        "finishing-a-development-branch"
+        "finishing-a-development-branch",
+        "karpathy-principles"
       ],
       "notes": "Required gates per AGENTS.md hard rules: bootstrap → plan → implement → evidence → ship. Review/test are optional coverage, NOT required phases."
     },
@@ -44,7 +46,8 @@
         "red-team-adversarial",
         "requesting-code-review",
         "finishing-a-development-branch",
-        "production-readiness"
+        "production-readiness",
+        "karpathy-principles"
       ],
       "triggered_skills": [
         "writing-plans",
@@ -54,7 +57,8 @@
         "red-team-adversarial",
         "requesting-code-review",
         "finishing-a-development-branch",
-        "production-readiness"
+        "production-readiness",
+        "karpathy-principles"
       ],
       "notes": "Implementation repeats approximate Red-Green-Refactor loops; test repeats cover regression reruns."
     },
@@ -81,7 +85,8 @@
         "red-team-adversarial",
         "requesting-code-review",
         "finishing-a-development-branch",
-        "production-readiness"
+        "production-readiness",
+        "karpathy-principles"
       ],
       "triggered_skills": [
         "writing-plans",
@@ -95,7 +100,8 @@
         "red-team-adversarial",
         "requesting-code-review",
         "finishing-a-development-branch",
-        "production-readiness"
+        "production-readiness",
+        "karpathy-principles"
       ],
       "notes": "Models a heavier feature where auth and data concerns widen the review and test surface. doc-lookup activates because task touches framework APIs."
     },
@@ -115,7 +121,8 @@
         "systematic-debugging",
         "red-team-adversarial",
         "requesting-code-review",
-        "finishing-a-development-branch"
+        "finishing-a-development-branch",
+        "karpathy-principles"
       ],
       "triggered_skills": [
         "executing-plans",
@@ -123,7 +130,8 @@
         "systematic-debugging",
         "red-team-adversarial",
         "requesting-code-review",
-        "finishing-a-development-branch"
+        "finishing-a-development-branch",
+        "karpathy-principles"
       ],
       "notes": "Models a bug-fix path where repeated observe-hypothesize-verify loops inflate implement and test passes."
     },
@@ -154,7 +162,8 @@
         "red-team-adversarial",
         "requesting-code-review",
         "finishing-a-development-branch",
-        "production-readiness"
+        "production-readiness",
+        "karpathy-principles"
       ],
       "triggered_skills": [
         "writing-plans",
@@ -171,7 +180,8 @@
         "red-team-adversarial",
         "requesting-code-review",
         "finishing-a-development-branch",
-        "production-readiness"
+        "production-readiness",
+        "karpathy-principles"
       ],
       "notes": "Models the broadest lifecycle path with parallelization, platform coordination, and repeated review/test passes. doc-lookup activates because task touches framework APIs across all layers."
     },
@@ -194,7 +204,8 @@
         "systematic-debugging",
         "red-team-adversarial",
         "finishing-a-development-branch",
-        "production-readiness"
+        "production-readiness",
+        "karpathy-principles"
       ],
       "triggered_skills": [
         "receiving-code-review",
@@ -203,7 +214,8 @@
         "verification-before-completion",
         "red-team-adversarial",
         "finishing-a-development-branch",
-        "production-readiness"
+        "production-readiness",
+        "karpathy-principles"
       ],
       "notes": "Models the cost of reviewer feedback cycles where review and implementation phases repeat before shipping."
     }

--- a/.agentcortex/metadata/trigger-compact-index.json
+++ b/.agentcortex/metadata/trigger-compact-index.json
@@ -175,7 +175,7 @@
         ]
       },
       "load_policy": "always",
-      "content_hash": "e7478969"
+      "content_hash": "9a61a553"
     },
     {
       "id": "test-driven-development",

--- a/.agentcortex/tests/test_helpers.py
+++ b/.agentcortex/tests/test_helpers.py
@@ -18,8 +18,14 @@ def sanitize_deployed_ssot(target: Path) -> None:
             adr_lines += [f"  - {adr_dir}/{f.name}\n" for f in sorted(d.glob("ADR-*.md"))]
     replacement = r'\1\n' + ''.join(adr_lines) if adr_lines else r'\1 none\n'
     content = re.sub(r'(\*\*ADR Index\*\*:)\n(?:\s+-\s+\S.*\.md\n)*', replacement, content)
-    # Replace Active Backlog value with none
-    content = re.sub(r'(\*\*Active Backlog\*\*:)\s*`[^`]+`', r'\1 none', content)
+    # Replace Active Backlog value with none. Support both:
+    #   - backtick-wrapped file paths (post-bootstrap state)
+    #   - the `(none yet)` placeholder used in the initial template
+    content = re.sub(
+        r'(\*\*Active Backlog\*\*:)\s*(?:`[^`]+`|\(none yet\))',
+        r'\1 none',
+        content,
+    )
     # Remove Spec Index file entries (keep header and instruction lines).
     # Support both older backtick-wrapped entries and current plain bullet entries.
     content = re.sub(

--- a/.agentcortex/tests/test_lifecycle_contract.py
+++ b/.agentcortex/tests/test_lifecycle_contract.py
@@ -32,9 +32,9 @@ class LifecycleContractTests(unittest.TestCase):
     def test_phase_output_compression_contract_is_canonical(self) -> None:
         """AGENTS.md should define the shared compression contract used by phase workflows."""
         self.assertIn("### Phase Output Compression", self.agents_text)
-        self.assertIn("`/plan` should output the gate block plus the plan itself", self.agents_text)
-        self.assertIn("`/review` should lead with the burden-of-proof table", self.agents_text)
-        self.assertIn("`/test` should report commands, pass/fail counts, coverage deltas", self.agents_text)
+        self.assertIn("`/plan` \u2192 gate + plan", self.agents_text)
+        self.assertIn("`/review` \u2192 burden-of-proof table", self.agents_text)
+        self.assertIn("`/test` \u2192 commands + pass/fail + coverage delta", self.agents_text)
 
     def test_plan_workflow_does_not_require_extra_wait_after_explicit_request(self) -> None:
         """Plan should proceed directly when the user explicitly asked for planning."""

--- a/.agentcortex/tests/test_lifecycle_skill_activation.py
+++ b/.agentcortex/tests/test_lifecycle_skill_activation.py
@@ -69,12 +69,14 @@ EXPECTED_SCENARIO_SKILLS = {
             "verification-before-completion",
             "systematic-debugging",
             "finishing-a-development-branch",
+            "karpathy-principles",
         },
         "triggered": {
             "writing-plans",
             "executing-plans",
             "verification-before-completion",
             "finishing-a-development-branch",
+            "karpathy-principles",
         },
     },
     "feature-core-logic-tdd": {
@@ -88,6 +90,7 @@ EXPECTED_SCENARIO_SKILLS = {
             "requesting-code-review",
             "finishing-a-development-branch",
             "production-readiness",
+            "karpathy-principles",
         },
         "triggered": {
             "writing-plans",
@@ -98,6 +101,7 @@ EXPECTED_SCENARIO_SKILLS = {
             "requesting-code-review",
             "finishing-a-development-branch",
             "production-readiness",
+            "karpathy-principles",
         },
     },
     "feature-api-auth-db": {
@@ -115,6 +119,7 @@ EXPECTED_SCENARIO_SKILLS = {
             "requesting-code-review",
             "finishing-a-development-branch",
             "production-readiness",
+            "karpathy-principles",
         },
         "triggered": {
             "writing-plans",
@@ -129,6 +134,7 @@ EXPECTED_SCENARIO_SKILLS = {
             "requesting-code-review",
             "finishing-a-development-branch",
             "production-readiness",
+            "karpathy-principles",
         },
     },
     "hotfix-debug-loop": {
@@ -139,6 +145,7 @@ EXPECTED_SCENARIO_SKILLS = {
             "red-team-adversarial",
             "requesting-code-review",
             "finishing-a-development-branch",
+            "karpathy-principles",
         },
         "triggered": {
             "executing-plans",
@@ -147,6 +154,7 @@ EXPECTED_SCENARIO_SKILLS = {
             "red-team-adversarial",
             "requesting-code-review",
             "finishing-a-development-branch",
+            "karpathy-principles",
         },
     },
     "architecture-multi-agent": {
@@ -167,6 +175,7 @@ EXPECTED_SCENARIO_SKILLS = {
             "requesting-code-review",
             "finishing-a-development-branch",
             "production-readiness",
+            "karpathy-principles",
         },
         "triggered": {
             "writing-plans",
@@ -184,6 +193,7 @@ EXPECTED_SCENARIO_SKILLS = {
             "requesting-code-review",
             "finishing-a-development-branch",
             "production-readiness",
+            "karpathy-principles",
         },
     },
     "post-review-feedback-loop": {
@@ -196,6 +206,7 @@ EXPECTED_SCENARIO_SKILLS = {
             "red-team-adversarial",
             "finishing-a-development-branch",
             "production-readiness",
+            "karpathy-principles",
         },
         "triggered": {
             "receiving-code-review",
@@ -205,6 +216,7 @@ EXPECTED_SCENARIO_SKILLS = {
             "red-team-adversarial",
             "finishing-a-development-branch",
             "production-readiness",
+            "karpathy-principles",
         },
     },
 }

--- a/.agentcortex/tests/test_skill_notes_contract.py
+++ b/.agentcortex/tests/test_skill_notes_contract.py
@@ -123,10 +123,17 @@ class SkillNotesContractTests(unittest.TestCase):
         conditional. Phase workflows reference AGENTS.md instead of repeating the prose."""
         # AGENTS.md retains the detailed conditional text in §Shared Phase Contracts
         agents_text = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        # Capability-by-presence: metadata is checked first, with an explicit
+        # fallback clause so missing metadata files MUST NOT block skill loading.
         self.assertIn(
-            "if the repo also has `.agentcortex/metadata/trigger-compact-index.json`",
-            agents_text.casefold(),
-            "AGENTS.md: compact-index check should be conditional, not universal",
+            "`.agentcortex/metadata/trigger-compact-index.json`",
+            agents_text,
+            "AGENTS.md: Phase-Entry Skill Loading must reference the compact-index metadata path",
+        )
+        self.assertIn(
+            "If neither metadata file exists",
+            agents_text,
+            "AGENTS.md: Phase-Entry Skill Loading must carry the capability-by-presence fallback",
         )
         # AGENTS.md §Shared Phase Contracts has the canonical config.yaml reference
         self.assertIn(

--- a/.agentcortex/tests/test_trigger_metadata_tools.py
+++ b/.agentcortex/tests/test_trigger_metadata_tools.py
@@ -98,7 +98,7 @@ class TriggerMetadataToolTests(unittest.TestCase):
     def test_validator_passes_on_repo_state(self) -> None:
         result = run_tool(".agentcortex/tools/validate_trigger_metadata.py", "--root", ".")
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("20 entries, 6 lifecycle scenarios, and fresh compact index parity", result.stdout)
+        self.assertIn("21 entries, 6 lifecycle scenarios, and fresh compact index parity", result.stdout)
 
     def test_compact_index_check_passes_on_repo_state(self) -> None:
         result = run_tool(".agentcortex/tools/generate_compact_index.py", "--root", ".", "--check")

--- a/.agentcortex/tests/test_trigger_registry_format.py
+++ b/.agentcortex/tests/test_trigger_registry_format.py
@@ -46,7 +46,7 @@ class TriggerRegistryFormatTests(unittest.TestCase):
     def test_entry_count_matches_expected(self) -> None:
         """Guard against accidental entry loss during format migration."""
         data = load_data(REGISTRY_PATH)
-        self.assertEqual(len(data["entries"]), 20, "Expected 20 trigger entries")
+        self.assertEqual(len(data["entries"]), 21, "Expected 21 trigger entries")
 
     def test_detect_by_fields_are_lists(self) -> None:
         """detect_by sub-fields that should be lists MUST be lists."""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ Global directives for all AI agents. Loaded automatically every turn
 - **Learning Propagation Rule**: Only repeatable process mistakes MUST be recorded as reusable lessons and included in handoff; minor one-off mistakes stay local, and behavior-boundary changes MUST escalate to Spec/ADR.
 - **Read-Once Discipline**: Read `AGENTS.md` and `engineering_guardrails.md` (when required) once at the start of the session. Do NOT re-read them in subsequent turns — the content persists in conversation history. **Safety Valve**: If the agent detects genuine uncertainty about a specific governance rule, a targeted re-read of at most ONE `##`-level section of the relevant file is permitted and does not count as a Token Leak violation. Do NOT re-read the full file under this exception.
 - **Context Pruning**: If user interaction has exceeded 8+ turns on the same task, MUST proactively suggest: "We're at [N] turns. To save tokens, I recommend running a handoff and continuing in a new conversation. Proceed? (yes/no)". Do NOT wait for the user to notice. Self-initiate this suggestion.
+- **Response Brevity**: Default to short, information-dense output. No preamble ("Here's what I'll do..."), no postamble self-summary ("I've now completed..."), no decorative tables or multi-section dashboards when a sentence suffices. Expand ONLY when the user explicitly asks for detail, or when producing a gate block / plan artifact / ship evidence that governance requires. Grounded in [Claude Code Best Practices](https://code.claude.com/docs/en/best-practices) ("Keep it concise... Bloated files cause Claude to ignore your actual instructions") and [Anthropic Prompting Best Practices](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices) ("Respond directly without preamble"). Full rule and examples: `.agentcortex/docs/guides/token-governance.md §8 Output Brevity`.
+- **Response Budget (Hard Cap)**: Chat responses ≤ 8 lines of prose + essential structured blocks (gate YAML, compact-block template, burden-of-proof table, commit hash — these do NOT count toward the prose cap, but must themselves be terse). Claude Code's default system prompt uses `≤4 lines unless necessary`; this 8-line budget is 2× that baseline to accommodate governance receipts, and is the hard ceiling — not a soft target. Structured phase outputs (`/bootstrap`, `/plan`, `/implement`, `/review`, `/test`, `/handoff`, `/ship`, `/retro`, `/audit`, `/govern-docs`) are all subject to this budget. Required fields listed in workflow "Expected Output Format" sections are a **ceiling, not a floor** — skip any field that does not change the next-phase decision. If a field's value is `none`, `n/a`, or identical to the previous phase, omit it.
 
 ## vNext State Model
 
@@ -145,11 +147,20 @@ Each phase adds local scope after these 5 gates (see individual workflow files f
 
 ### Phase Output Compression
 
-When moving through `/plan`, `/implement`, `/review`, `/test`, and `/ship`, phase outputs MUST stay compact and delta-oriented:
+When moving through `/bootstrap`, `/plan`, `/implement`, `/review`, `/test`, `/handoff`, and `/ship`, phase chat outputs MUST stay compact and delta-oriented. The chat response is a summary of what landed in the Work Log file — NOT a re-emission of everything the Work Log already captures.
 
-- No redundant "awaiting confirmation" after gate pass when user explicitly requested the phase.
-- Reuse prior evidence by reference (`Ref: Work Log Evidence`), not re-narration.
-- Each phase outputs only its delta: `/plan` → gate + plan; `/review` → burden-of-proof table + delta since implement; `/test` → commands + pass/fail + coverage delta; `/ship` → final deltas + evidence refs + remaining constraints.
+- No redundant "awaiting confirmation" after gate pass when the user explicitly requested the phase.
+- Reuse prior evidence by reference (`Ref: Work Log Evidence`, `Ref: Work Log §<section>`), not re-narration.
+- The Work Log file is the persistent record. Do NOT duplicate its contents in the chat response. A 1-line pointer + key decisions is sufficient.
+- Each phase outputs only its delta in chat:
+  - `/bootstrap` → Classification (+1-line why), Goal, Skills (comma list), Context Read Receipt (1 line), Next Step. Full Constraints, AC, Non-goals, Risks, and the Read Plan live in the Work Log file, NOT in the chat response.
+  - `/plan` → gate + plan (compact block: Target Files · Steps · Risk+Rollback · AC Coverage · Mode). No section headers when the block is < 15 lines.
+  - `/implement` → files changed (list), tests run (1 line), checkpoint SHA. No code re-narration.
+  - `/review` → burden-of-proof table + delta since implement. No re-printing the task description.
+  - `/test` → commands + pass/fail + coverage delta. No re-printing the test skeleton.
+  - `/handoff` → pointer to archived Work Log + 3-line Resume block.
+  - `/ship` → final deltas + evidence refs + remaining constraints. No multi-paragraph prose.
+- **Workflow Expected Output Format is the ceiling, not the floor.** When a workflow file prescribes an output template, that template is the MAXIMUM chat output, not a required minimum. Skip any listed field that does not change the next-phase decision — if a field's value is `none`, `n/a`, or unchanged since the previous phase, omit it. Do NOT add extra decorative sections, bonus explanations, or "summary of what I just did" blocks on top of the template. Governed by the `Response Budget (Hard Cap)` in `## Core Directives` — chat prose ≤ 8 lines + essential structured blocks.
 
 ## Multi-Session Concurrency (Antigravity)
 


### PR DESCRIPTION
## Summary
- Shift token savings from hot-path input reduction (blocked by test invariants) to runtime output reduction via compact-block templates across 10 workflow files
- Add explicit Response Budget (Hard Cap) of ≤8 lines prose + essential structured blocks to AGENTS.md, grounded in Claude Code's ≤4-lines baseline (2×)
- Close two sibling-project gaps: explicit numerical cap on chat prose + skip-unchanged-fields rule for Expected Output Format templates
- Fix 9 pre-existing test-drift failures (baseline 9F/169P → 0F/178P)

## What changed
- **AGENTS.md**: +Response Budget Hard Cap directive; Phase Output Compression bullet rewritten to state "ceiling, not floor" + skip-unchanged-fields
- **10 workflows** (bootstrap, plan, implement, review, test, ship, handoff, audit, retro, govern-docs): reference \`AGENTS.md §Phase Output Compression\` as single anchor; compact-block output templates
- **retro.md**: compact KPT block (≤6 lines) at top of Output Format; items 4–7 relabeled "Work Log content (NOT chat)"
- **govern-docs.md**: replaced decorative 3-part header dashboard with 5-line compact Restructure block
- **research.md**: ≤1-line bullet rule in Structure findings

## What did NOT change
- Skill-Aware Auto-Enforced blocks (TDD/SDD/auth-security/verification-before-completion) untouched
- Phase verification, gate receipts, burden-of-proof table, state machine, SSoT writes, skill cache, test invariants all preserved

## Test plan
- [x] pytest full suite: 178/178 pass
- [x] validate.sh: pass=62 warn=4 fail=1 skip=2 (identical to baseline)
- [x] All 10 affected workflows grep-verified to reference \`AGENTS.md §Phase Output Compression\`
- [x] Structural validator + trigger-compact-index regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)