### PR TITLE
Simplify install/update UX and preserve existing project files

### DIFF
--- a/.agentcortex/bin/deploy.sh
+++ b/.agentcortex/bin/deploy.sh
@@ -77,7 +77,8 @@ get_tier() {
         # wrapper — user may customize these delegation scripts
         installers/deploy_brain.sh|installers/deploy_brain.ps1|installers/deploy_brain.cmd) echo "wrapper" ;;
 
-        # scaffold — created once, user expected to modify
+        # scaffold — created once, user expected to modify (or merge framework + project content)
+        AGENTS.md|CLAUDE.md) echo "scaffold" ;;
         .gitattributes) echo "scaffold" ;;
         .agentcortex/context/current_state.md) echo "scaffold" ;;
         .agentcortex/adr/*) echo "scaffold" ;;
@@ -178,9 +179,24 @@ deploy_file() {
             fi
         fi
     elif [ -f "$dst" ] && ! $is_update; then
-        # Fresh install but file already exists (pre-manifest era)
-        cp ${CP_FLAG:+"$CP_FLAG"} "$src" "$dst"
-        [ -n "$do_chmod" ] && chmod +x "$dst"
+        # Fresh install but file already exists (pre-manifest era, or first deploy into existing project).
+        # For scaffold/wrapper tiers, preserve the user's file and write a sidecar so nothing is clobbered.
+        if [ "$tier" != "core" ]; then
+            local dst_hash
+            dst_hash="$(compute_sha256 "$dst")"
+            if [ "$src_hash" != "$dst_hash" ]; then
+                cp ${CP_FLAG:+"$CP_FLAG"} "$src" "$dst.acx-incoming"
+                echo "  [SKIP] $rel (pre-existing; new version at $rel.acx-incoming — merge manually or ask AI agent to merge)"
+                COUNT_SKIPPED=$((COUNT_SKIPPED + 1))
+                # Record the USER's current hash so future updates still detect modification.
+                record_deployed "$tier" "$rel" "$dst_hash"
+                return 0
+            fi
+            # Same content — safe to let it be (no cp needed since identical)
+        else
+            cp ${CP_FLAG:+"$CP_FLAG"} "$src" "$dst"
+            [ -n "$do_chmod" ] && chmod +x "$dst"
+        fi
     else
         # File doesn't exist in target — always deploy
         cp ${CP_FLAG:+"$CP_FLAG"} "$src" "$dst"
@@ -829,13 +845,16 @@ echo "Agentic OS v${ACX_VERSION} (${SOURCE_COMMIT}) deployed successfully!"
 echo ""
 if $IS_UPDATE; then
     echo "Summary: ${COUNT_UPDATED} updated / ${COUNT_SKIPPED} skipped / ${COUNT_NEW} new / ${COUNT_REMOVED} removed"
-    if [ "$COUNT_SKIPPED" -gt 0 ]; then
-        echo ""
-        echo "Skipped files have .acx-incoming sidecars with the new version."
-        echo "Review and merge manually, then re-run deploy to update the manifest."
-    fi
 else
     echo "Installed ${TOTAL_DEPLOYED} files."
+fi
+if [ "$COUNT_SKIPPED" -gt 0 ]; then
+    echo ""
+    echo "⚠ Skipped files detected — your existing files were preserved."
+    echo "  New versions are saved as *.acx-incoming sidecars."
+    echo ""
+    echo "  → Manual merge:  diff each pair, keep your content + adopt framework updates, then re-run deploy."
+    echo "  → AI-assisted:   ask your AI agent — \"merge each *.acx-incoming into its target, preserving project-specific content and adopting framework updates, then delete the sidecars\""
 fi
 echo ""
 echo "Platform Entry Points Ready:"

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ Designed for cost-effective models (Gemini Flash, Haiku, etc.):
 > degraded mode — Python-dependent checks report `WARN` instead of `FAIL`.
 > Pass `--no-python` to suppress warnings: `bash .agentcortex/bin/validate.sh --no-python`
 
+**Install (first time):**
+
 ```bash
 # Clone Agentic OS
 git clone https://github.com/KbWen/agentic-os.git
@@ -193,21 +195,36 @@ git clone https://github.com/KbWen/agentic-os.git
 ./agentic-os/installers/deploy_brain.sh /path/to/your-project
 ```
 
+**Update (after first install):** the installer lives inside your project. Run it from your project root — it reads the deploy manifest and auto-fetches the latest framework version from GitHub.
+
+```bash
+bash installers/deploy_brain.sh .
+```
+
+> **Existing files won't be overwritten.** If your project already has `AGENTS.md`, `CLAUDE.md`, or other framework-managed files, they are preserved. The new framework version is saved as `<filename>.acx-incoming` sidecar. Review and merge manually — or ask your AI agent: *"Merge each .acx-incoming into its target, preserving my project-specific content and adopting framework updates."*
+
+> **AI-agent install:** If you're asking an AI assistant to install Agentic OS, point it to this README. The commands above are deterministic — no platform-specific heuristics required.
+
 <details>
 <summary><b>Windows (PowerShell / CMD)</b></summary>
 
 ```powershell
-# PowerShell (recommended for lightweight governance-brain install)
-powershell -ExecutionPolicy Bypass -File .\installers\deploy_brain.ps1 .
+# Clone Agentic OS (first time)
+git clone https://github.com/KbWen/agentic-os.git
 
-# CMD
-installers\deploy_brain.cmd .
+# Deploy into your project
+powershell -ExecutionPolicy Bypass -File .\agentic-os\installers\deploy_brain.ps1 C:\path\to\your-project
+
+# CMD alternative
+.\agentic-os\installers\deploy_brain.cmd C:\path\to\your-project
 ```
 
 Use the PowerShell entrypoint when possible. It resolves Git Bash directly and does not require a WSL distro.
-The CMD wrapper delegates through the same Windows-friendly path first, then falls back to bash only if needed.
 
 ```powershell
+# Already installed? Run from your project root to update:
+powershell -ExecutionPolicy Bypass -File .\installers\deploy_brain.ps1 .
+
 # Validation after install
 powershell -ExecutionPolicy Bypass -File .\.agentcortex\bin\validate.ps1
 

--- a/installers/deploy_brain.ps1
+++ b/installers/deploy_brain.ps1
@@ -61,6 +61,7 @@ if (-not $scriptDir) { $scriptDir = (Get-Location).Path }
 $scriptDir = Normalize-PathString $scriptDir
 # When deployed to installers/, the project root is one level up.
 $projectRoot = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($scriptDir, '..'))
+# Canonical path (referenced by validate.sh contract; routing logic lives in deploy_brain.sh)
 $canonical = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($projectRoot, '.agentcortex', 'bin', 'deploy.sh'))
 
 $bashLauncher = Resolve-BashLauncher
@@ -86,18 +87,14 @@ if ($DryRun) { $bashArgs += '--dry-run' }
 if ($Source) { $bashArgs += '--source'; $bashArgs += $Source }
 $bashArgs += "$Target"
 
-if (Test-Path -Path $canonical -PathType Leaf) {
-    # Normal path: canonical deploy exists locally
-    & $bashLauncher $canonical @bashArgs
-} else {
-    # Bootstrap path: delegate to wrapper which handles fetch
-    $wrapperSh = [System.IO.Path]::Combine($scriptDir, 'deploy_brain.sh')
-    if (-not (Test-Path -Path $wrapperSh -PathType Leaf)) {
-        Write-Error "Neither canonical deploy nor deploy_brain.sh wrapper found."
-        exit 1
-    }
-    & $bashLauncher $wrapperSh @bashArgs
+# Always delegate to deploy_brain.sh — it handles install vs update routing (NVM-style).
+# PS1's job is only to find bash; all dispatch logic lives in the sh wrapper.
+$wrapperSh = [System.IO.Path]::Combine($scriptDir, 'deploy_brain.sh')
+if (-not (Test-Path -Path $wrapperSh -PathType Leaf)) {
+    Write-Error "deploy_brain.sh wrapper not found alongside this script."
+    exit 1
 }
+& $bashLauncher $wrapperSh @bashArgs
 
 $exitCode = if (Get-Variable LASTEXITCODE -ErrorAction SilentlyContinue) { $LASTEXITCODE } else { 0 }
 exit $exitCode

--- a/installers/deploy_brain.sh
+++ b/installers/deploy_brain.sh
@@ -7,14 +7,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CANONICAL="$PROJECT_ROOT/.agentcortex/bin/deploy.sh"
 
-# If canonical deploy exists locally, use it (normal path)
-if [[ -f "$CANONICAL" ]]; then
-  exec bash "$CANONICAL" "$@"
-fi
-
-# --- Bootstrap: canonical deploy not found (fresh clone with gitignored Agentic OS) ---
-echo "Agentic OS framework not found locally — bootstrapping from remote..."
-
 ACX_SOURCE="${ACX_SOURCE:-}"
 ACX_CACHE="$PROJECT_ROOT/.agentcortex-src"
 MANIFEST="$PROJECT_ROOT/.agentcortex-manifest"
@@ -23,6 +15,16 @@ MANIFEST="$PROJECT_ROOT/.agentcortex-manifest"
 if [[ -z "$ACX_SOURCE" && -f "$MANIFEST" ]]; then
     ACX_SOURCE="$(grep '^source_repo:' "$MANIFEST" | awk '{print $2}')" || true
 fi
+
+# NVM-style dispatch:
+#   No manifest + canonical present  → first-time run from the cloned source repo → use canonical
+#   Manifest present (already installed) → always fetch fresh source for update
+#   No canonical, no manifest          → fresh bootstrap (only installers/ available)
+if [[ ! -f "$MANIFEST" && -f "$CANONICAL" ]]; then
+    exec bash "$CANONICAL" "$@"
+fi
+
+echo "Agentic OS bootstrap — fetching source and deploying..."
 
 if [[ -z "$ACX_SOURCE" ]]; then
     echo "" >&2


### PR DESCRIPTION
## Summary

- **One command for install and update** — `installers/deploy_brain.sh` now uses NVM-style dispatch based on manifest presence. After the first install, users can run `bash installers/deploy_brain.sh .` from their project root and the installer auto-fetches the latest framework version from the `source_repo` recorded in the manifest.
- **AGENTS.md / CLAUDE.md are no longer clobbered** — reclassified from `core` to `scaffold` tier. Pre-existing project files are preserved; the framework version is saved as `*.acx-incoming` sidecar for manual or AI-assisted merge.
- **Single dispatch source of truth** — `deploy_brain.ps1` always delegates to `deploy_brain.sh`, so Windows and Unix share identical install/update routing.

## Why

Previously, running `bash installers/deploy_brain.sh .` from a deployed project (the natural update command) was silently blocked by the self-deploy guard because `REPO_ROOT == TARGET`. The wrapper never fetched fresh source and users had to keep the `agentic-os` clone around indefinitely to update.

Additionally, a fresh install into a project that already had `AGENTS.md` or `CLAUDE.md` (common for established codebases) would overwrite the user's file without warning. Now existing files are preserved and the deploy summary gives explicit remediation paths for both humans and AI agents.

Pattern researched from NVM / Oh My Zsh / Mise: the presence of an install marker (for us, `.agentcortex-manifest`) is the install-vs-update discriminator, not a path comparison.

## Test plan

- [x] Fresh install into empty dir works (`Installed 183 files`)
- [x] Fresh install into project with existing `AGENTS.md` preserves user content and writes `.acx-incoming` sidecar
- [x] Same-dir update from deployed project (`bash installers/deploy_brain.sh .`) bootstraps and succeeds (`Summary: 183 updated`)
- [x] Source repo self-deploy (`bash .agentcortex/bin/deploy.sh .`) still blocked by guard
- [x] `validate.sh --no-python` passes on source repo (pass=65 warn=1 fail=0)
- [x] `validate.sh --no-python` passes on fresh downstream deploy (pass=63 warn=2 fail=0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)