### PR TITLE
Fix Windows lightweight install entrypoints

### DIFF
--- a/.agentcortex/context/.guard_receipt.json
+++ b/.agentcortex/context/.guard_receipt.json
@@ -1,6 +1,6 @@
 {
-  "expected_sha": "4bd810d3e21b14688df4e71f5916624e3ff7f867c5e55a256fb7ddcbe882c765",
-  "new_sha": "4bd810d3e21b14688df4e71f5916624e3ff7f867c5e55a256fb7ddcbe882c765",
+  "expected_sha": "5752add93e414f663917796e52f696ee3206f830dfa5b9293b43ceec2de74498",
+  "new_sha": "5752add93e414f663917796e52f696ee3206f830dfa5b9293b43ceec2de74498",
   "target": ".agentcortex/context/current_state.md",
-  "timestamp": 1776389256
+  "timestamp": 1776396311
 }

--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -13,7 +13,7 @@
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
 - **Last Updated**: 2026-04-17
 - **Last Verified**: 2026-04-17
-- **Update Sequence**: 4
+- **Update Sequence**: 5
 - **ADR Index**: (none yet)
 - **Active Backlog**: (none yet)
 - **Spec Index** (framework template specs at `.agentcortex/specs/`; project specs go to `docs/specs/`):
@@ -53,6 +53,7 @@
 - [Category: classification-flow][Severity: MEDIUM][Trigger: polish-pass-or-audit-batch] When the task is a batch of audit-driven polish edits that touch governance files (AGENTS.md, .agent/rules/*), the governance-file exclusion pushes it to `quick-win` minimum — not automatically `feature`. Classify by the flow you actually intend to run (quick-win skips spec + handoff legitimately); do not silently adopt `feature` label while running the quick-win flow. Self-check at bootstrap: "Am I going to write a spec? Will I run /handoff? If no to both, classification is quick-win."
 - [Category: worklog-format][Severity: LOW][Trigger: worklog-creation] Worklog header fields MUST use markdown list format (`- Branch: ...`) to match `validate.sh` regex `^- (\*\*Branch\*\*|Branch):`. YAML frontmatter and markdown tables both fail the check. Template at `.agentcortex/templates/worklog.md` uses a table for readability but the validator accepts only the list form today.
 - [Category: branch-awareness][Severity: LOW][Trigger: session-start-multi-turn-task] Run `git branch --show-current` at the start of any non-trivial task before deriving the worklog-key. The system-prompt gitStatus snapshot is taken once at session start and can become stale if the branch changed externally.
+- [Category: windows-install][Severity: MEDIUM][Trigger: windows-cmd-lightweight-install] On Windows, installer wrappers should prefer PowerShell or a real Git Bash path over PATH `bash.exe`; the WindowsApps `bash.exe` can be a WSL placeholder and break lightweight downstream installs when no distro is configured.
 
 ## Ship History
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Designed for cost-effective models (Gemini Flash, Haiku, etc.):
 | Dependency | Required? | Purpose |
 |:---|:---|:---|
 | **Git** | Required | Clone and deploy the framework |
-| **Bash** | Required | Run deploy & validate scripts (included with [Git for Windows](https://gitforwindows.org/)) |
+| **Bash** | Required | Run deploy & validate scripts (Git Bash from [Git for Windows](https://gitforwindows.org/) is enough on Windows) |
 | **Python 3.9+** | Recommended | Enables full validation (metadata, encoding, command sync checks) |
 | **SHA-256 tool** | Required for deploy | `sha256sum`, `shasum`, or `openssl` (pre-installed on most systems) |
 
@@ -197,14 +197,23 @@ git clone https://github.com/KbWen/agentic-os.git
 <summary><b>Windows (PowerShell / CMD)</b></summary>
 
 ```powershell
-# PowerShell
+# PowerShell (recommended for lightweight governance-brain install)
 powershell -ExecutionPolicy Bypass -File .\installers\deploy_brain.ps1 .
 
 # CMD
 installers\deploy_brain.cmd .
 ```
 
-Both wrappers call `deploy_brain.sh` under the hood — requires [Git for Windows](https://gitforwindows.org/) (includes Git Bash) or WSL.
+Use the PowerShell entrypoint when possible. It resolves Git Bash directly and does not require a WSL distro.
+The CMD wrapper delegates through the same Windows-friendly path first, then falls back to bash only if needed.
+
+```powershell
+# Validation after install
+powershell -ExecutionPolicy Bypass -File .\.agentcortex\bin\validate.ps1
+
+# Lightweight validation when Python is not installed
+bash ./.agentcortex/bin/validate.sh --no-python
+```
 
 </details>
 

--- a/installers/deploy_brain.cmd
+++ b/installers/deploy_brain.cmd
@@ -2,27 +2,28 @@
 setlocal
 
 :: When deployed to installers\, canonical deploy is one level up.
-:: Try canonical deploy via PowerShell first
-if exist "%~dp0..\agentcortex\bin\deploy.ps1" goto run_canonical_ps1
+:: Prefer the PowerShell wrapper on Windows because it resolves a real Git Bash
+:: path and avoids the WindowsApps bash.exe WSL placeholder.
+if exist "%~dp0..\.agentcortex\bin\deploy.ps1" goto run_canonical_ps1
 
 :: Try canonical deploy via bash
-if exist "%~dp0..\agentcortex\bin\deploy.sh" goto run_canonical_bash
+if exist "%~dp0..\.agentcortex\bin\deploy.sh" goto run_canonical_bash
 
-:: Bootstrap: canonical not found, use wrapper with fetch logic
-if exist "%~dp0deploy_brain.sh" goto run_bootstrap_bash
+:: Bootstrap: canonical not found, prefer the PowerShell wrapper first.
 if exist "%~dp0deploy_brain.ps1" goto run_bootstrap_ps1
+if exist "%~dp0deploy_brain.sh" goto run_bootstrap_bash
 
 echo [ERROR] Canonical deploy implementation not found and cannot bootstrap.
 exit /b 1
 
 :run_canonical_ps1
-powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0..\agentcortex\bin\deploy.ps1" %*
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0..\.agentcortex\bin\deploy.ps1" %*
 exit /b %errorlevel%
 
 :run_canonical_bash
 where bash >nul 2>nul
 if errorlevel 1 goto no_bash
-bash "%~dp0..\agentcortex\bin\deploy.sh" %*
+bash "%~dp0..\.agentcortex\bin\deploy.sh" %*
 exit /b %errorlevel%
 
 :run_bootstrap_bash

--- a/installers/deploy_brain.ps1
+++ b/installers/deploy_brain.ps1
@@ -17,11 +17,7 @@ function Normalize-PathString {
 function Resolve-BashLauncher {
     $candidates = @()
 
-    # 1. PATH lookup for bash itself
-    $bashCmd = Get-Command bash -ErrorAction SilentlyContinue
-    if ($bashCmd) { $candidates += $bashCmd.Source }
-
-    # 2. Derive from `git` location — covers scoop, chocolatey, custom prefixes,
+    # 1. Derive from `git` location — covers scoop, chocolatey, custom prefixes,
     # portable Git, GitHub Desktop. ($gitRoot)\{bin,usr\bin}\bash.exe is the
     # standard Git for Windows layout regardless of install path.
     $gitCmd = Get-Command git -ErrorAction SilentlyContinue
@@ -36,15 +32,22 @@ function Resolve-BashLauncher {
         }
     }
 
-    # 3. Static fallback (standard installer locations)
+    # 2. Static fallback (standard installer locations)
     $candidates += @(
         'C:\Program Files\Git\bin\bash.exe',
         'C:\Program Files\Git\usr\bin\bash.exe',
         'C:\Program Files (x86)\Git\bin\bash.exe'
     )
 
+    # 3. PATH lookup for bash itself, but only after preferring real Git Bash.
+    # WindowsApps\bash.exe is commonly just the WSL placeholder and breaks the
+    # lightweight install flow when no distro is installed.
+    $bashCmd = Get-Command bash -ErrorAction SilentlyContinue
+    if ($bashCmd) { $candidates += $bashCmd.Source }
+
     foreach ($candidate in $candidates | Select-Object -Unique) {
         if (-not (Test-Path -Path $candidate -PathType Leaf)) { continue }
+        if ($candidate -like '*\WindowsApps\bash.exe') { continue }
         & $candidate --version *> $null
         if ($LASTEXITCODE -eq 0) { return $candidate }
     }


### PR DESCRIPTION
## Summary
- fix the Windows CMD wrapper to point at the canonical .agentcortex paths
- prefer the PowerShell wrapper on Windows and avoid the WindowsApps WSL ash.exe placeholder
- document the Windows lightweight install and post-install validation flow in the README

## Verification
- powershell -ExecutionPolicy Bypass -File .\\installers\\deploy_brain.ps1 <temp-dir>
- cmd /c installers\\deploy_brain.cmd <temp-dir>
- powershell -ExecutionPolicy Bypass -File <temp-dir>\\.agentcortex\\bin\\validate.ps1
