### PR TITLE
Stage 1 audit micro-fixes: TF-2, TF-5, DOC-N1

### DIFF
--- a/.agent/workflows/bootstrap.md
+++ b/.agent/workflows/bootstrap.md
@@ -22,8 +22,9 @@ Before loading any context, walk the decision table below top-to-bottom — **fi
 | modifies `docs/specs/_product-backlog.md` | route to `/spec-intake` (not bootstrap) |
 | modifies any file in `docs/specs/` or `docs/architecture/` | minimum `quick-win` — continue to Step 1 |
 | modifies `AGENTS.md`, `.agent/rules/*`, or `.agent/config.yaml` | minimum `quick-win` — continue to Step 1 |
+| modifies `.agentcortex/templates/*` or `.agentcortex/bin/validate.*` | minimum `quick-win` — continue to Step 1 |
 | modifies any file with `status: frozen` frontmatter | minimum `quick-win` — continue to Step 1 |
-| modifies <3 files AND is non-semantic (typo, docs, non-functional config) AND scope is unambiguous | **tiny-fix** — skip Steps 1–6, inline plan + execute + evidence (Work Log skipped per §5) |
+| modifies <3 files (PR-scope, NOT per-logical-change) AND is non-semantic (typo, docs, non-functional config) AND scope is unambiguous | **tiny-fix** — skip Steps 1–6, inline plan + execute + evidence (Work Log skipped per §5) |
 | scope is unclear or multi-module | continue to Step 1 for full context loading |
 
 **TOKEN LEAK BLOCK**: If the task is ultimately classified as `tiny-fix` or `quick-win`, reading `engineering_guardrails.md` at any point is a structural Token Leak violation. Rely purely on AGENTS.md §Core Directives and bypass full guardrails. Rationale: loading SSoT + specs + archives for a typo fix wastes ~2,500 tokens (P6).

--- a/.agentcortex/metadata/trigger-compact-index.json
+++ b/.agentcortex/metadata/trigger-compact-index.json
@@ -175,7 +175,7 @@
         ]
       },
       "load_policy": "always",
-      "content_hash": "bee3f1f4"
+      "content_hash": "965fbc07"
     },
     {
       "id": "test-driven-development",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,4 +208,4 @@ If the answer to #3 is yes → add a section, do not create a new file.
 
 - Antigravity: `.agent/skills/`
 - Codex: `.agents/skills/`
-- Note: Distinct paths for platform compatibility.
+- Note: Both paths exist together. `.agent/skills/<name>` (Antigravity) is a **metadata stub** (~20 lines: frontmatter + Quick Reference + pointer to `runtime_anchor`). `.agents/skills/<name>/SKILL.md` is the **canonical full body** referenced by `runtime_anchor` and read on cache-miss. Workflows cite `.agents/skills/...` for cross-platform reach; bootstrap-time skill triggering reads only the stub.


### PR DESCRIPTION
## Summary

Quick-win batch addressing 3 micro-findings from the governance lifecycle audit (PR companion to the audit PR; can land in either order).

- **TF-2** — `.agent/workflows/bootstrap.md` §0: add escalation row for `.agentcortex/templates/*` and `.agentcortex/bin/validate.*`. Prevents future tiny-fix routing for framework files where a "non-semantic" tweak can break worklog regex (Global Lesson already documents this footgun).
- **TF-5** — bootstrap §0 row 5: clarify "<3 files" is **PR-scope, NOT per-logical-change**. Closes batch-tiny-fix abuse (e.g., 5 typo edits across 5 files masquerading as tiny).
- **DOC-N1** — `AGENTS.md` §Platform Paths: replace misleading "Distinct paths for platform compatibility" line with explicit stub vs full-body explanation. The original wording caused a careful Security review to misjudge `red-team-adversarial` as missing — this PR closes the documentation ambiguity.

## Deviation from audit recommendation

Audit's Pragmatist sub-agent recommended narrow scope (`.agentcortex/templates/worklog.md` only). I broadened TF-2 to `.agentcortex/templates/*` because all 6 templates govern downstream files (worklog, current_state, ADR, spec, docs README, user prefs) — same risk class. Friction increment is negligible (template edits are infrequent).

## Side effect

Regenerated `.agentcortex/metadata/trigger-compact-index.json` to clear pre-existing `[FAIL] compact index freshness` validate fail (unrelated to the 3 edits but cleans CI baseline before further governance work).

## Validate

`pass=66 warn=5 fail=0` (5 warns all pre-existing — old work logs, stale advisory lock from another session, optional guard hook sample).

## Test plan

- [ ] `bash .agentcortex/bin/validate.sh` exits 0
- [ ] `grep "PR-scope, NOT per-logical-change" .agent/workflows/bootstrap.md` returns 1 hit
- [ ] `grep "agentcortex/templates" .agent/workflows/bootstrap.md` returns 1 hit
- [ ] Read AGENTS.md §Platform Paths; confirm stub vs body explanation is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)