### PR TITLE
Fix AC-1: bootstrap §0a applies_to glob coverage (Lesson L5)

### DIFF
--- a/.agent/workflows/bootstrap.md
+++ b/.agent/workflows/bootstrap.md
@@ -58,21 +58,29 @@ Each classification reads ONLY the rows marked REQUIRED. Skip rows marked SKIP �
 > **When**: ONLY for `feature` or `architecture-change` classifications (AFTER Step 0 pre-classification).
 > **Skip for**: `tiny-fix`, `quick-win`, `hotfix` — these NEVER trigger this check. Zero extra tokens.
 
-If the task is classified as `feature` or `architecture-change`, check:
+If the task is classified as `feature` or `architecture-change`, run the **ADR Coverage Check** via `.agentcortex/tools/check_adr_coverage.py --paths <task-target-files>` (Lesson L5 fix, see SSoT §Global Lessons 2026-04-25). The tool reads ADR frontmatter `applies_to:` glob lists; outputs cover/no-cover plus exit code:
 
-1. **No ADR exists**: `docs/adr/` contains no project-specific ADR.
+- **Exit 2 — `no_adr_at_all`** (`docs/adr/` is empty):
    → Output: `"🏗️ New project detected — no architecture ADR found. Run /app-init to establish project conventions? (yes/skip)"`
    → If yes: run `/app-init` workflow, then return here.
    → If skip: record `"App-init skipped by user"` in Work Log. Detection will NOT trigger again this session.
 
-2. **Partial ADR exists**: An ADR exists but has `[TBD]` sections relevant to the current task (e.g., task touches DB but ADR has `[TBD]` for Database section).
-   → Output: `"⚠️ Your architecture ADR has [TBD] sections relevant to this task: [list]. Fill them now via /app-init --partial? (yes/skip)"`
+- **Exit 1 — `no_covering_adr`** (ADRs exist, but no ADR's `applies_to` glob matches the current task's target files):
+   → Output: `"📐 No existing ADR covers this task's target files: [list]. Available ADRs: [list]. Run /adr to record this architectural decision before /spec? (yes/skip)"`
+   → If yes: route to `/adr` workflow, then return here.
+   → If skip: record `"ADR coverage skipped by user — task: <summary>"` in Work Log Drift Log. Detection will NOT re-trigger this session.
+   → ⚠️ Auxiliary stderr lists ADRs missing `applies_to:` frontmatter — these should be retro-fitted (one-line PR) so they participate in coverage matching going forward.
+
+- **Exit 0 — covered**: Proceed to Step 1. The covering ADR(s) are written to `## External References` of the Work Log so `/plan` and `/implement` can cite them.
+
+> **Why coverage, not existence?** Lesson L5: the prior "No ADR exists" check became permanently False after the first ADR shipped (ADR-001 landed → all subsequent `architecture-change` tasks silently skipped the prompt because *some* ADR existed). The `applies_to:` glob makes coverage a positive predicate.
+
+**Cost**: This check reads only the ADR frontmatter (~30 tokens × N ADRs). It does NOT read full ADR content — that happens later during /implement when skills are loaded. ADRs without `applies_to:` are reported but not blocking.
+
+**Partial-ADR escalation (preserved from prior wording)**: If a covering ADR has `[TBD]` sections relevant to the current task, surface them inline:
+   → Output: `"⚠️ Covering ADR [<name>] has [TBD] sections relevant to this task: [list]. Fill them now via /app-init --partial? (yes/skip)"`
    → If yes: run `/app-init` in partial mode (§8 of app-init.md — only ask questions for TBD sections).
    → If skip: proceed, but AI uses generic conventions (skill scaffold defaults).
-
-3. **ADR exists and covers this task**: No action needed. Proceed to Step 1.
-
-**Cost**: This check reads only the ADR frontmatter + section headers (~50 tokens). It does NOT read full ADR content — that happens later during /implement when skills are loaded.
 
 **User-initiated trigger**: If user says "設定架構", "init app", "define tech stack", or similar intent at ANY point (even mid-development), route to `/app-init` regardless of current phase or classification. This allows mid-project architecture decisions.
 

--- a/.agentcortex/tools/check_adr_coverage.py
+++ b/.agentcortex/tools/check_adr_coverage.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""bootstrap §0a — ADR coverage check (replaces "no ADR exists" trigger).
+
+Lesson L5 (current_state.md §Global Lessons, 2026-04-25):
+  bootstrap §0a's existing "No ADR exists" condition becomes permanently
+  False after the first ADR ships, silently skipping the ADR prompt for
+  every subsequent architecture-change. This tool replaces existence
+  with COVERAGE: each ADR declares its `applies_to:` glob list in
+  frontmatter; if NO ADR's glob matches the current task's changed files,
+  fire the prompt.
+
+Usage:
+  python .agentcortex/tools/check_adr_coverage.py --root . --paths file1 file2 ...
+
+Exit codes:
+  0  at least one ADR covers the given paths
+  1  no ADR covers — bootstrap should fire the /adr prompt
+  2  no ADRs exist at all — bootstrap should fire the /app-init prompt
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+APPLIES_TO_RE = re.compile(
+    r"^applies_to\s*:\s*(\[.*?\]|\n(?:\s+-\s+\S.*\n?)+)",
+    re.MULTILINE,
+)
+LIST_ITEM_RE = re.compile(r'^\s*-\s+["\']?([^"\'\n]+?)["\']?\s*$', re.MULTILINE)
+FLOW_LIST_ITEM_RE = re.compile(r'["\']([^"\']+)["\']')
+
+
+def parse_applies_to(fm_text: str) -> list[str]:
+    """Extract `applies_to:` value (list of glob patterns) from frontmatter."""
+    m = APPLIES_TO_RE.search(fm_text)
+    if not m:
+        return []
+    body = m.group(1).strip()
+    if body.startswith("["):
+        # Flow list: ["a", "b"]
+        return FLOW_LIST_ITEM_RE.findall(body)
+    # Block list:
+    #   - "a"
+    #   - "b"
+    return LIST_ITEM_RE.findall(body)
+
+
+def adr_globs(adr_dir: Path) -> dict[str, list[str]]:
+    """Map ADR filename → its applies_to globs (empty list if not declared)."""
+    result: dict[str, list[str]] = {}
+    if not adr_dir.is_dir():
+        return result
+    for path in sorted(adr_dir.glob("ADR-*.md")):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        m = FRONTMATTER_RE.match(text)
+        if not m:
+            result[path.name] = []
+            continue
+        result[path.name] = parse_applies_to(m.group(1))
+    return result
+
+
+def covers(globs: Iterable[str], target_path: str) -> bool:
+    target_path = target_path.replace("\\", "/")
+    for pattern in globs:
+        if fnmatch.fnmatch(target_path, pattern):
+            return True
+        if pattern.endswith("/**") and target_path.startswith(pattern[:-3] + "/"):
+            return True
+        if pattern == target_path:
+            return True
+    return False
+
+
+def covering_adrs(adr_map: dict[str, list[str]], paths: list[str]) -> dict[str, list[str]]:
+    """Return {adr_name: [matched_paths]} for ADRs that cover at least one path."""
+    result: dict[str, list[str]] = {}
+    for adr, globs in adr_map.items():
+        matched = [p for p in paths if covers(globs, p)]
+        if matched:
+            result[adr] = matched
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--root", default=".", help="Repo root (default: cwd)")
+    ap.add_argument(
+        "--paths",
+        nargs="+",
+        required=True,
+        help="Repo-relative POSIX paths the current task is changing",
+    )
+    ap.add_argument(
+        "--adr-dir",
+        default="docs/adr",
+        help="ADR directory relative to root (default: docs/adr)",
+    )
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.root).resolve()
+    adr_dir = root / args.adr_dir
+
+    adr_map = adr_globs(adr_dir)
+    if not adr_map:
+        print("no_adr_at_all", file=sys.stdout)
+        return 2
+
+    matches = covering_adrs(adr_map, args.paths)
+    if matches:
+        for adr, matched in matches.items():
+            print(f"covered_by:{adr} → {','.join(matched)}")
+        return 0
+
+    print("no_covering_adr", file=sys.stdout)
+    declared_adrs = [adr for adr, globs in adr_map.items() if globs]
+    if declared_adrs:
+        print(f"  declared ADRs: {', '.join(declared_adrs)}", file=sys.stderr)
+    undeclared = [adr for adr, globs in adr_map.items() if not globs]
+    if undeclared:
+        print(
+            f"  ADRs missing 'applies_to:' frontmatter: {', '.join(undeclared)}",
+            file=sys.stderr,
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/adr/ADR-001-governance-friction-tuning.md
+++ b/docs/adr/ADR-001-governance-friction-tuning.md
@@ -1,3 +1,17 @@
+---
+status: accepted
+date: 2026-04-23
+deciders: "@kbwen, AI Agent (Claude Opus 4.6)"
+classification: architecture-change
+applies_to:
+  - "AGENTS.md"
+  - ".agent/rules/engineering_guardrails.md"
+  - ".agentcortex/docs/guides/context-budget.md"
+  - ".agentcortex/docs/guides/token-governance.md"
+  - ".agentcortex/docs/guides/token-optimization-quickstart.md"
+  - "docs/guides/token-optimization-quickstart*.md"
+---
+
 # ADR-001: Governance Friction Tuning
 
 - **Status**: Accepted

--- a/tests/guard/test_adr_coverage.py
+++ b/tests/guard/test_adr_coverage.py
@@ -1,0 +1,113 @@
+"""Unit tests for tools/check_adr_coverage.py — Lesson L5 (AC-1) fix.
+
+Spec: bootstrap.md §0a (rewritten 2026-04-25)
+Lesson: current_state.md §Global Lessons L5 (post-first-adr regression)
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / ".agentcortex" / "tools"))
+
+import check_adr_coverage as cov  # noqa: E402
+
+
+def _adr(text: str, dirpath: Path, name: str) -> Path:
+    p = dirpath / name
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+class TestParseAppliesTo(unittest.TestCase):
+    def test_block_list(self) -> None:
+        fm = """status: accepted
+applies_to:
+  - "AGENTS.md"
+  - ".agent/rules/**"
+"""
+        self.assertEqual(cov.parse_applies_to(fm), ["AGENTS.md", ".agent/rules/**"])
+
+    def test_flow_list(self) -> None:
+        fm = 'applies_to: ["a.md", "b/**"]\nother: x\n'
+        self.assertEqual(cov.parse_applies_to(fm), ["a.md", "b/**"])
+
+    def test_missing(self) -> None:
+        fm = "status: accepted\n"
+        self.assertEqual(cov.parse_applies_to(fm), [])
+
+
+class TestCovers(unittest.TestCase):
+    def test_exact(self) -> None:
+        self.assertTrue(cov.covers(["AGENTS.md"], "AGENTS.md"))
+
+    def test_recursive_glob(self) -> None:
+        self.assertTrue(cov.covers([".agent/rules/**"], ".agent/rules/sub/x.md"))
+
+    def test_negative(self) -> None:
+        self.assertFalse(cov.covers(["AGENTS.md"], "src/foo.py"))
+
+    def test_windows_path_normalized(self) -> None:
+        self.assertTrue(cov.covers([".agent/rules/**"], r".agent\rules\x.md"))
+
+
+class TestAdrGlobs(unittest.TestCase):
+    def test_reads_frontmatter(self) -> None:
+        with tempfile.TemporaryDirectory() as base_dir:
+            adr_dir = Path(base_dir)
+            _adr(
+                '---\nstatus: accepted\napplies_to:\n  - "AGENTS.md"\n---\n# ADR-001\n',
+                adr_dir,
+                "ADR-001-x.md",
+            )
+            globs = cov.adr_globs(adr_dir)
+            self.assertIn("ADR-001-x.md", globs)
+            self.assertEqual(globs["ADR-001-x.md"], ["AGENTS.md"])
+
+    def test_no_frontmatter_returns_empty_globs(self) -> None:
+        with tempfile.TemporaryDirectory() as base_dir:
+            adr_dir = Path(base_dir)
+            _adr("# ADR-001 no frontmatter\nbody", adr_dir, "ADR-001-x.md")
+            globs = cov.adr_globs(adr_dir)
+            self.assertEqual(globs["ADR-001-x.md"], [])
+
+    def test_missing_dir(self) -> None:
+        self.assertEqual(cov.adr_globs(Path("/no/such/dir")), {})
+
+
+class TestL5Regression(unittest.TestCase):
+    """Lesson L5: post-first-ADR existence check breaks. Verify coverage check
+    correctly distinguishes 'ADR exists' from 'ADR covers this task'."""
+
+    def test_exists_does_not_imply_covers(self) -> None:
+        with tempfile.TemporaryDirectory() as base_dir:
+            adr_dir = Path(base_dir)
+            _adr(
+                '---\napplies_to:\n  - "AGENTS.md"\n---\n# ADR-001 governance only\n',
+                adr_dir,
+                "ADR-001-governance.md",
+            )
+            adr_map = cov.adr_globs(adr_dir)
+            # ADR exists, but task touches src/queue/ — not covered
+            covering = cov.covering_adrs(adr_map, ["src/queue/redis.py"])
+            self.assertEqual(covering, {})
+
+    def test_covering_adr_returned(self) -> None:
+        with tempfile.TemporaryDirectory() as base_dir:
+            adr_dir = Path(base_dir)
+            _adr(
+                '---\napplies_to:\n  - "src/queue/**"\n---\n# ADR-002 queue migration\n',
+                adr_dir,
+                "ADR-002-queue.md",
+            )
+            adr_map = cov.adr_globs(adr_dir)
+            covering = cov.covering_adrs(adr_map, ["src/queue/redis.py"])
+            self.assertIn("ADR-002-queue.md", covering)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix the `bootstrap §0a` regression that broke the moment ADR-001 landed: the existence check (`no ADR exists`) became permanently False, silently skipping the ADR prompt for every subsequent `architecture-change` task — including the work that produced ADR-002 itself.

## What changed

- **New tool** `.agentcortex/tools/check_adr_coverage.py` (~140 LOC, stdlib only) — reads ADR YAML frontmatter `applies_to:` glob list, tests against task target files, returns 0/1/2 exit codes for covered / no-covering-ADR / no-ADRs-at-all.
- **bootstrap.md §0a** rewritten to call the tool. Preserves partial-ADR-with-[TBD] escalation behavior. Cites Lesson L5 inline so future readers know why.
- **ADR-001 retro-fit**: added YAML frontmatter (status / date / deciders / classification preserved verbatim) plus `applies_to:` covering AGENTS.md + .agent/rules/engineering_guardrails.md + token-governance / context-budget / token-optimization-quickstart guides.
- **Tests** `tests/guard/test_adr_coverage.py` — 12 cases including the explicit L5-regression test (`test_exists_does_not_imply_covers`).

## Verification

- `python -m unittest discover -s tests/guard` → 12/12 in 0.023s
- `bash .agentcortex/bin/validate.sh` → pass=66 warn=5 fail=0
- Live smoke: AGENTS.md → covered by ADR-001 (exit 0); src/api/foo.js → no_covering_adr (exit 1)

## Why coverage, not existence

Lesson L5 from PR #73 retro: the prior check confused "any ADR exists" with "an ADR covers this task". Once a single ADR shipped, the positive predicate became unreachable. `applies_to:` glob makes coverage a positive predicate that scales with the number of ADRs.

## Out of scope

- ADR-002 retro-fit with `applies_to:` — owned by PR #72 (ADR-002 is on that branch). Will land naturally when PR #72 rebases on main with this PR merged.
- validate.sh integration of "every ADR declares applies_to:" hygiene check — separate small PR if desired.

## Test plan

- [ ] `bash .agentcortex/bin/validate.sh` exits 0 in CI
- [ ] `python -m unittest discover -s tests/guard` exits 0
- [ ] Manual smoke: invoke the tool with mock paths against the merged ADR set

## Related

- Closes AC-1 from PR #70 audit (`docs/audit/governance-lifecycle-2026-04-25.md` §0.1 row "AC-1 (revised)" rationale + 2026-04-25 retro PR #73 Lesson L5)
- Companion PRs in this convergence cycle: PR #73 (retro lessons), PR #72 (ADR-002 ship), PR #75 (Sentinel hook — pending), PR #76 (ADR-003 hash chain — pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)