### PR TITLE
fix: use word-boundary regex in classify_result_marker

### DIFF
--- a/.agentcortex/tools/verify_agent_evidence.py
+++ b/.agentcortex/tools/verify_agent_evidence.py
@@ -299,12 +299,18 @@ def phase_order_status(classification: str, phases: list[str]) -> tuple[bool, bo
     return True, all(phase in seen for phase in required)
 
 
+_PASS_PATTERN = re.compile(r"\b(?:pass(?:ed)?|success|ok)\b", re.IGNORECASE)
+_FAIL_PATTERN = re.compile(r"\b(?:fail(?:ed)?|error)\b", re.IGNORECASE)
+
+
 def classify_result_marker(result: str) -> bool | None:
-    lowered = result.strip().lower()
-    if any(token in lowered for token in {"pass", "passed", "success", "ok"}):
-        return True
-    if any(token in lowered for token in {"fail", "failed", "error"}):
+    text = result.strip()
+    has_fail = bool(_FAIL_PATTERN.search(text))
+    has_pass = bool(_PASS_PATTERN.search(text))
+    if has_fail:
         return False
+    if has_pass:
+        return True
     return None
 
 


### PR DESCRIPTION
## Summary
- Replace substring `in` matching with `re.compile(r'\b...\b')` word-boundary patterns in `classify_result_marker()`
- Check fail **before** pass so mixed-result strings like `"1 test failed, 5 passed"` correctly return `False`
- Pre-compile patterns as module-level constants to avoid re-compiling on every call

## Evidence
```
password reset completed: None   # was True (false positive on "pass")
token expired: None              # was True (false positive on "ok" in "token")
errorHandler registered: None    # was False (false positive on "error")
1 test failed, 5 passed: False   # was True (pass check ran first)
all tests pass: True             # still correct
```
Validation: `pass=69 warn=2 fail=0 skip=2` — no regressions.

Closes #34
Also fixes #42 (deeper analysis of the same bug)