### PR TITLE
feat: SKILL.md heading-scope optimization (H73)

### DIFF
--- a/.agentcortex/metadata/trigger-compact-index.json
+++ b/.agentcortex/metadata/trigger-compact-index.json
@@ -268,7 +268,7 @@
         ]
       },
       "load_policy": "on-match",
-      "content_hash": "a0256417"
+      "content_hash": "22dddc01"
     },
     {
       "id": "writing-plans",
@@ -348,7 +348,7 @@
         ]
       },
       "load_policy": "on-match",
-      "content_hash": "32196039"
+      "content_hash": "e24f19bc"
     },
     {
       "id": "database-design",
@@ -373,7 +373,7 @@
         ]
       },
       "load_policy": "on-match",
-      "content_hash": "495f6b32"
+      "content_hash": "dec2bec8"
     },
     {
       "id": "frontend-patterns",
@@ -396,7 +396,7 @@
         ]
       },
       "load_policy": "on-match",
-      "content_hash": "4ef23d41"
+      "content_hash": "308279c1"
     },
     {
       "id": "auth-security",
@@ -425,7 +425,7 @@
         ]
       },
       "load_policy": "on-match",
-      "content_hash": "cb1b4ee1"
+      "content_hash": "9e4556e5"
     },
     {
       "id": "doc-lookup",
@@ -450,7 +450,7 @@
         ]
       },
       "load_policy": "on-match",
-      "content_hash": "da759b65"
+      "content_hash": "88229b32"
     },
     {
       "id": "dispatching-parallel-agents",
@@ -574,7 +574,7 @@
         ]
       },
       "load_policy": "phase-entry",
-      "content_hash": "177dacdf"
+      "content_hash": "d29dde6d"
     },
     {
       "id": "production-readiness",
@@ -596,7 +596,7 @@
         ]
       },
       "load_policy": "phase-entry",
-      "content_hash": "39c08f81"
+      "content_hash": "dd1f151b"
     }
   ]
 }

--- a/.agentcortex/metadata/trigger-registry.yaml
+++ b/.agentcortex/metadata/trigger-registry.yaml
@@ -61,6 +61,13 @@ entries:
       Use the stable phase-entry workflow checks, prefer Work Log Skill Notes
       when present, and fall back to full SKILL.md files only on cache miss.
 
+  # ── Heading-scope metadata ──
+  # Skills with detail_ref_headings support phase-entry scoped reads.
+  # On phase entry, the AI loads ONLY the listed headings from SKILL.md
+  # instead of the full file. Full read occurs on cache miss only.
+  # Skills without detail_ref_headings (<3KB) are loaded in full — the
+  # overhead is too small to justify scoping.
+
   - id: test-driven-development
     kind: skill
     canonical_ref: .agent/skills/test-driven-development
@@ -150,6 +157,8 @@ entries:
     canonical_ref: .agent/skills/red-team-adversarial
     mirror_ref: .agents/skills/red-team-adversarial/agents/openai.yaml
     detail_ref: .agents/skills/red-team-adversarial/SKILL.md
+    detail_ref_headings:
+      default: ["## Ironclad Rules", "## When to Use (Auto-Trigger Matrix)", "## Modes"]
     platforms: [claude, codex, antigravity]
     phase_scope: [review, test]
     trigger_priority: contextual
@@ -253,6 +262,9 @@ entries:
     canonical_ref: .agent/skills/api-design
     mirror_ref: .agents/skills/api-design/agents/openai.yaml
     detail_ref: .agents/skills/api-design/SKILL.md
+    detail_ref_headings:
+      default: ["## When to Apply", "## Checklist"]
+      implement: ["## When to Apply", "## Conventions", "## Checklist"]
     platforms: [claude, codex, antigravity]
     phase_scope: [implement, review, test]
     trigger_priority: contextual
@@ -281,6 +293,9 @@ entries:
     canonical_ref: .agent/skills/database-design
     mirror_ref: .agents/skills/database-design/agents/openai.yaml
     detail_ref: .agents/skills/database-design/SKILL.md
+    detail_ref_headings:
+      default: ["## When to Apply", "## Checklist"]
+      implement: ["## When to Apply", "## Conventions", "## Checklist"]
     platforms: [claude, codex, antigravity]
     phase_scope: [plan, implement, review, test]
     trigger_priority: contextual
@@ -309,6 +324,9 @@ entries:
     canonical_ref: .agent/skills/frontend-patterns
     mirror_ref: .agents/skills/frontend-patterns/agents/openai.yaml
     detail_ref: .agents/skills/frontend-patterns/SKILL.md
+    detail_ref_headings:
+      default: ["## When to Apply", "## Checklist"]
+      implement: ["## When to Apply", "## Conventions", "## Checklist"]
     platforms: [claude, codex, antigravity]
     phase_scope: [implement, review, test]
     trigger_priority: contextual
@@ -337,6 +355,9 @@ entries:
     canonical_ref: .agent/skills/auth-security
     mirror_ref: .agents/skills/auth-security/agents/openai.yaml
     detail_ref: .agents/skills/auth-security/SKILL.md
+    detail_ref_headings:
+      default: ["## When to Apply", "## Relationship to Security Guardrails", "## Checklist"]
+      implement: ["## When to Apply", "## Conventions", "## Checklist"]
     platforms: [claude, codex, antigravity]
     phase_scope: [plan, implement, review, test]
     trigger_priority: hard
@@ -365,6 +386,8 @@ entries:
     canonical_ref: .agent/skills/doc-lookup
     mirror_ref: .agents/skills/doc-lookup/agents/openai.yaml
     detail_ref: .agents/skills/doc-lookup/SKILL.md
+    detail_ref_headings:
+      default: ["## When to Apply", "## Fetch Protocol", "## Checklist"]
     platforms: [claude, codex, antigravity]
     phase_scope: [implement, review]
     trigger_priority: contextual
@@ -525,6 +548,8 @@ entries:
     canonical_ref: .agent/skills/karpathy-principles
     mirror_ref: .agents/skills/karpathy-principles/agents/openai.yaml
     detail_ref: .agents/skills/karpathy-principles/SKILL.md
+    detail_ref_headings:
+      default: ["## When to Apply", "## Checklist", "## Code Simplification Checklist"]
     platforms: [claude, codex, antigravity]
     phase_scope: [plan, implement, review]
     trigger_priority: advisory
@@ -553,6 +578,8 @@ entries:
     canonical_ref: .agent/skills/production-readiness
     mirror_ref: .agents/skills/production-readiness/agents/openai.yaml
     detail_ref: .agents/skills/production-readiness/SKILL.md
+    detail_ref_headings:
+      default: ["## When to Use", "## Observability Checklist"]
     platforms: [claude, codex, antigravity]
     phase_scope: [review, ship]
     trigger_priority: contextual

--- a/.agentcortex/tools/analyze_token_lifecycle.py
+++ b/.agentcortex/tools/analyze_token_lifecycle.py
@@ -114,6 +114,20 @@ def compute_scoped_tokens(text: str) -> tuple[int, bool]:
     return max(1, scoped_tokens), False
 
 
+def compute_skill_scoped_tokens(detail_path: Path) -> tuple[int, int, bool]:
+    """Return ``(full_tokens, scoped_tokens, is_fallback)`` for a SKILL.md.
+
+    Uses the same ``## Heading-Scoped Read Note`` convention as workflows.
+    Skills without the note return ``scoped == full`` with ``fallback=False``.
+    """
+    if not detail_path.is_file():
+        return 0, 0, False
+    text = detail_path.read_text(encoding="utf-8")
+    full_tok = estimate_tokens_text(text)
+    scoped_tok, fallback = compute_scoped_tokens(text)
+    return full_tok, scoped_tok, fallback
+
+
 # ---------------------------------------------------------------------------
 # Core analysis
 # ---------------------------------------------------------------------------
@@ -156,6 +170,13 @@ def analyze(root: Path) -> dict[str, Any]:
         else:
             wf_scope_cache[phase] = (0, 0, False)
 
+    # Pre-compute skill scope data (full vs heading-scoped).
+    skill_scope_cache: dict[str, tuple[int, int, bool]] = {}
+    for sid, entry in skill_entries.items():
+        detail_path = root / entry["detail_ref"]
+        full, scoped, fallback = compute_skill_scoped_tokens(detail_path)
+        skill_scope_cache[sid] = (full, scoped, fallback)
+
     # Pre-compute compact-index entries for fast lookup.
     compact_entries = {e["id"]: e for e in compact_index["entries"]}
 
@@ -193,8 +214,11 @@ def analyze(root: Path) -> dict[str, Any]:
 
         # --- Execution detail (first-load + continuation) ---
         detail_first_load_tokens = 0
+        detail_first_load_scoped_tokens = 0
         continuation_tokens = 0
+        continuation_scoped_tokens = 0
         detail_load_counts: dict[str, int] = {}
+        skill_scope_fallbacks: list[str] = []
 
         for skill_id in triggered_skills:
             if skill_id not in skill_entries:
@@ -208,11 +232,25 @@ def analyze(root: Path) -> dict[str, Any]:
             detail_load_counts[skill_id] = load_count
 
             detail_first_load_tokens += detail_tok
+
+            # Scoped first-load (uses heading-scoped read note if present).
+            full, scoped, fallback = skill_scope_cache.get(
+                skill_id, (detail_tok, detail_tok, False)
+            )
+            detail_first_load_scoped_tokens += scoped
+            if fallback:
+                skill_scope_fallbacks.append(skill_id)
+
             if load_count > 1:
                 cont_cost = max(1, int(detail_tok * CONTINUATION_FRACTION))
+                cont_scoped = max(1, int(scoped * CONTINUATION_FRACTION))
                 continuation_tokens += (load_count - 1) * cont_cost
+                continuation_scoped_tokens += (load_count - 1) * cont_scoped
 
         execution_detail_tokens = detail_first_load_tokens + continuation_tokens
+        execution_detail_scoped_tokens = (
+            detail_first_load_scoped_tokens + continuation_scoped_tokens
+        )
 
         # --- Totals ---
         current_total_tokens = (
@@ -226,12 +264,23 @@ def analyze(root: Path) -> dict[str, Any]:
                     json.dumps(compact_entries[s])
                 )
 
+        # Projected without skill scoping (workflow-scope + compact-index only).
         projected_total = (
             workflow_scoped_tokens
             + compact_slice_tokens
             + execution_detail_tokens
         )
         delta = current_total_tokens - projected_total
+
+        # Projected WITH skill heading-scope (workflow + compact + skill scope).
+        projected_total_with_skill_scope = (
+            workflow_scoped_tokens
+            + compact_slice_tokens
+            + execution_detail_scoped_tokens
+        )
+        delta_with_skill_scope = (
+            current_total_tokens - projected_total_with_skill_scope
+        )
 
         results.append(
             {
@@ -240,8 +289,12 @@ def analyze(root: Path) -> dict[str, Any]:
                 "current_total_tokens": current_total_tokens,
                 "current_probe_tokens": current_probe_tokens,
                 "execution_detail_tokens": execution_detail_tokens,
+                "execution_detail_scoped_tokens": execution_detail_scoped_tokens,
                 "detail_first_load_tokens": detail_first_load_tokens,
+                "detail_first_load_scoped_tokens": detail_first_load_scoped_tokens,
                 "continuation_tokens": continuation_tokens,
+                "continuation_scoped_tokens": continuation_scoped_tokens,
+                "skill_scope_fallbacks": skill_scope_fallbacks,
                 "workflow_tokens": workflow_tokens,
                 "workflow_scoped_tokens": workflow_scoped_tokens,
                 "workflow_scope_fallbacks": workflow_scope_fallbacks,
@@ -251,12 +304,16 @@ def analyze(root: Path) -> dict[str, Any]:
                     "codex": {
                         "projected_total_tokens": projected_total,
                         "delta_vs_current_tokens": delta,
+                        "projected_with_skill_scope": projected_total_with_skill_scope,
+                        "delta_with_skill_scope": delta_with_skill_scope,
                         "compact_slice_tokens": compact_slice_tokens,
                         "probe_strategy": "compact-index",
                     },
                     "claude": {
                         "projected_total_tokens": projected_total,
                         "delta_vs_current_tokens": delta,
+                        "projected_with_skill_scope": projected_total_with_skill_scope,
+                        "delta_with_skill_scope": delta_with_skill_scope,
                         "compact_slice_tokens": compact_slice_tokens,
                         "probe_strategy": "compact-index",
                     },
@@ -294,11 +351,15 @@ def main() -> None:
             codex = result["platforms"]["codex"]
             print(f"\n--- {result['id']} ({result['classification']}) ---")
             print(f"  Current total : {result['current_total_tokens']:>8,}")
-            print(f"  Projected     : {codex['projected_total_tokens']:>8,}")
-            print(f"  Savings       : {codex['delta_vs_current_tokens']:>8,}")
+            print(f"  Projected     : {codex['projected_total_tokens']:>8,}  (wf-scope + compact-index)")
+            print(f"  + Skill scope : {codex['projected_with_skill_scope']:>8,}  (+ skill heading-scope)")
+            print(f"  Savings (wf)  : {codex['delta_vs_current_tokens']:>8,}")
+            print(f"  Savings (all) : {codex['delta_with_skill_scope']:>8,}")
             print(f"  Workflow      : {result['workflow_tokens']:>8,}  (scoped: {result['workflow_scoped_tokens']:,})")
             print(f"  Probe         : {result['current_probe_tokens']:>8,}  (compact: {codex['compact_slice_tokens']:,})")
-            print(f"  Exec detail   : {result['execution_detail_tokens']:>8,}  (first: {result['detail_first_load_tokens']:,}, cont: {result['continuation_tokens']:,})")
+            print(f"  Exec detail   : {result['execution_detail_tokens']:>8,}  (scoped: {result['execution_detail_scoped_tokens']:,})")
+            print(f"    first-load  : {result['detail_first_load_tokens']:>8,}  (scoped: {result['detail_first_load_scoped_tokens']:,})")
+            print(f"    continuation: {result['continuation_tokens']:>8,}  (scoped: {result['continuation_scoped_tokens']:,})")
 
 
 if __name__ == "__main__":

--- a/.agents/skills/api-design/SKILL.md
+++ b/.agents/skills/api-design/SKILL.md
@@ -98,6 +98,14 @@ During /review:
 - [ ] Error messages don't leak internal details (stack traces, SQL, paths)
 - [ ] CORS configured per ADR policy
 
+## Heading-Scoped Read Note
+
+For phase-entry loading, read only:
+- `When to Apply`
+- `Checklist`
+
+Load `Conventions`, `Anti-Patterns`, and `References` on full read or cache miss only.
+
 ## Anti-Patterns
 
 - **God endpoint**: One endpoint that does everything based on query params. Split into specific endpoints.

--- a/.agents/skills/auth-security/SKILL.md
+++ b/.agents/skills/auth-security/SKILL.md
@@ -115,6 +115,15 @@ During /test:
 - [ ] Test: rate limit triggers after N failures
 - [ ] Test: password change invalidates old tokens
 
+## Heading-Scoped Read Note
+
+For phase-entry loading, read only:
+- `When to Apply`
+- `Relationship to Security Guardrails`
+- `Checklist`
+
+Load `Conventions`, `Anti-Patterns`, and `References` on full read or cache miss only.
+
 ## Anti-Patterns
 
 - **JWT in localStorage**: Vulnerable to XSS. Use httpOnly cookies or in-memory only.

--- a/.agents/skills/database-design/SKILL.md
+++ b/.agents/skills/database-design/SKILL.md
@@ -78,6 +78,14 @@ During /review:
 - [ ] Backward compatibility: old code can still function until deployed together
 - [ ] Sensitive data columns identified (for encryption/hashing per security guardrails)
 
+## Heading-Scoped Read Note
+
+For phase-entry loading, read only:
+- `When to Apply`
+- `Checklist`
+
+Load `Conventions`, `Anti-Patterns`, and `References` on full read or cache miss only.
+
 ## Anti-Patterns
 
 - **Schema via ORM only**: Relying on ORM auto-sync without migration files. No rollback, no history, no review.

--- a/.agents/skills/doc-lookup/SKILL.md
+++ b/.agents/skills/doc-lookup/SKILL.md
@@ -141,6 +141,15 @@ B) Match existing code — consistent with codebase
 → Which approach do you prefer?
 ```
 
+## Heading-Scoped Read Note
+
+For phase-entry loading, read only:
+- `When to Apply`
+- `Fetch Protocol`
+- `Checklist`
+
+Load `Conventions`, `Doc URL Registry`, `Common Rationalizations`, `Conflict Detection Template`, `Anti-Patterns`, and `References` on full read or cache miss only.
+
 ## Anti-Patterns
 
 - **"I know this API"**: Assuming training data is correct without verification. Framework APIs change between versions — always check.

--- a/.agents/skills/frontend-patterns/SKILL.md
+++ b/.agents/skills/frontend-patterns/SKILL.md
@@ -82,6 +82,14 @@ During /review:
 - [ ] Route guards for authenticated pages
 - [ ] Loading indicators for async operations
 
+## Heading-Scoped Read Note
+
+For phase-entry loading, read only:
+- `When to Apply`
+- `Checklist`
+
+Load `Conventions`, `Anti-Patterns`, and `References` on full read or cache miss only.
+
 ## Anti-Patterns
 
 - **God component**: Component with 300+ lines doing everything. Split into smaller components.

--- a/.agents/skills/karpathy-principles/SKILL.md
+++ b/.agents/skills/karpathy-principles/SKILL.md
@@ -106,6 +106,15 @@ When reviewing or refactoring, apply Chesterton's Fence — understand WHY befor
 - Fewer lines is not always simpler — a 1-line nested ternary is worse than a 5-line if/else
 - Separate simplification commits from feature commits — never mix
 
+## Heading-Scoped Read Note
+
+For phase-entry loading, read only:
+- `When to Apply`
+- `Checklist`
+- `Code Simplification Checklist`
+
+Load numbered principle sections (`## 1`–`## 4`), `Common Rationalizations`, `Anti-Patterns`, and `References` on full read or cache miss only.
+
 ## Common Rationalizations
 
 | Rationalization | Reality |

--- a/.agents/skills/production-readiness/SKILL.md
+++ b/.agents/skills/production-readiness/SKILL.md
@@ -47,6 +47,14 @@ The rollback plan (per engineering_guardrails.md §12.5) must answer:
 - **How will operators know the rollback is needed?** (alert, dashboard, manual check)
 - **How will operators know the rollback succeeded?** (error rate drops, health check passes)
 
+## Heading-Scoped Read Note
+
+For phase-entry loading, read only:
+- `When to Use`
+- `Observability Checklist`
+
+Load `What This Skill Does NOT Cover`, `Anti-Patterns`, and `Interaction with Other Skills` on full read or cache miss only.
+
 ## What This Skill Does NOT Cover
 
 - **Tool selection**: Sentry vs Crashlytics vs Datadog — team/project decides.

--- a/.agents/skills/red-team-adversarial/SKILL.md
+++ b/.agents/skills/red-team-adversarial/SKILL.md
@@ -130,6 +130,15 @@ Output: Use the Beast Mode Analysis format below.
 - [what happens if dependency X fails? if network drops?]
 ```
 
+## Heading-Scoped Read Note
+
+For phase-entry loading, read only:
+- `Ironclad Rules`
+- `When to Use (Auto-Trigger Matrix)`
+- `Modes`
+
+Load `Output Formats`, `Blocking Rules`, `Work Log Integration`, `Red Team Findings`, and `Common Mistakes` on full read or cache miss only.
+
 ## Blocking Rules (Different from Security Guardrails)
 
 Red Team findings use a graduated blocking model:

--- a/docs/specs/_product-backlog.md
+++ b/docs/specs/_product-backlog.md
@@ -44,6 +44,7 @@ Governance file bloat review (2026-04-12) identified 10 findings across P0–P2:
 | 26 | ~~Skill whitelist~~ — Reverted: auto-load is intentional for extensibility; code review is the real gate | Expert review: prompt injection via skill files | — | — | Cancelled | — |
 | 27 | ADR auto-discovery in bootstrap (frontmatter-only scan) | Expert review: ADR indexing weakness | — | quick-win | Shipped | — |
 | 28 | Token budget instrumentation (optional files_read counter in §Session Info) | Expert review: unverified token budgets | — | quick-win | Pending | — |
+| 29 | SKILL.md heading-scope optimization (phase-entry loads only essential sections) | Upstream H73: ~30% skill token savings | — | quick-win | Shipped | — |
 
 ## Status Key
 


### PR DESCRIPTION
## Summary

- Add `## Heading-Scoped Read Note` to 8 heavy SKILL.md files (>3KB) enabling AI agents to load only essential sections on phase entry
- Add `detail_ref_headings` metadata to `trigger-registry.yaml` for structured programmatic access (includes per-phase overrides, e.g. `implement` loads `Conventions` too)
- Extend `analyze_token_lifecycle.py` to measure skill heading-scope savings alongside existing workflow scoping

## Token Savings — this PR's contribution only (skill heading-scope)

Measured as delta between "workflow-scope + compact-index" (pre-existing) and "+ skill heading-scope" (this PR):

| Scenario | Pre-existing optimized | + Skill scope (this PR) | **This PR's savings** |
|---|---|---|---|
| quick-win-single-module | 19,191 | 17,864 | -1,327 (7%) |
| feature-core-logic-tdd | 35,455 | 31,238 | -4,217 (12%) |
| feature-api-auth-db | 45,122 | 32,770 | **-12,352 (20%)** |
| hotfix-debug-loop | 27,889 | 24,989 | -2,900 (10%) |
| architecture-multi-agent | 53,221 | 37,238 | **-15,983 (30%)** |

Heavy scenarios benefit most because they trigger many multi-phase skills (auth-security×6, database-design×6, etc.) where continuation costs multiply.

**Caveat**: analyzer uses the `default` heading set for all phases. In practice, `implement` phase loads `Conventions` too (per registry override), so real savings are ~15-18% for scenarios with many implement repeats.

## Governance impact: none

- Scoped set always includes gate-critical sections (When to Apply, Checklist, Ironclad Rules)
- Deferred sections (Conventions, Anti-Patterns, References) available on cache miss
- No workflow, gate, evidence, or phase-order changes

## Test plan

- [x] `analyze_token_lifecycle.py --format text` runs clean with new fields
- [x] `validate.ps1` passes (63 pass, 4 warn, 1 fail = WIP work log)
- [x] Compact index regenerated and fresh
- [x] All 8 SKILL.md heading-scope notes parseable by existing `compute_scoped_tokens()`
- [x] Manual per-skill token verification matches analyzer output

🤖 Generated with [Claude Code](https://claude.com/claude-code)