### PR TITLE
Fix R-1 (BLOCKER): wire ADR-003 hash chain into /ship INDEX.jsonl append

### DIFF
--- a/.agent/workflows/ship.md
+++ b/.agent/workflows/ship.md
@@ -201,12 +201,17 @@ Before proceeding with ship, check `docs/reviews/` for any review snapshots that
    - If Ship History exceeds 10 entries, archive older entries to `.agentcortex/context/archive/ship-history-YYYY.md` and keep only the latest 10 in `current_state.md`.
 3. Archive `.agentcortex/context/work/<worklog-key>.md` to `.agentcortex/context/archive/` (if task complete).
     - Do NOT duplicate `/retro`-promoted Global Lessons during ship. `/retro` owns structured Global Lesson promotion.
-    - **Archive Index Update**: After archiving, append a structured record to `.agentcortex/context/archive/INDEX.jsonl` (one JSON object per line) via `.agentcortex/tools/guard_context_write.py`:
-      ```json
-      {"log": "<archived-filename>", "branch": "<branch>", "classification": "<tier>", "modules": ["<file-or-module>"], "specs": ["<spec-ref>"], "patterns": ["<tag>"], "decisions": ["<1-line>"], "shipped": "<YYYY-MM-DD>"}
+    - **Archive Index Update**: After archiving, append a structured record to `.agentcortex/context/archive/INDEX.jsonl`. Per ADR-003 (`docs/adr/ADR-003-hash-chained-audit-log.md`), every append MUST add `prev_sha` (computed by the helper) so the chain stays intact. Use:
+      ```bash
+      python .agentcortex/tools/append_chain_entry.py append \
+        --path .agentcortex/context/archive/INDEX.jsonl \
+        --entry '{"log": "<archived-filename>", "branch": "<branch>", "classification": "<tier>", "modules": ["<file-or-module>"], "specs": ["<spec-ref>"], "patterns": ["<tag>"], "decisions": ["<1-line>"], "shipped": "<YYYY-MM-DD>"}'
       ```
-      - If `INDEX.jsonl` does not exist, create it. If a legacy `INDEX.md` exists, keep it as a compatibility mirror but prefer `INDEX.jsonl` for new entries.
-      - Fallback: If `.agentcortex/tools/guard_context_write.py` is unavailable, write the JSONL line directly.
+      - The helper reads the previous entry, computes its sha256[:8], and prepends `prev_sha` to the new entry. The first (genesis) entry uses `prev_sha: "GENESIS"`.
+      - **Do NOT** include `prev_sha` in the `--entry` JSON yourself; the helper rejects entries that already contain it.
+      - **Do NOT** call `guard_context_write.py append` for `INDEX.jsonl` — that path lacks chain awareness and will silently break the chain on next `validate.sh` (caught by `check_audit_chain.py`). The helper is the only correct path.
+      - If `INDEX.jsonl` does not exist, the helper creates it. If a legacy `INDEX.md` exists, keep it as a compatibility mirror but prefer `INDEX.jsonl` for new entries.
+      - **Python-unavailable fallback**: If `python` is unavailable, write the JSONL line directly with `prev_sha: "GENESIS"` (treat as standalone entry; chain integrity becomes best-effort). Record the fallback in Work Log Drift Log.
 4. **Product Backlog Update**: If `docs/specs/_product-backlog.md` exists and this feature is listed:
    - Update feature status: `In Progress` → `Shipped`
    - Update `last_updated` in frontmatter


### PR DESCRIPTION
## Summary

3-expert post-merge regression audit (Regression Auditor + Pragmatist + Real-World Simulator) independently identified the **same blocker**:

ADR-003 (PR #76) shipped `append_chain_entry.py` and `check_audit_chain.py`, but `/ship` workflow text still tells the agent to use `guard_context_write.py append_write` — which does NOT add `prev_sha`. **Next `/ship` would silently break the chain ADR-003 just promised.**

Today the chain is intact only because PR #76's conflict-resolve hand-wrote `prev_sha` for the 2 migrated entries.

## What changed

- `.agent/workflows/ship.md` §State Update step 3 — archive INDEX.jsonl append protocol now invokes `append_chain_entry.py append --path ... --entry '<json>'` instead of `guard_context_write.py append_write`.
- Added explicit "do NOT include prev_sha in --entry" guard (helper rejects duplicate prev_sha).
- Added explicit "do NOT call guard_context_write.py append for INDEX.jsonl" warning with cite to `check_audit_chain.py` as the CI-time catcher.
- Documented Python-unavailable fallback (record in Drift Log; treat as standalone GENESIS entry).

## Verification

- `bash .agentcortex/bin/validate.sh` → pass=69 warn=5 fail=0 (doc-only; no behavior shift until next `/ship`)
- `python -m unittest discover -s tests/guard` → all green
- Helper round-trip already proven by `tests/guard/test_audit_chain.py`

## Why zero-regression-risk

- Doc-only change to `/ship` workflow text.
- Helper is already shipped + tested + invoked correctly per its own tests.
- The "do NOT call guard_context_write.py append for INDEX.jsonl" warning is **additive** — does not remove `guard_context_write.py` for other paths (e.g., `current_state.md` still uses it correctly).
- Python-unavailable fallback degrades to single-entry GENESIS (best-effort), preserving AGENTS.md doctrine.

## Test plan

- [ ] Run validate.sh in CI
- [ ] Manual: at next `/ship`, follow the new ship.md §3 instructions and verify `check_audit_chain.py` reports chain intact

## Related

- Closes R-1 (BLOCKER) from 3-expert regression audit
- Companion convergence PRs (will follow): R-2/R-3 (bootstrap §0 + §0a hardening), R-4 (ADR self-frontmatter), R-5/R-6 (lint UX + sentinel telemetry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

⚡ ACX