### PR TITLE
fix: add missing core commands to check_command_sync.py

### DIFF
--- a/.agentcortex/tools/check_command_sync.py
+++ b/.agentcortex/tools/check_command_sync.py
@@ -12,16 +12,32 @@ import sys
 
 
 EXPECTED_COMMANDS = [
+    # Core workflow commands (AGENTS.md §1)
     "spec-intake",
+    "spec",
     "bootstrap",
     "plan",
     "implement",
     "review",
     "test",
+    "test-classify",
+    "test-skeleton",
     "handoff",
     "ship",
+    "hotfix",
+    "adr",
+    "retro",
+    "research",
+    "brainstorm",
+    "audit",
     "decide",
-    "test-classify",
+    "sync-docs",
+    "govern-docs",
+    "worktree-first",
+    "help",
+    # Optional modules
+    "ask-openrouter",
+    "codex-cli",
     "claude-cli",
 ]
 


### PR DESCRIPTION
## Summary

- `EXPECTED_COMMANDS` in `.agentcortex/tools/check_command_sync.py` only covered 11 of ~21 core commands from `AGENTS.md §1`, leaving 10 commands unvalidated in downstream repos
- Added all missing core commands: `hotfix`, `adr`, `retro`, `research`, `brainstorm`, `audit`, `spec`, `sync-docs`, `govern-docs`, `worktree-first`, `test-skeleton`, `help`
- Added missing optional modules `ask-openrouter` and `codex-cli` for parity with existing `claude-cli`
- Organized list with comments separating core commands from optional modules

## Evidence

```
Summary: pass=69 warn=2 fail=0 skip=2
Agentic OS integrity check passed
```

Warnings are pre-existing (stale advisory lock, optional guard hook sample absent).

Closes #41