### PR TITLE
fix: bridge research→spec-intake gap and add quick-win L2 knowledge nudge

### DIFF
--- a/.agent/workflows/research.md
+++ b/.agent/workflows/research.md
@@ -24,3 +24,29 @@ Conduct autonomous exploratory research. AI investigates the codebase, external 
 - If research reveals a clear path forward, recommend it directly — don't just list facts and wait.
 - If the problem is bigger than expected, suggest rollback + upgrade via `/decide` instead of silent reclassification.
 - If research is inconclusive after reasonable effort, say so explicitly and list what would unblock further progress.
+
+## Spec Handoff (optional)
+
+If **Next Actions** point toward building or specifying something new, persist findings so `/spec-intake` can consume them without relying on conversation memory.
+
+**Before writing**: Check if `docs/specs/_research-<topic>.md` (exact filename) already exists. If yes, update it in place — do NOT create a duplicate. If other `_research-*.md` files exist under different names, list them to the user and ask: `"Related research files exist: <list>. Write new file, append to one of these, or cancel?"` — do NOT guess semantic overlap.
+
+1. Write (or update) `docs/specs/_research-<topic>.md`:
+   ```markdown
+   ---
+   status: research
+   topic: <topic>
+   date: <YYYY-MM-DD>
+   ---
+   ## Key Facts
+   <verified findings that should inform the spec>
+   ## Constraints Found
+   <hard limits or risks the spec must respect>
+   ## Suggested Scope
+   <recommended feature boundaries>
+   ```
+2. Tell the user: `"Research summary saved to docs/specs/_research-<topic>.md. Run /spec-intake to continue — it will load this file automatically and delete it after intake."`
+
+**Lifecycle**: `_research-*.md` files are transient. They exist only between `/research` and `/spec-intake`. If the user does not intend to run `/spec-intake`, do NOT write the file — keep findings in the Work Log only.
+
+This step is optional — only write the file if research concludes with a clear "build this next" direction AND the user will follow up with `/spec-intake`.

--- a/.agent/workflows/ship.md
+++ b/.agent/workflows/ship.md
@@ -77,6 +77,22 @@ Scan Work Log `## Phase Summary` and the plan's compact block for a `Confidence:
 - [ ] Domain Doc updated or skip justified (feature / architecture-change only — see §Knowledge Consolidation below)
 - [ ] Observability Readiness verified (feature / architecture-change only — see §Observability Readiness below)
 
+## Quick-win / Hotfix Knowledge Nudge (advisory)
+
+**Scope**: `quick-win` and `hotfix` only. Skipped for `tiny-fix`, `feature`, `architecture-change`.
+
+**Domain inference**: Derive `<affected module>` and `<domain>` from (in order): (a) Work Log Task Description keywords, (b) top-level path of changed files in the diff (e.g., `src/auth/*` → domain `auth`). If neither yields a clear answer, ask the user: `"Which domain does this fix belong to? (list existing docs/architecture/*.log.md names, or 'new:<name>')"`. Do NOT guess silently.
+
+After evidence is recorded, output this prompt once per ship (not re-prompted on retry):
+
+> "Did this fix change how `<affected module>` works in a non-obvious way? If yes, consider appending one line to `docs/architecture/<domain>.log.md` — no spec required, just a timestamped note."
+
+If the user confirms yes:
+- If `docs/architecture/<domain>.log.md` exists: append a minimal L2 entry (date, branch, one-line decision/constraint).
+- If it does not exist: offer `"No domain doc for '<domain>' yet. Create docs/architecture/<domain>.log.md now? (yes/no)"` — create only on confirmation.
+
+If the user says no: skip silently. This is never a gate — it only surfaces the option.
+
 ## Observability Readiness Check (feature / architecture-change only)
 
 **Scope**: This check applies ONLY to `feature` and `architecture-change` classifications. `tiny-fix`, `quick-win`, and `hotfix` are exempt.

--- a/.agent/workflows/spec-intake.md
+++ b/.agent/workflows/spec-intake.md
@@ -20,6 +20,13 @@ Accept spec from the user in ANY of these forms — do NOT ask the user to refor
 
 If the spec source is a file path, READ it immediately. Do NOT ask the user to paste it again.
 
+### Pre-flight: Research Artifacts
+
+Before processing any input, glob `docs/specs/_research-*.md`:
+- If files exist: list them to the user and ask: `"Found research files: <list>. Load which as background context for this intake? (all / specific / none)"`. Do NOT auto-prepend — stale files from abandoned sessions cause cross-contamination.
+- On the user's selection: read the chosen files and use their content as background context. Do NOT ask the user to re-explain findings already captured there.
+- **After** the Feature Inventory is written to `_product-backlog.md` (or a single feature spec is generated), delete each **consumed** `_research-*.md` file (only the ones the user selected). Files the user rejected as irrelevant should also be flagged: `"Delete stale research file <name>? (yes/no)"` — delete on confirmation. These files are transient by design.
+
 ---
 
 ## 1a. Context Budget: Persist Before Processing


### PR DESCRIPTION
## Summary

- **research→spec-intake bridge**: `/research` can now optionally write `docs/specs/_research-<topic>.md` as a transient handoff artifact; `/spec-intake` discovers these files pre-flight and lets the user select which to load as context — preventing stale cross-contamination from abandoned sessions
- **quick-win/hotfix L2 nudge**: `/ship` now prompts quick-win and hotfix sessions to optionally append a one-line note to the relevant domain L2 doc, closing the knowledge leak where fast-path tasks never contributed to domain docs; includes domain inference logic and offer-to-create when the doc doesn't exist yet
- **Orphan file prevention**: `_research-*.md` lifecycle is strictly transient (research → spec-intake → delete); dedup uses exact filename match with user-prompted conflict resolution

## Test plan

- [ ] Run `/research` on a topic, verify Spec Handoff section prompts correctly and writes file only when user confirms intent to run spec-intake
- [ ] Run `/spec-intake` with existing `_research-*.md` files present — verify Pre-flight section lists files and asks before loading
- [ ] Run `/ship` on a quick-win branch, verify Knowledge Nudge fires once and correctly infers or asks for domain
- [ ] Verify no `_research-*.md` files linger after a completed spec-intake

🤖 Generated with [Claude Code](https://claude.com/claude-code)