### PR TITLE
fix: repair 3 stale test assertions after doc dedup commits

### DIFF
--- a/.agent/workflows/bootstrap.md
+++ b/.agent/workflows/bootstrap.md
@@ -284,7 +284,7 @@ Everything below — Classification justification, Recommended Skills rule table
 
 ### 3.6 Recommended Skills Rule Table
 
-Write the result to Work Log `## Recommended Skills` (provenance tags as per §3.6a). Chat response shows only the comma list per §3 template. Skip for `tiny-fix`. **No skill metadata file reads required at this stage** — trigger data is embedded in the table above, and bootstrap does not depend on `.agentcortex/metadata/trigger-registry.yaml` or `trigger-compact-index.json`. **Exception**: The Conflict Pass (below) DOES read `.agent/rules/skill_conflict_matrix.md` once when ≥2 skills are recommended and the task is NOT `tiny-fix`. This is the only file read at this stage. Repos MAY layer registry/compact-index metadata on top later for richer cost_risk signals.
+Write the result to Work Log `## Recommended Skills` (provenance tags as per §3.6a). Chat response shows only the comma list per §3 template. Skip for `tiny-fix`. **No skill metadata file reads required at this stage** — trigger data is embedded in the table above, and bootstrap does not depend on `.agentcortex/metadata/trigger-registry.yaml` or `trigger-compact-index.json`. The embedded rule table is the canonical low-token trigger source during bootstrap; repos MAY layer registry/compact-index metadata on top later for richer cost_risk signals. **Exception**: The Conflict Pass (below) DOES read `.agent/rules/skill_conflict_matrix.md` once when ≥2 skills are recommended and the task is NOT `tiny-fix`. This is the only file read at this stage.
 
    **Mandatory Skills (always activate when condition met):**
 

--- a/.agentcortex/tests/test_skill_notes_contract.py
+++ b/.agentcortex/tests/test_skill_notes_contract.py
@@ -146,13 +146,8 @@ class SkillNotesContractTests(unittest.TestCase):
             agents_text,
             "AGENTS.md Shared Phase Contracts: must reference config.yaml skill_cache_policy",
         )
-        # CLAUDE.md still references config.yaml in its startup loading instructions
-        claude_text = (ROOT / "CLAUDE.md").read_text(encoding="utf-8")
-        self.assertIn(
-            "config.yaml",
-            claude_text,
-            "CLAUDE.md: should reference skill_cache_policy from config.yaml",
-        )
+        # CLAUDE.md is intentionally simplified to @import AGENTS.md (commit 95ceafb); it must
+        # NOT duplicate the skill_cache_policy reference that already lives in AGENTS.md above.
         # Phase workflow files reference AGENTS.md instead of repeating the skill-loading prose
         phase_workflows = [
             ROOT / ".agent/workflows/plan.md",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@
 4. Read `.agent/rules/engineering_guardrails.md`. *(Skip for tiny-fix and quick-win.)*
 5. If `.agentcortex/context/work/<worklog-key>.md` exists, read to resume. *(Skip for tiny-fix.)*
 
-Token budget rationale: conditional loading saves ~5,000 tokens for tiny-fix, ~3,500 for quick-win. Full mechanics: `AGENTS.md §vNext State Model`.
+Token budget rationale: conditional loading saves ~5,000 tokens for tiny-fix, ~3,500 tokens for quick-win. Full mechanics: `AGENTS.md §vNext State Model`.
 
 ## Slash Commands
 


### PR DESCRIPTION
## Summary
Three tests have been failing on main since earlier governance cleanup commits. Each failure is a stale assertion that didn't track a doc rewording — not a real contract violation. This PR repairs all three with minimal, targeted changes.

### 1. `test_token_savings_documented`
**Symptom:** Asserted `"3,500 tokens"` but CLAUDE.md said `"~3,500 for quick-win"` (missing the word `tokens`).
**Fix:** Add `tokens` to CLAUDE.md so both halves of the sentence are parallel.

### 2. `test_bootstrap_keeps_embedded_rule_table_as_canonical_trigger_source`
**Symptom:** Asserted the exact phrase `"embedded rule table is the canonical low-token trigger source"` in `bootstrap.md`.
**Root cause:** Commit [`0f82233`](https://github.com/KbWen/agentic-os/commit/0f82233) (PR #56) reworded §3.6 to spell out the metadata-file exception, and the canonical-source sentence got dropped as collateral damage. The architectural intent ("rule table is canonical, metadata is optional layering") is unchanged — only the wording was lost.
**Fix:** Restore the sentence in `bootstrap.md` §3.6. One sentence, additive.

### 3. `test_phase_entry_contract_is_capability_by_presence`
**Symptom:** Asserted `"config.yaml"` in CLAUDE.md.
**Root cause:** Commit [`95ceafb`](https://github.com/KbWen/agentic-os/commit/95ceafb) deliberately simplified CLAUDE.md to `@import AGENTS.md` and added the directive `"Do NOT duplicate rules from AGENTS.md here."` The test's CLAUDE.md `config.yaml` assertion directly contradicts that directive — and the same test already verifies `config.yaml` is in AGENTS.md (line 144), which is the canonical location.
**Fix:** Drop the 7-line CLAUDE.md block from the test. Preserves the AGENTS.md assertion.

## Evidence
```
Before: 175 passed, 3 failed
After:  178 passed, 0 failed
validate.sh: pass=69 warn=2 fail=0 skip=2
```

## Changed files
- `CLAUDE.md` — add `tokens` (1 word)
- `.agent/workflows/bootstrap.md` — restore canonical-source sentence in §3.6
- `.agentcortex/tests/test_skill_notes_contract.py` — drop stale CLAUDE.md config.yaml assertion

## Risk
- Low. No production code changed.
- CLAUDE.md wording restores parallel structure — no behavior change.
- bootstrap.md wording restores a removed architectural contract — reinforces intent.
- Test change is net-negative (fewer asserts) but the dropped assertion was actively wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)