### PR TITLE
Improve skill/workflow discoverability + install UX simplification

### DIFF
--- a/.agent/workflows/bootstrap.md
+++ b/.agent/workflows/bootstrap.md
@@ -362,9 +362,10 @@ These items are the AI's working notes. They live in the Work Log sections liste
 - **Next Step Recommendation** — the chat block's `Next:` field uses this map:
   - `tiny-fix` → proceed directly with inline plan
   - `quick-win` → `/plan`
-  - `feature` → `/brainstorm` or `/spec` (spec required before `/plan`)
-  - `architecture-change` → `/brainstorm` → `/spec` (ADR + spec required before `/plan`)
+  - `feature` → if no frozen spec: **`/brainstorm` first** (skip = log in Drift Log), then `/spec` → `/plan`; if frozen spec exists: `/spec` or `/plan`
+  - `architecture-change` → **`/brainstorm` first** (skip = log in Drift Log) → `/spec` (ADR required) → `/plan`
   - `hotfix` → `/research` (systematic debugging)
+  - *(Any classification)* Design fork detected (two viable approaches, OR/Either in task description) → suggest `/decide` before committing to a direction
 
 ## 4. Hard Checkpoints
 

--- a/.agent/workflows/implement.md
+++ b/.agent/workflows/implement.md
@@ -33,6 +33,11 @@ Before ANY code change, AI MUST:
 2. IF Work Log contains a `Recommended Skills` entry: apply the Phase-Entry Skill-Loading Protocol (AGENTS.md §Phase-Entry Skill Loading). Then enforce skill-specific execution rules (see §Skill Execution Overrides below). Reuse `## Conflict Resolution` from bootstrap if multiple skills need precedence or scoping boundaries.
 3. *(Advisory — feature / architecture-change only)* If a step appears to conflict with a Spec Non-goal, surface: "⚠️ Step [N] may touch Non-goal: [item]. Proceed? (yes/no)"
 4. **Confidence Gate** (per `engineering_guardrails.md` §4.1): Re-assess confidence for THIS implementation step (not the overall plan). If `<80%`, STOP and clarify. If `80–90%`, state the assumption on the step before proceeding. If `>90%`, proceed — but when recording the step in `## Phase Summary` at end of phase, include `Confidence: <N>% — high` so the gate is auditable even for smooth-running steps.
+5. **Plan-Derived Skill Check** *(feature / architecture-change — advisory)*: Scan the approved plan in the Work Log for structural signals. Zero additional file reads — plan is already loaded.
+   - **Output format**: Single line in chat. Emit ONLY activated skills (skip NOT listed). Zero output if none activate.
+   - **Template**: `Plan-derived skills: +<skill1>, +<skill2> (written to Work Log)`
+   - Triggers (silent; emit only matches): 3+ independent low-coupling subtasks → `dispatching-parallel-agents`; 4+ target files OR cross-module → `subagent-driven-development`; independent parallel workstreams → `using-git-worktrees`.
+   - Activated skills are appended to Work Log `Recommended Skills` with provenance `(plan-derived)`.
 
 > **Discovery ownership**: Existing code patterns, doc lookup, external references, and spec alignment (AC mapping) are resolved during `/plan`. If discovery proves insufficient here, redirect to `/research` — do not add ad-hoc ceremony.
 

--- a/.agent/workflows/plan.md
+++ b/.agent/workflows/plan.md
@@ -54,6 +54,18 @@ If `verdict: fail`, the receipt records the failure and missing items. This make
   - If no spec exists: STOP. Output: "⚠️ No specification found. Run `/spec` first."
 - `tiny-fix`, `quick-win`, and `hotfix` are EXEMPT from this gate.
 
+## Pre-Plan Advisory Suggestions (Advisory — never blocks)
+
+> **Output format**: Single compact line. Emit ONLY when ≥1 condition triggers; emit NOTHING otherwise. Full reasoning goes to Drift Log, not chat.
+> **Template**: `Advisory: <item1> · <item2> · <item3> — reply skip/accept-<n>`
+
+Trigger conditions (check silently; emit only matches):
+- Classification `feature` or `architecture-change` + no `/brainstorm` or `/research` phase in Work Log → `/brainstorm (no exploration)`
+- Plan step selects a tech stack component (language, framework, database, infrastructure) → `/adr (tech choice)`
+- Plan step reveals a design fork (two valid approaches, OR/Either in step descriptions) → `/decide (design fork)`
+
+Skip → record reason in `## Drift Log` as `Skipped: <advisory> — <1-line reason>`. No reason required beyond 1 line.
+
 ## Design Gate (UI Tasks — Auto-Enforced)
 
 > Ref: `engineering_guardrails.md` §4.4 — Design-First Rule

--- a/.agent/workflows/routing.md
+++ b/.agent/workflows/routing.md
@@ -16,6 +16,8 @@ It does NOT contain governance rules — those remain in `AGENTS.md`.
 
 ## 1. Workflow Trigger Map
 
+> **Auto-suggest when** column: Present only in sections where phase-lifecycle or classification context can trigger the workflow without an explicit user phrase. Core Phase Workflows, Spec & Intake, Emergency & Fix, Testing Helpers, and Utility sections do not have this column — they are routed explicitly or through governance gates.
+
 ### Core Phase Workflows
 
 | Phrases | Route |
@@ -39,12 +41,12 @@ It does NOT contain governance rules — those remain in `AGENTS.md`.
 
 ### Architecture & Setup
 
-| Phrases | Route |
-|---|---|
-| "設定架構", "init app", "define tech stack", "set up project" | `/app-init` (full) |
-| "加後端", "set up [layer]", "define [layer] conventions", "加 API", "加資料庫" | `/app-init --partial` (mid-development) |
-| "新增 skill", "add skill for X" | `/app-init` §3 (skill-only generation) |
-| "architecture decision", "為什麼選這個", "record decision", "ADR" | `/adr` |
+| Phrases | Route | Auto-suggest when |
+|---|---|---|
+| "設定架構", "init app", "define tech stack", "set up project" | `/app-init` (full) | — |
+| "加後端", "set up [layer]", "define [layer] conventions", "加 API", "加資料庫" | `/app-init --partial` (mid-development) | — |
+| "新增 skill", "add skill for X" | `/app-init` §3 (skill-only generation) | — |
+| "architecture decision", "為什麼選這個", "record decision", "ADR" | `/adr` | tech stack selection detected in /plan |
 
 ### Emergency & Fix
 
@@ -55,26 +57,26 @@ It does NOT contain governance rules — those remain in `AGENTS.md`.
 
 ### Research & Analysis
 
-| Phrases | Route |
-|---|---|
-| "研究一下", "investigate", "explore", "look into this" | `/research` |
-| "腦力激盪", "brainstorm", "explore options", "what are our choices" | `/brainstorm` |
-| "audit this repo", "評估現狀", "map existing code" | `/audit` |
+| Phrases | Route | Auto-suggest when |
+|---|---|---|
+| "研究一下", "investigate", "explore", "look into this" | `/research` | hotfix classification; uncertainty about root cause in /implement |
+| "腦力激盪", "brainstorm", "explore options", "what are our choices" | `/brainstorm` | feature/arch-change with no frozen spec (bootstrap §3.7) |
+| "audit this repo", "評估現狀", "map existing code" | `/audit` | first session in a new module, no ADR exists |
 
 ### Completion & Handoff
 
-| Phrases | Route |
-|---|---|
-| "交接", "handoff", "summarize for next session" | `/handoff` |
-| "記錄決定", "log decision", "why did we choose" | `/decide` |
-| "回顧", "retrospective", "lessons learned", "retro" | `/retro` |
+| Phrases | Route | Auto-suggest when |
+|---|---|---|
+| "交接", "handoff", "summarize for next session" | `/handoff` | — |
+| "記錄決定", "log decision", "why did we choose" | `/decide` | design fork detected in /plan or /implement (see plan.md Pre-Plan Advisory) |
+| "回顧", "retrospective", "lessons learned", "retro" | `/retro` | after /ship completes (ship.md lifecycle hook) |
 
 ### Documentation
 
-| Phrases | Route |
-|---|---|
-| "同步文件", "sync docs", "docs out of date" | `/sync-docs` |
-| "更新治理文件", "update governance docs" | `/govern-docs` |
+| Phrases | Route | Auto-suggest when |
+|---|---|---|
+| "同步文件", "sync docs", "docs out of date" | `/sync-docs` | /ship touches docs/specs/ or docs/architecture/ files |
+| "更新治理文件", "update governance docs" | `/govern-docs` | /ship release includes .agent/ or AGENTS.md changes |
 
 ### Testing & Planning Helpers
 

--- a/.agent/workflows/ship.md
+++ b/.agent/workflows/ship.md
@@ -234,3 +234,15 @@ Before proceeding with ship, check `docs/reviews/` for any review snapshots that
    f. **Restructure Advisory** (AC-19): Count L2 entries in the `primary_domain` log. If any section has ≥ `domain_doc.restructure_threshold` entries (default: 5 from `.agent/config.yaml`), output advisory: `"Domain doc '<domain>' has N entries. Consider /govern-docs --restructure <domain>."`
 
 8. **SSoT Heartbeat Update** (AC-25): As the final step of State Update & Archival, increment the `Update Sequence` by 1 in `current_state.md` and set `Last Updated` to the current ISO timestamp. This runs after all other ship writes (SSoT, archive, backlog, freeze, knowledge consolidation) are complete. Use guard_context_write.py for this write.
+
+## Post-Ship Lifecycle Suggestions (Advisory)
+
+> **Output format**: Single line appended to ship chat block. Emit ONLY triggered items. **Never blocks.**
+> **Template**: `Next: /retro · /<other-workflow> (<trigger reason>) — skip all?`
+
+Trigger conditions (check silently; emit only matches):
+- Always → `/retro`
+- Ship commit touches `docs/specs/` or `docs/architecture/` → `/sync-docs (docs changed)`
+- Ship commit touches `.agent/`, `AGENTS.md`, or `.agentcortex/` → `/govern-docs (governance changed)`
+
+Skip → no Drift Log entry required (ship is a terminal phase; retro will surface patterns separately).

--- a/.agentcortex/metadata/trigger-compact-index.json
+++ b/.agentcortex/metadata/trigger-compact-index.json
@@ -446,7 +446,8 @@
           "library usage",
           "config option",
           "CLI command",
-          "version-sensitive pattern"
+          "version-sensitive pattern",
+          "project ADR tech stack"
         ]
       },
       "load_policy": "on-match",
@@ -592,7 +593,10 @@
           "error handling",
           "logging",
           "crash reporting",
-          "observability"
+          "observability",
+          "new API endpoint",
+          "new service class",
+          "new background job"
         ]
       },
       "load_policy": "phase-entry",

--- a/.agentcortex/metadata/trigger-registry.yaml
+++ b/.agentcortex/metadata/trigger-registry.yaml
@@ -395,9 +395,10 @@ entries:
     detect_by:
       classification: [quick-win, feature, architecture-change, hotfix]
       intent_patterns: ["查文件", "check docs", "查官方文檔", "read the docs", "看文件再做"]
-      scope_signals: [framework API, library usage, config option, CLI command, version-sensitive pattern]
+      scope_signals: [framework API, library usage, config option, CLI command, version-sensitive pattern, project ADR tech stack]
       failure_signals: []
       phase_conditions: []
+    capability_condition: "docs/adr/ exists"  # zero cost when no ADR; auto-match when ADR present and task touches codebase files
     load_policy: on-match
     cost_type: mixed
     cost_risk: low
@@ -587,7 +588,7 @@ entries:
     detect_by:
       classification: [feature, architecture-change]
       intent_patterns: ["observability check", "production readiness", "觀測性檢查"]
-      scope_signals: [error handling, logging, crash reporting, observability]
+      scope_signals: [error handling, logging, crash reporting, observability, new API endpoint, new service class, new background job]
       failure_signals: []
       phase_conditions: [enter-review-or-ship]
     load_policy: phase-entry


### PR DESCRIPTION
## Summary

Two commits on this branch (both ahead of main):

### 1. Install UX simplification (845e3b6)
- Simplify install/update UX
- Preserve existing project files during install

### 2. Skill/workflow discoverability (64db81f)
- Add trigger points for previously under-used workflows: \`/brainstorm\`, \`/decide\`, \`/adr\`, \`/retro\`, \`/sync-docs\`, \`/govern-docs\`
- Add Plan-Derived Skill Check in \`/implement\` for \`dispatching-parallel-agents\`, \`subagent-driven-development\`, \`using-git-worktrees\`
- Widen detection signals for \`doc-lookup\` (capability-by-presence via \`docs/adr/\`) and \`production-readiness\` (structural signals)
- All new suggestions are **advisory only** (skippable with \`skip\`, no new hard gates)
- **Compressed output format**: single-line compact blocks, emit only on trigger — ≤50 tokens/session overhead
- Governance integrity preserved: No-Bypass Rule, phase order, Classification Freeze all unchanged

Files touched (commit 2): \`.agent/workflows/{bootstrap,plan,implement,ship,routing}.md\`, \`.agentcortex/metadata/trigger-{registry.yaml,compact-index.json}\`

## Test plan

- [x] \`bash .agentcortex/bin/validate.sh\` → pass=69, fail=0
- [x] Dry-run simulation on synthetic feature task verified all 5 new trigger points fire correctly
- [x] Independent review confirmed: no hard gates added, schema consistent, cross-references valid
- [x] Output budget compliance verified (AGENTS.md §Response Budget Hard Cap)
- [ ] End-to-end flow test on a real feature task (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)