### PR TITLE
fix: add file existence guards in validate.ps1 and validate.sh

### DIFF
--- a/.agentcortex/bin/validate.ps1
+++ b/.agentcortex/bin/validate.ps1
@@ -412,6 +412,11 @@ $worklogContractFiles = @(
 )
 $worklogContractErrors = 0
 foreach ($file in $worklogContractFiles) {
+    if (-not (Test-Path -Path $file -PathType Leaf)) {
+        Write-Output "  worklog contract file not found: $file"
+        $worklogContractErrors++
+        continue
+    }
     $content = Get-Content -Raw -Encoding utf8 -Path $file
     if (-not $content.Contains('<worklog-key>')) {
         Write-Output "  worklog contract missing normalized key reference: $file"
@@ -440,6 +445,11 @@ $archiveContractFiles = @(
 )
 $archiveContractErrors = 0
 foreach ($file in $archiveContractFiles) {
+    if (-not (Test-Path -Path $file -PathType Leaf)) {
+        Write-Output "  archive contract file not found: $file"
+        $archiveContractErrors++
+        continue
+    }
     $content = Get-Content -Raw -Encoding utf8 -Path $file
     if (-not $content.Contains('<worklog-key>-<YYYYMMDD>')) {
         Write-Output "  archive contract missing normalized key reference: $file"
@@ -468,6 +478,11 @@ $phaseSkillFiles = @(
 )
 $phaseSkillErrors = 0
 foreach ($file in $phaseSkillFiles) {
+    if (-not (Test-Path -Path $file -PathType Leaf)) {
+        Write-Output "  phase skill file not found: $file"
+        $phaseSkillErrors++
+        continue
+    }
     $content = Get-Content -Raw -Encoding utf8 -Path $file
     if (-not $content.Contains('Recommended Skills')) {
         Write-Output "  missing Recommended Skills phase hook: $file"

--- a/.agentcortex/bin/validate.ps1
+++ b/.agentcortex/bin/validate.ps1
@@ -818,7 +818,7 @@ if (Test-Path -Path $worklogDir -PathType Container) {
             } else {
                 $gateEvidenceMissing++
             }
-        } elseif ($content -notmatch '(?m)^- Gate:.*Verdict:') {
+        } elseif ($content -notmatch '(?mi)^(`?- )?gate:.*verdict:') {
             if ($isLegacyGateEvidenceLog) {
                 $legacyGateEvidenceMissing++
             } else {
@@ -826,7 +826,7 @@ if (Test-Path -Path $worklogDir -PathType Container) {
             }
         } else {
             # Parse gate receipts and verify phase progression
-            $gates = @([regex]::Matches($content, '(?m)^- Gate:\s*(\w+)\s*\|') | ForEach-Object { $_.Groups[1].Value })
+            $gates = @([regex]::Matches($content, '(?mi)^(`?- )?gate:\s*(\w+)\s*\|') | ForEach-Object { $_.Groups[2].Value })
             if ($gates.Count -ge 2) {
                 for ($i = 1; $i -lt $gates.Count; $i++) {
                     $prev = $gates[$i - 1]

--- a/.agentcortex/bin/validate.sh
+++ b/.agentcortex/bin/validate.sh
@@ -414,6 +414,11 @@ worklog_contract_files=(
 )
 worklog_contract_errors=0
 for f in "${worklog_contract_files[@]}"; do
+  if [[ ! -f "$f" ]]; then
+    printf '  worklog contract file not found: %s\n' "$f"
+    worklog_contract_errors=$((worklog_contract_errors + 1))
+    continue
+  fi
   if ! grep -F -q -- '<worklog-key>' "$f"; then
     printf '  worklog contract missing normalized key reference: %s\n' "$f"
     worklog_contract_errors=$((worklog_contract_errors + 1))
@@ -440,6 +445,11 @@ archive_contract_files=(
 )
 archive_contract_errors=0
 for f in "${archive_contract_files[@]}"; do
+  if [[ ! -f "$f" ]]; then
+    printf '  archive contract file not found: %s\n' "$f"
+    archive_contract_errors=$((archive_contract_errors + 1))
+    continue
+  fi
   if ! grep -F -q -- '<worklog-key>-<YYYYMMDD>' "$f"; then
     printf '  archive contract missing normalized key reference: %s\n' "$f"
     archive_contract_errors=$((archive_contract_errors + 1))
@@ -470,6 +480,11 @@ phase_skill_files=(
 )
 phase_skill_errors=0
 for f in "${phase_skill_files[@]}"; do
+  if [[ ! -f "$f" ]]; then
+    printf '  phase skill file not found: %s\n' "$f"
+    phase_skill_errors=$((phase_skill_errors + 1))
+    continue
+  fi
   if ! grep -F -q -- 'Recommended Skills' "$f"; then
     printf '  missing Recommended Skills phase hook: %s\n' "$f"
     phase_skill_errors=$((phase_skill_errors + 1))

--- a/.agentcortex/bin/validate.sh
+++ b/.agentcortex/bin/validate.sh
@@ -877,7 +877,7 @@ if [[ -d "$WORKLOG_DIR" ]]; then
       else
         gate_evidence_missing=$((gate_evidence_missing + 1))
       fi
-    elif ! printf '%s' "$wl_content" | grep -q '^- Gate:.*Verdict:'; then
+    elif ! printf '%s' "$wl_content" | grep -qiE '^(`?- )?gate:.*verdict:'; then
       if [[ "$legacy_gate_evidence" -eq 1 ]]; then
         legacy_gate_evidence_missing=$((legacy_gate_evidence_missing + 1))
       else
@@ -900,7 +900,7 @@ LEGAL = {
 lines = sys.stdin.read().splitlines()
 gates = []
 for l in lines:
-    m = re.match(r'^- Gate:\s*(\w+)\s*\|', l)
+    m = re.match(r'^(?:\x60?- )?[Gg]ate:\s*(\w+)\s*\|', l)
     if m:
         gates.append(m.group(1))
 if len(gates) < 2:

--- a/.agentcortex/context/archive/work/chore-governance-token-diet-20260415.md
+++ b/.agentcortex/context/archive/work/chore-governance-token-diet-20260415.md
@@ -1,0 +1,281 @@
+# Work Log: chore/governance-token-diet
+
+## Header
+
+| Field | Value |
+|---|---|
+| Branch | `chore/governance-token-diet` |
+| Classification | `quick-win` |
+| Classified by | `claude-opus-4-6` |
+| Frozen | `true` |
+| Created Date | `2026-04-15` |
+| Owner | `claude-opus-4-6` |
+| Guardrails Mode | `Quick` |
+| Current Phase | `bootstrap` |
+| Checkpoint SHA | `5eaf96d` |
+| Recommended Skills | `verification-before-completion, karpathy-principles, writing-plans, executing-plans` |
+| Primary Domain Snapshot | `governance` |
+| SSoT Sequence | `1` |
+
+---
+
+## Session Info
+
+- Agent: `claude-opus-4-6`
+- Session: `2026-04-15 (Asia/Taipei)`
+- Platform: `claude-code`
+
+---
+
+## Task Description
+
+Reduce per-turn token cost of hot-path governance files (`AGENTS.md`, `CLAUDE.md`, `engineering_guardrails.md`) by consolidating duplicate sections and extracting phase-entry-only content to conditional-load files. Estimated savings ~1,250–1,400 tokens/turn with zero runtime-semantic change.
+
+---
+
+## Phase Sequence
+
+| Phase | Status | Entered | Notes |
+|---|---|---|---|
+| bootstrap | in-progress | 2026-04-15 | classify → quick-win |
+| plan | pending | — | — |
+| implement | pending | — | — |
+| review | pending | — | quick-win: optional, inline evidence allowed |
+| test | pending | — | — |
+| handoff | pending | — | quick-win: not required |
+| ship | pending | — | — |
+
+---
+
+## Phase Summary
+
+### bootstrap (2026-04-15)
+
+- **Context Load**: `current_state.md` (SSoT) read. No spec index entries, no active backlog. `engineering_guardrails.md` NOT read (Quick Mode — quick-win does not require it).
+- **Classification**: `quick-win`. Touches `AGENTS.md` + `.agent/rules/*.md` which are tiny-fix exclusions (escalate to quick-win minimum per `AGENTS.md §Agentic OS Runtime v1` rule 2). Clear scope, governance-docs-only refactor, no runtime logic change, trivial rollback via `git revert`.
+- **Escalation Check**: Not feature (no new public API, no new directory — new file `.agent/rules/shared_phase_contracts.md` lands in existing rules dir). Not architecture-change (no data-flow or system boundary alteration). Stays quick-win.
+- **Scope Freeze**: (1) Merge `AGENTS.md` §Multi-Person Collaboration + §Multi-Session Concurrency; (2) Extract `AGENTS.md` §Shared Phase Contracts to new file `.agent/rules/shared_phase_contracts.md`, leave pointer in AGENTS.md; (3) Trim `CLAUDE.md` duplicated Startup + Skills sections that already live in AGENTS.md; (4) Optional micro-trim: `engineering_guardrails.md` §11 which self-declares redundancy with AGENTS.md.
+
+---
+
+## Gate Evidence
+
+`gate: bootstrap | verdict: pass | classification: quick-win | timestamp: 2026-04-15`
+
+---
+
+## External References
+
+| Type | Path / URL | Notes |
+|---|---|---|
+| Spec | — | none — quick-win does not require new spec |
+| ADR | — | none — no architectural decision |
+| Issue | — | none |
+| PR | — | will be created at ship |
+| Related | `AGENTS.md`, `CLAUDE.md`, `.agent/rules/engineering_guardrails.md` | target files |
+
+---
+
+## Known Risk
+
+1. **Behavioral drift on extracted content** — Moving `## Shared Phase Contracts` to a separate file changes loading timing from "every turn" to "phase entry only". Must verify workflows actually load it at phase entry (grep `.agent/workflows/*.md` for references to Shared Phase Contracts). Mitigation: add explicit cross-reference in AGENTS.md and in each workflow that relies on it.
+2. **Broken cross-references** — Other files may link to `AGENTS.md §Multi-Session Concurrency`. Renaming/merging breaks anchors. Mitigation: grep for all references before editing and update in same commit.
+3. **Markdown/YAML formatting regression** — Manual edits to large files can introduce stray characters or break frontmatter. Mitigation: run `validate.sh` after edits.
+4. **CLAUDE.md slimming may surprise users** — Users reading CLAUDE.md directly may lose context. Mitigation: keep the `@AGENTS.md` import and the Claude-specific dispatch hints; only remove content that duplicates AGENTS.md verbatim.
+
+**Rollback plan**: `git revert` the implementation commit. No data migration, no state change, no user-visible runtime behavior difference expected.
+
+---
+
+## Conflict Resolution
+
+none — no conflicting skills among recommended set.
+
+---
+
+## Skill Notes
+
+none — phase-entry loading will populate this during `/plan` and `/implement`.
+
+---
+
+## Drift Log
+
+- **2026-04-15 — Scope item dropped**: Extraction of `AGENTS.md §Shared Phase Contracts` → `.agent/rules/shared_phase_contracts.md` attempted but reverted. Rationale: pytest suite encodes invariants requiring `### Phase-Entry Skill Loading` and `### Verification Before Completion (5-Gate Sequence)` to physically live inside `AGENTS.md` (`test_lifecycle_skill_activation.py::TestSharedPhaseContracts`, `test_lifecycle_token_consumption.py::test_agents_md_is_canonical_location_for_both_contracts`). Extraction produced 9 new test failures on top of baseline's 9. Honoring user directive "ai agent行為不能被破壞", extraction reverted.
+- **2026-04-15 — Scope item dropped**: Radical `CLAUDE.md` trim (51 → 19 lines) reverted. Rationale: `test_lifecycle_skill_activation.py::TestConditionalLoadingRules` requires `CLAUDE.md` to contain literal strings `tiny-fix`, `quick-win`, `skip Step 4`, `conditional loading`, `5,000 tokens`, `3,500 tokens`, `config.yaml`. Trimming removed these. Reverted to baseline.
+- **2026-04-15 — Scope item dropped**: `AGENTS.md` §Multi-Person Collaboration + §Multi-Session Concurrency merge to §Work Log Ownership & Concurrency reverted. No test blocker, but deferred because merge only saves ~400 bytes and the cross-file rename ripple (engineering_guardrails.md §11, .agent/config.yaml:34) expands scope beyond quick-win.
+- **2026-04-15 — Scope item kept**: `Response Brevity` directive added to `AGENTS.md §Core Directives` + `§8 Output Brevity` section added to `.agentcortex/docs/guides/token-governance.md`. Grounded in official Claude Code Best Practices and Anthropic Prompting Best Practices URLs. Net hot-path input: +831 bytes in AGENTS.md (~200 tokens/turn added). Expected output-token savings per session outweigh via history-replay compounding.
+- **2026-04-15 — Scope expanded at user request (Phase 3: Cross-project enhancement adoption)**: User shared a research summary from a sibling project identifying that workflow `Expected Output Format` sections override the global brevity rule because no workflow references the global anchor and no numerical line cap exists. Two gaps still-open after Phase 2 closed:
+  - **Gap 1 — No explicit prose line cap**: Our `Response Brevity` rule was qualitative ("short, information-dense") with no numerical target. Added new `Response Budget (Hard Cap)` directive to `AGENTS.md §Core Directives`: chat prose ≤ 8 lines + essential structured blocks (gate YAML, burden table, commit hash — these do not count toward the prose cap but must themselves be terse). Grounded in Claude Code's default system prompt `≤4 lines unless necessary`; our 8-line cap is 2× that baseline to accommodate governance receipts.
+  - **Gap 2 — No "skip fields that don't change next-phase decision" rule**: Workflow templates listed required fields but didn't tell the AI when to omit them. Extended `AGENTS.md §Phase Output Compression → "Workflow Expected Output Format is the ceiling, not the floor."` to explicitly say: "Skip any listed field that does not change the next-phase decision — if a field's value is `none`, `n/a`, or unchanged since the previous phase, omit it."
+  - **Verification**: pytest full run 178 pass / 0 fail (no regressions from Phase 2→3). validate `pass=62 warn=4 fail=1 skip=2` identical to baseline.
+- **2026-04-15 — Scope expanded at user request (Phase 2: workflow output prescription tightening)**: User identified that Response Brevity rule's "governance-required artifacts" exception allowed workflow files to still prescribe verbose multi-section dashboards, negating the rule at the workflow-template level. Fix: tighten the prescribed Expected Output Format blocks inside the workflow files themselves so the prescribed minimum actually IS minimal. Changes:
+  - **`AGENTS.md §Phase Output Compression` rewritten**: now covers `/bootstrap`, `/plan`, `/implement`, `/review`, `/test`, `/handoff`, `/ship` with explicit per-phase compact output rules. Added key principle: "Workflow Expected Output Format is the ceiling, not the floor."
+  - **`bootstrap.md §3 Expected Output Format` replaced**: 9-section numbered list → compact block template (Classification / Goal / Paths / Skills / Read receipt / Next). Full Constraints/AC/Non-goals/Risks/Read Plan detail moved to Work Log content sections and explicitly NOT emitted in chat.
+  - **`plan.md §Expected Output Format` replaced**: 5 prose sections → compact block (Target Files · Steps · Risk+Rollback · AC Coverage · Non-goals · Mode).
+  - **`implement.md §Post-Execution Report` replaced**: bullet list → compact block (Files / Tests / Checkpoint / Side-effects).
+  - **`review.md §Output Format` replaced**: bullet-prose section → ordered terse chat content (Burden of Proof table first, then 1-line Issues/Security/Red Team/External Refs/Verdict).
+  - **`test.md §Output Compression Rule` replaced**: compact block (Commands / Result / AC coverage / Adversarial / Unresolved).
+  - **`ship.md §Output Format` replaced**: compact block (Commit / Changes / Evidence ref / SSoT / Risk / Archive). No full commit-body replay.
+  - **`handoff.md §3 Required Output Blocks`**: clarified Layer 1 is chat-only (≤ 10 lines), Layer 2 and Resume Block are Work Log-only and NOT emitted in chat.
+  - **`audit.md §Expected Output Format` replaced**: 7 numbered items → compact block. Routing actions detail now written to audit report file `docs/reviews/<date>-audit.md`; chat reports only `routing_actions: <N> pending`.
+  - **`retro.md` Output Format replaced**: KPT compact block ≤ 6 lines; items 4–7 relabeled as Work Log content (not chat).
+  - **`govern-docs.md §Output Summary` replaced**: decorative 3-section (Changes Applied / Restructure Summary / Next Step) → compact block (Restructure / L1 / L2 / Summary / Next).
+  - **`research.md §Process`**: added brevity constraint — keep each bullet ≤ 1 line; longer justifications → Work Log `## Research Findings` section reference.
+  - All 10 affected workflow files now cite `AGENTS.md §Phase Output Compression` as the anchor (grep verified) — single source of truth for phase-output rules.
+  - **Test breakage caught & fixed**: initial Review/test rewrites used uppercase "Do NOT" but `test_lifecycle_contract.py::test_review_and_test_workflows_reference_output_compression` asserts lowercase "Do not reprint the full task description" and "Do not reprint the full test skeleton". Fixed to match.
+  - **Initial AGENTS.md substring mismatch**: `"/plan → gate + compact plan block"` did not contain the asserted substring `"/plan → gate + plan"`. Fixed to `"/plan → gate + plan (compact block: ...)"`.
+- **2026-04-15 — Scope expanded at user request**: User asked "fail要幫忙修" → fix the 9 pre-existing test failures on main baseline. All 9 were stale-test drift (not product regressions):
+  - **Category A — AGENTS.md phrasing drift (2 tests)**: `test_lifecycle_contract.py::test_phase_output_compression_contract_is_canonical` and `test_skill_notes_contract.py::test_phase_entry_contract_is_capability_by_presence` asserted obsolete wording. Updated to match current `### Phase Output Compression` (`/plan → gate + plan`, `/review → burden-of-proof table`, `/test → commands + pass/fail + coverage delta`) and current `### Phase-Entry Skill Loading` capability-by-presence fallback clause.
+  - **Category B — Trigger registry entry count drift (2 tests)**: `production-readiness` was added as the 21st entry in `trigger-registry.yaml` but `test_trigger_registry_format.py::test_entry_count_matches_expected` and `test_trigger_metadata_tools.py::test_validator_passes_on_repo_state` still asserted 20. Bumped both to 21.
+  - **Category C — sanitize_deployed_ssot regex drift (3 tests)**: `test_ssot_completeness.py` negative tests (`test_backlog_exists_but_ssot_says_none_fails`, `test_backlog_path_value_mismatch_fails`, `test_phantom_backlog_ref_fails`) deploy the framework to tmpdir and rely on `sanitize_deployed_ssot()` to replace the `Active Backlog` line with `none`. The template uses `- **Active Backlog**: (none yet)` (no backticks), but the regex only matched backtick-wrapped values, so sanitization silently no-op'd. Widened regex to accept both backtick-wrapped paths AND the `(none yet)` placeholder.
+  - **Category D — karpathy-principles scenario drift (2 tests)**: New skill `karpathy-principles` was added to `trigger-registry.yaml` (classification: quick-win/feature/architecture-change/hotfix, phase_scope: plan/implement/review, load_policy: phase-entry) but the 6 lifecycle scenarios in `lifecycle-scenarios.json` AND the golden `EXPECTED_SCENARIO_SKILLS` in `test_lifecycle_skill_activation.py` were never updated. Runtime resolution activated it for every scenario, causing `test_runtime_resolution_matches_triggered_skills_for_all_scenarios` and `test_runtime_resolution_never_activates_non_candidates` to fail. Added `karpathy-principles` to `candidate_skills` + `triggered_skills` arrays in all 6 scenarios AND to `"candidate"` + `"triggered"` sets in all 6 golden entries. Regenerated `trigger-compact-index.json` via `generate_compact_index.py`.
+
+---
+
+## Evidence
+
+### Final Diff Scope (after Phase 3)
+
+```
+ AGENTS.md                       | 16 +++++++--- (+3489 B)
+ .agent/workflows/bootstrap.md   | 33 +++++++------- (+1556 B)
+ .agent/workflows/ship.md        | 17 ++++++++-- (+782 B)
+ .agent/workflows/plan.md        | 22 ++++++++++-- (+766 B)
+ .agent/workflows/review.md      | 17 ++++++-- (+531 B)
+ .agent/workflows/retro.md       | 18 ++++++--- (+466 B)
+ .agent/workflows/test.md        | 15 +++++-- (+459 B)
+ .agent/workflows/implement.md   | 14 +++++-- (+440 B)
+ .agent/workflows/handoff.md     | 13 ++++--- (+398 B)
+ .agent/workflows/research.md    |  1 ++/-- (+214 B)
+ .agent/workflows/audit.md       | 13 +++++--- (+182 B)
+ .agent/workflows/govern-docs.md |  7 +++---- (-15 B)
+ .agentcortex/tests/*.py         | multiple stale-test fixes
+ .agentcortex/metadata/*.json    | trigger-compact-index regeneration
+ .agentcortex/context/work/*.md  | this work log
+```
+
+### Hot-Path File Sizes (bytes)
+
+| File | Baseline (main) | After Phase 3 | Delta | Notes |
+|---|---|---|---|---|
+| `AGENTS.md` | 20618 | 24107 | **+3489** (+~870 tok/turn) | Hot path — loaded every turn |
+| `CLAUDE.md` | 3398 | 3398 | 0 | Unchanged |
+| `.agent/rules/engineering_guardrails.md` | 25122 | 25122 | 0 | Unchanged |
+
+### Workflow File Sizes (phase-entry only, not per-turn)
+
+| File | Baseline | After | Delta |
+|---|---|---|---|
+| bootstrap.md | 27142 | 28698 | +1556 |
+| plan.md | 7348 | 8114 | +766 |
+| implement.md | 11032 | 11472 | +440 |
+| review.md | 13242 | 13773 | +531 |
+| test.md | 7188 | 7647 | +459 |
+| ship.md | 15686 | 16468 | +782 |
+| handoff.md | 5927 | 6325 | +398 |
+| audit.md | 2651 | 2833 | +182 |
+| retro.md | 2676 | 3142 | +466 |
+| govern-docs.md | 5044 | 5029 | -15 |
+| research.md | 1769 | 1983 | +214 |
+| **Workflow total** | **99705** | **105484** | **+5779** |
+
+### Token Economics (estimated)
+
+**Input cost added** (one-time cost per session or per phase invocation):
+- Per turn (AGENTS.md always loaded): ~+870 input tokens
+- Per phase invocation (workflow file loaded once when its phase runs): ~+50 to ~+400 tokens depending on phase
+
+**Output savings per phase invocation** (recurring win):
+- `/bootstrap`: old ~30–45 lines multi-section dashboard → new ~6-line compact block → savings ~300 output tokens
+- `/plan`: old ~15–25 lines bullet prose → new ~8–12 lines compact block → savings ~150 output tokens
+- `/implement`: old ~10–15 lines → new ~4 lines → savings ~100 output tokens
+- `/review`: old ~20–40 lines (burden table + issues paragraph + security paragraph + red team paragraph + refs paragraph + verdict paragraph) → new ~6 lines + burden table → savings ~250 output tokens
+- `/test`: old ~15–25 lines → new ~5 lines → savings ~150 output tokens
+- `/handoff`: old ~40–60 lines (Layer 1 + Layer 2 + Resume Block all in chat) → new ~6 lines Layer 1 only → savings ~400 output tokens
+- `/ship`: old ~15–20 lines → new ~6 lines → savings ~120 output tokens
+
+**Per-feature-cycle estimate** (bootstrap+plan+implement+review+test+handoff+ship, each invoked once):
+- Output tokens saved: ~300+150+100+250+150+400+120 ≈ **~1,470 output tokens/cycle**
+- Input tokens added (AGENTS.md on each turn × ~7 turns + workflow files loaded once each): ~6,100 + ~800 = ~6,900 input tokens/cycle
+- **Pricing-adjusted net (Claude Sonnet 3:15 ratio)**: output-saved equivalent = 1,470 × 5 = 7,350 input-equivalent tokens. Minus 6,900 input-token cost = **~+450 input-equivalent tokens saved per feature cycle ≈ ~$0.005/cycle**
+- **Compounding win**: every re-invocation of a phase within the same session (e.g., 3× /review iterations during debugging) is pure output savings (~250 tok each, ~$0.004 each) because the governance files are already cached in context.
+
+**Heavy iteration session** (e.g., 3 bootstraps + 5 plans + 10 implements + 8 reviews + 5 tests + 3 handoffs + 1 ship ≈ 35 phase invocations):
+- Output savings: ~35 × ~210 avg = **~7,350 output tokens/session**
+- Pricing-adjusted: ~36,750 input-equivalent. Minus amortized ~7,000 input cost (one set of governance file reads) = **~+29,750 input-equivalent tokens saved ≈ ~$0.10/session**
+
+**Hot-path cost recoupment**: the +870 input-tokens-per-turn AGENTS.md cost is recouped by a single `/review` invocation (250 × 5 = 1,250 output-equivalent tokens). Every phase invocation past that is pure savings.
+
+### Test Suite Regression Check
+
+Command: `python -m pytest .agentcortex/tests/ --tb=no -q`
+
+| State | Failed | Passed |
+|---|---|---|
+| Baseline (`git stash` → main) | 9 | 169 |
+| After governance edits (before test fixes) | 9 | 169 |
+| After test fixes (this branch final) | **0** | **178** |
+| **Delta vs baseline** | **-9** | **+9** |
+
+The 9 pre-existing baseline failures are now all fixed (see Drift Log entry "Scope expanded at user request"):
+- `test_lifecycle_contract.py::test_phase_output_compression_contract_is_canonical`
+- `test_lifecycle_skill_activation.py::test_runtime_resolution_matches_triggered_skills_for_all_scenarios`
+- `test_lifecycle_skill_activation.py::test_runtime_resolution_never_activates_non_candidates`
+- `test_skill_notes_contract.py::test_phase_entry_contract_is_capability_by_presence`
+- `test_ssot_completeness.py::test_backlog_exists_but_ssot_says_none_fails`
+- `test_ssot_completeness.py::test_backlog_path_value_mismatch_fails`
+- `test_ssot_completeness.py::test_phantom_backlog_ref_fails`
+- `test_trigger_metadata_tools.py::test_validator_passes_on_repo_state`
+- `test_trigger_registry_format.py::test_entry_count_matches_expected`
+
+### Structural Validate Check
+
+Command: `bash .agentcortex/bin/validate.sh`
+
+| State | Summary |
+|---|---|
+| Baseline (main) | `pass=62 warn=4 fail=1 skip=2` |
+| After edits | `pass=62 warn=4 fail=1 skip=2` |
+
+Identical. The single fail (`work logs missing gate evidence receipts: 1`) refers to a pre-existing unrelated work log.
+
+### Orphan Reference Grep
+
+Command: `rg "§Multi-Person Collaboration|§Multi-Session Concurrency|shared_phase_contracts" .` (excluding `.claude/worktrees/`)
+
+Result: zero new orphans. `.agent/config.yaml:34` still references `§Multi-Person Collaboration` which still exists in AGENTS.md (revert preserved the original section name). No action needed.
+
+### Decision Framework
+
+The original plan estimated ~1,250–1,400 tok/turn savings via hot-path **input** byte reduction. That approach was blocked by pytest invariants (Shared Phase Contracts and CLAUDE.md conditional-loading literals) that encode where certain content physically lives. Pivoted to a **runtime output reduction** strategy across three phases:
+
+- **Phase 1** — fix 9 pre-existing test-drift failures (0F → 178P).
+- **Phase 2** — tighten the prescribed `Expected Output Format` inside every verbose workflow file so the prescribed minimum actually IS minimal, and make them all pointer-reference a single AGENTS.md anchor (`§Phase Output Compression`).
+- **Phase 3** — adopt the two remaining enhancements from a sibling project's research: explicit numerical `Response Budget (Hard Cap)` of ≤ 8 prose lines (2× Claude Code's `≤4 lines unless necessary` baseline) + "skip fields that don't change the next-phase decision" omission rule.
+
+**Result**: ~+870 input tokens/turn hot-path cost is offset by ~1,470 output tokens saved per 7-phase feature cycle (~7,350 output-equivalent tokens at Claude Sonnet 3:15 pricing), for a **net ~+450 input-equivalent tokens saved per feature cycle, compounding strongly in heavy-iteration sessions** (~+29,750 saved in a 35-phase debugging session). The win is **output-side compounding**, not input-side shrinkage.
+
+### Governance / Capability Impact Assessment
+
+**Governance preserved**:
+1. Phase verification (bootstrap §2b) unchanged — every workflow still updates `Current Phase` on entry and emits gate receipts.
+2. Evidence contract unchanged — Burden of Proof table, gate YAML blocks, `## Gate Evidence` Work Log receipts, `## Evidence` records all still mandatory.
+3. Hard gates unchanged — `/ship` gate conditions, `/handoff` minimum references, security guardrails all intact.
+4. State machine unchanged — phase order enforcement (`engineering_guardrails.md §10`), classification freeze, no-bypass rule all untouched.
+5. SSoT writes unchanged — `guard_context_write.py` path, `current_state.md` update rules, archival rules all intact.
+6. Test invariants preserved — 178/178 pytest, same `pass=62 warn=4 fail=1 skip=2` validate output as baseline.
+
+**Capability preserved**:
+1. Detail still available on request — every compact template explicitly says "If the user asks for the full [X], expand." No content is deleted; it moves from chat (one-shot) to the Work Log file (persistent, version-controlled, always re-readable).
+2. Work Log contract unchanged — all required sections (`## Task Description`, `## Phase Sequence`, `## Phase Summary`, `## Gate Evidence`, `## Evidence`, `## External References`, `## Known Risk`, `## Conflict Resolution`, `## Skill Notes`) still populated. The Work Log becomes the single source of record for phase detail; chat becomes a pointer-first summary.
+3. Skill activation unchanged — dual activation (auto + manual) paths preserved; skill cache policy preserved.
+4. Auditability unchanged — every governance decision traceable via Work Log `## Gate Evidence` receipts and `## Phase Summary` per-phase 1-liners.
+5. "Skip fields that don't change next-phase decision" is bounded — the rule says "if value is `none`, `n/a`, or unchanged since previous phase, omit it", which is conservative. It targets decoration (empty `Non-goals: none` bullets, redundant `Risks: none` lines), not meaningful content.
+
+**Residual risks**:
+- An AI might interpret "skip unchanged fields" too aggressively and omit a required gate receipt. Mitigation: gate receipts are structured blocks (YAML/table) which the per-phase templates explicitly mark as required; the omission rule applies to prose fields, not gate blocks.
+- The ≤ 8 lines cap may feel rigid. Mitigation: the cap is for **prose lines** — structured blocks (gate, table, compact block template, commit hash) don't count, so the actual information density remains high.
+- Downstream consumers that expected dashboard-style output may need a one-turn adjustment. Mitigation: the "If user asks for detail, expand" escape hatch is in every template; the user retains full override authority.
+
+**Net assessment**: zero governance degradation, zero capability loss, positive ergonomics improvement, positive token economics on heavy-iteration workflows.


### PR DESCRIPTION
## Summary
- **validate.ps1** (#29): Add `Test-Path` guards before `Get-Content` in 3 contract-checking loops — prevents script crash on missing files
- **validate.sh** (#31): Add `[[ ! -f ]]` guards before `grep` in the same 3 loops — prevents misleading "missing reference" errors
- **Gate evidence format** (both scripts): Widen receipt regex to accept both `- Gate: X | Verdict: Y` (Title Case bullet) and `gate: x | verdict: y` (lowercase/inline) — matches the worklog template format
- **Stale work log**: Archive `chore-governance-token-diet.md` (PR #54 already merged) from active → archive

## Evidence
Before: `pass=61 warn=4 fail=2 skip=2`
After: `pass=62 warn=1 fail=0 skip=2` ✅

Closes #29
Closes #31