### PR TITLE
Fix CC-2: Sentinel ⚡ ACX Stop hook (Lesson L4 — observer-only)

### DIFF
--- a/.claude/hooks/check-sentinel.py
+++ b/.claude/hooks/check-sentinel.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Stop hook: verify last assistant text ends with the Sentinel ⚡ ACX marker.
+
+Closes the CC-2 honor-system gap (audit `docs/audit/governance-lifecycle-2026-04-25.md`
+§0.1 + Lesson L4 in current_state.md §Global Lessons): without an external
+observer, the agent can silently drop the Sentinel and there is no detection
+or audit trail.
+
+Contract:
+  - Reads Claude Code Stop hook payload from stdin (JSON with `transcript_path`,
+    `session_id`, `stop_hook_active`).
+  - Tails the transcript JSONL, finds the last assistant message's text content.
+  - If `⚡ ACX` is NOT present in the last ~200 characters, writes a violation
+    receipt to `.agentcortex/context/sentinel-violations.jsonl` (append-only),
+    prints a stderr warning (surfaced in Claude Code hook logs), and exits 1.
+  - Otherwise exits 0.
+
+Capability-by-presence: if Python is unavailable downstream, Claude Code logs
+the missing command but does not block the session. Adopters opt in by keeping
+`.claude/settings.json` registration; opt out by removing it.
+
+This hook is intentionally minimal — it observes, it does not block. Blocking
+would risk a denial-of-service against legitimate sessions if the sentinel
+check has a bug. The receipt + stderr warning are sufficient for `validate.sh`
+to surface violations on next run (see follow-up PR adding the validate.sh
+integration).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+SENTINEL = "⚡ ACX"
+SENTINEL_WINDOW = 200  # search the last N chars of the assistant text
+RECEIPT = Path(".agentcortex/context/sentinel-violations.jsonl")
+
+
+def read_payload() -> dict:
+    try:
+        return json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+
+
+def last_assistant_text(transcript_path: Path) -> str:
+    """Return the text content of the last assistant message in the transcript."""
+    last_text = ""
+    if not transcript_path.exists():
+        return last_text
+    try:
+        with transcript_path.open(encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if obj.get("type") != "assistant":
+                    continue
+                content = obj.get("message", {}).get("content", [])
+                if not isinstance(content, list):
+                    continue
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        text = block.get("text", "")
+                        if text.strip():
+                            last_text = text
+    except OSError:
+        pass
+    return last_text
+
+
+def has_sentinel(text: str) -> bool:
+    if not text:
+        return False
+    tail = text.rstrip()[-SENTINEL_WINDOW:]
+    return SENTINEL in tail
+
+
+def write_violation(payload: dict, last_text: str, receipt_path: Path | None = None) -> None:
+    # Late-bind to module RECEIPT so test patches via hook.RECEIPT take effect.
+    if receipt_path is None:
+        receipt_path = RECEIPT
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "timestamp": int(time.time()),
+        "session_id": payload.get("session_id"),
+        "violation": "missing_sentinel",
+        "marker": SENTINEL,
+        "tail": last_text.rstrip()[-SENTINEL_WINDOW:] if last_text else "",
+        "stop_hook_active": payload.get("stop_hook_active", False),
+    }
+    line = json.dumps(record, sort_keys=True, ensure_ascii=False) + "\n"
+    # O_APPEND for kernel-atomic line writes (matches guard_context_write append mode)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+    fd = os.open(str(receipt_path), flags, 0o644)
+    try:
+        os.write(fd, line.encode("utf-8"))
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def main() -> int:
+    payload = read_payload()
+    transcript_str = payload.get("transcript_path", "")
+    if not transcript_str:
+        return 0
+    last_text = last_assistant_text(Path(transcript_str))
+    if not last_text:
+        # No assistant text yet — nothing to check.
+        return 0
+    if has_sentinel(last_text):
+        return 0
+    write_violation(payload, last_text)
+    print(
+        f"⚠️ Sentinel '{SENTINEL}' missing from last assistant message. "
+        f"Logged to {RECEIPT}",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "Project-shared Claude Code config. User-local permissions live in settings.local.json.",
+  "_governance_ref": "Closes CC-2 from docs/audit/governance-lifecycle-2026-04-25.md §0.1 + Lesson L4 in current_state.md §Global Lessons.",
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .claude/hooks/check-sentinel.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !.agentcortex/context/work/.gitkeep.md
 .agentcortex/context/.guard_receipt.json
 .agentcortex/context/.guard_locks/
+.agentcortex/context/sentinel-violations.jsonl
 .agentcortex/context/private/
 .agent/private/
 

--- a/tests/guard/test_sentinel_hook.py
+++ b/tests/guard/test_sentinel_hook.py
@@ -1,0 +1,173 @@
+"""Tests for .claude/hooks/check-sentinel.py — Sentinel ⚡ ACX Stop hook.
+
+Closes CC-2 honor-system gap; promotes Lesson L4 from honor-system to
+externally observable.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+HOOK = ROOT / ".claude" / "hooks" / "check-sentinel.py"
+
+# Load the hook module dynamically (it's not on a package path)
+_spec = importlib.util.spec_from_file_location("check_sentinel", HOOK)
+hook = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(hook)  # type: ignore[union-attr]
+
+
+def _make_transcript(messages: list[dict], path: Path) -> None:
+    """Write a fake transcript JSONL: each msg is {type, content_text}."""
+    lines = []
+    for m in messages:
+        if m.get("type") == "assistant":
+            lines.append(
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [{"type": "text", "text": m["content_text"]}]
+                        },
+                    }
+                )
+            )
+        else:
+            lines.append(json.dumps({"type": m["type"], "message": {"content": m.get("content_text", "")}}))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+class TestHasSentinel(unittest.TestCase):
+    def test_sentinel_present_at_end(self) -> None:
+        self.assertTrue(hook.has_sentinel("hello world\n\n⚡ ACX"))
+
+    def test_sentinel_within_tail_window(self) -> None:
+        self.assertTrue(hook.has_sentinel("a" * 50 + "\n⚡ ACX\n"))
+
+    def test_sentinel_missing(self) -> None:
+        self.assertFalse(hook.has_sentinel("hello world without marker"))
+
+    def test_sentinel_far_from_tail(self) -> None:
+        # Sentinel deep in the middle of long text — outside the 200-char tail window
+        text = "⚡ ACX\n" + ("x" * 500)
+        self.assertFalse(hook.has_sentinel(text))
+
+    def test_empty(self) -> None:
+        self.assertFalse(hook.has_sentinel(""))
+
+
+class TestLastAssistantText(unittest.TestCase):
+    def test_picks_last_assistant(self) -> None:
+        with tempfile.TemporaryDirectory() as base_dir:
+            t = Path(base_dir) / "transcript.jsonl"
+            _make_transcript(
+                [
+                    {"type": "user", "content_text": "hi"},
+                    {"type": "assistant", "content_text": "first reply"},
+                    {"type": "user", "content_text": "more"},
+                    {"type": "assistant", "content_text": "second reply ⚡ ACX"},
+                ],
+                t,
+            )
+            text = hook.last_assistant_text(t)
+            self.assertIn("second reply", text)
+
+    def test_missing_file_returns_empty(self) -> None:
+        self.assertEqual(hook.last_assistant_text(Path("/no/such/file")), "")
+
+
+class TestWriteViolation(unittest.TestCase):
+    def test_writes_jsonl_record(self) -> None:
+        with tempfile.TemporaryDirectory() as base_dir:
+            receipt = Path(base_dir) / "violations.jsonl"
+            payload = {"session_id": "abc", "stop_hook_active": False}
+            hook.write_violation(payload, "tail text without marker", receipt_path=receipt)
+            content = receipt.read_text(encoding="utf-8")
+            line = content.strip()
+            obj = json.loads(line)
+            self.assertEqual(obj["violation"], "missing_sentinel")
+            self.assertEqual(obj["session_id"], "abc")
+            self.assertIn("tail text", obj["tail"])
+
+    def test_appends_not_overwrites(self) -> None:
+        with tempfile.TemporaryDirectory() as base_dir:
+            receipt = Path(base_dir) / "violations.jsonl"
+            hook.write_violation({"session_id": "1"}, "first", receipt_path=receipt)
+            hook.write_violation({"session_id": "2"}, "second", receipt_path=receipt)
+            lines = [ln for ln in receipt.read_text(encoding="utf-8").splitlines() if ln]
+            self.assertEqual(len(lines), 2)
+
+
+class TestEndToEnd(unittest.TestCase):
+    """Run the hook's main() against fake stdin + transcript, verify behavior."""
+
+    def setUp(self) -> None:
+        # Keep the temp dir alive across the test method so receipts can be inspected.
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.base = Path(self._tmpdir.name)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def _run(self, transcript_messages: list[dict], session_id: str = "test") -> tuple[int, Path]:
+        t = self.base / "transcript.jsonl"
+        _make_transcript(transcript_messages, t)
+        payload = {"session_id": session_id, "transcript_path": str(t)}
+        saved_receipt = hook.RECEIPT
+        saved_stdin = sys.stdin
+        saved_stderr = sys.stderr
+        tmp_receipt = self.base / "viol.jsonl"
+        hook.RECEIPT = tmp_receipt
+        try:
+            from io import StringIO
+            sys.stdin = StringIO(json.dumps(payload))
+            sys.stderr = StringIO()
+            rc = hook.main()
+        finally:
+            hook.RECEIPT = saved_receipt
+            sys.stdin = saved_stdin
+            sys.stderr = saved_stderr
+        return rc, tmp_receipt
+
+    def test_sentinel_present_returns_zero(self) -> None:
+        rc, receipt = self._run(
+            [{"type": "assistant", "content_text": "all done\n\n⚡ ACX"}]
+        )
+        self.assertEqual(rc, 0)
+        self.assertFalse(receipt.exists(), "no receipt should be written on success")
+
+    def test_sentinel_missing_returns_one_and_logs(self) -> None:
+        rc, receipt = self._run(
+            [{"type": "assistant", "content_text": "all done without marker"}]
+        )
+        self.assertEqual(rc, 1)
+        self.assertTrue(receipt.exists())
+        line = receipt.read_text(encoding="utf-8").strip()
+        obj = json.loads(line)
+        self.assertEqual(obj["violation"], "missing_sentinel")
+
+    def test_no_assistant_yet_returns_zero(self) -> None:
+        rc, receipt = self._run([{"type": "user", "content_text": "hello"}])
+        self.assertEqual(rc, 0)
+        self.assertFalse(receipt.exists())
+
+    def test_no_transcript_path_returns_zero(self) -> None:
+        # Direct call with empty payload
+        saved_stdin = sys.stdin
+        try:
+            from io import StringIO
+            sys.stdin = StringIO("{}")
+            rc = hook.main()
+        finally:
+            sys.stdin = saved_stdin
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes the CC-2 honor-system gap surfaced by the audit and confirmed 10/10 feasibility by Red Team Attack POC #4: "a single user message could disable the Sentinel rule and there's no detection or audit trail."

This PR adds a Claude Code Stop hook that validates the last assistant message ends with `⚡ ACX` and writes a violation receipt if not.

## What changed

- **`.claude/hooks/check-sentinel.py`** (NEW, ~95 LOC, stdlib only) — Stop hook script. Reads transcript, checks tail for `⚡ ACX`, writes append-only JSONL receipt + stderr warning on miss.
- **`.claude/settings.json`** (NEW) — project-shared config registering the hook. User-local `settings.local.json` unaffected.
- **`.gitignore`** — `sentinel-violations.jsonl` is per-machine.
- **`tests/guard/test_sentinel_hook.py`** (13 cases) — boundary detection, transcript parsing, append semantics, end-to-end main() exit codes.

## Why observer-only, not blocking

Blocking would risk DoS against legitimate sessions if the check has a bug. The receipt + stderr is sufficient for `validate.sh` (separate follow-up PR) to surface violations between sessions. Lesson L4 was about removing honor-system theatre, not adding a new failure surface.

## Verification

- `python -m unittest discover -s tests/guard` → 13/13 in 0.03s
- `bash .agentcortex/bin/validate.sh` → pass=66 warn=5 fail=0
- Capability-by-presence: if Python is missing downstream, Claude Code logs the missing command but does not break the session.

## How this maps to lessons

- L4 (honor-system rules without external observer = theatre) — Sentinel is the most-cited honor-system rule. This PR moves it from theatre to externally observable.
- Other L4 surfaces (Token Leak Drift Log, Skill cache hash) follow same pattern in subsequent PRs / ADR-003.

## Out of scope (deferred)

- `validate.sh` check that fails when `sentinel-violations.jsonl` is non-empty (gives the receipt teeth in CI). Small follow-up PR.
- ADR-003 hash-chained tamper-evident log (separate PR; would extend the receipt to be cryptographically append-only).

## Self-test

If I forget `⚡ ACX` at the end of this PR description, the hook will catch me. (The hook is opt-in via `.claude/settings.json` so it only fires for users who keep the registration.)

## Test plan

- [ ] `bash .agentcortex/bin/validate.sh` exits 0 in CI
- [ ] `python -m unittest discover -s tests/guard` exits 0
- [ ] Manual: drop `⚡ ACX` from a test response; verify `sentinel-violations.jsonl` gets a record
- [ ] Manual: keep `⚡ ACX`; verify no record appears

## Related

- Closes CC-2 from PR #70 audit (`docs/audit/governance-lifecycle-2026-04-25.md` §0.1) and Lesson L4 from PR #73 retro
- Companion: PR #73 (retro), PR #74 (AC-1 fix), PR #76 ADR-003 hash chain (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

⚡ ACX