### PR TITLE
Fix R-2 + R-3: bootstrap §0 tiny-fix ADR-coverage guard + §0a Python-unavailable fallback

### DIFF
--- a/.agent/workflows/bootstrap.md
+++ b/.agent/workflows/bootstrap.md
@@ -24,7 +24,7 @@ Before loading any context, walk the decision table below top-to-bottom — **fi
 | modifies `AGENTS.md`, `.agent/rules/*`, or `.agent/config.yaml` | minimum `quick-win` — continue to Step 1 |
 | modifies `.agentcortex/templates/*` or `.agentcortex/bin/validate.*` | minimum `quick-win` — continue to Step 1 |
 | modifies any file with `status: frozen` frontmatter | minimum `quick-win` — continue to Step 1 |
-| modifies <3 files (PR-scope, NOT per-logical-change) AND is non-semantic (typo, docs, non-functional config) AND scope is unambiguous | **tiny-fix** — skip Steps 1–6, inline plan + execute + evidence (Work Log skipped per §5) |
+| modifies <3 files (PR-scope, NOT per-logical-change) AND is non-semantic (typo, docs, non-functional config) AND scope is unambiguous AND target paths do NOT match any ADR's `applies_to:` glob | **tiny-fix** — skip Steps 1–6, inline plan + execute + evidence (Work Log skipped per §5) |
 | scope is unclear or multi-module | continue to Step 1 for full context loading |
 
 **TOKEN LEAK BLOCK**: If the task is ultimately classified as `tiny-fix` or `quick-win`, reading `engineering_guardrails.md` at any point is a structural Token Leak violation. Rely purely on AGENTS.md §Core Directives and bypass full guardrails. Rationale: loading SSoT + specs + archives for a typo fix wastes ~2,500 tokens (P6).
@@ -59,7 +59,11 @@ Each classification reads ONLY the rows marked REQUIRED. Skip rows marked SKIP �
 > **When**: ONLY for `feature` or `architecture-change` classifications (AFTER Step 0 pre-classification).
 > **Skip for**: `tiny-fix`, `quick-win`, `hotfix` — these NEVER trigger this check. Zero extra tokens.
 
-If the task is classified as `feature` or `architecture-change`, run the **ADR Coverage Check** via `.agentcortex/tools/check_adr_coverage.py --paths <task-target-files>` (Lesson L5 fix, see SSoT §Global Lessons 2026-04-25). The tool reads ADR frontmatter `applies_to:` glob lists; outputs cover/no-cover plus exit code:
+If the task is classified as `feature` or `architecture-change`, run the **ADR Coverage Check** via `.agentcortex/tools/check_adr_coverage.py --paths <task-target-files>` (Lesson L5 fix, see SSoT §Global Lessons 2026-04-25). The tool reads ADR frontmatter `applies_to:` glob lists; outputs cover/no-cover plus exit code.
+
+**Python-unavailable fallback** (per AGENTS.md doctrine): If `python --version` fails (no Python on this host), record `"ADR coverage check skipped: python unavailable"` in Work Log Drift Log and proceed to Step 1 with `## External References` left empty for coverage info. Do NOT fail the bootstrap. The fallback degrades to no-coverage-prompt, never to a hard-fail.
+
+Tool exit codes:
 
 - **Exit 2 — `no_adr_at_all`** (`docs/adr/` is empty):
    → Output: `"🏗️ New project detected — no architecture ADR found. Run /app-init to establish project conventions? (yes/skip)"`


### PR DESCRIPTION
## Summary

Two zero-regression fixes from the 3-expert post-merge regression audit (Auditor REGRESSION-3 + REGRESSION-4):

**R-2 (MEDIUM)** — bootstrap §0 row "modifies <3 files... tiny-fix" pre-empts §0a. A 2-file architecture-change (e.g., ADR + 1 tool) gets silently routed to tiny-fix because §0 is first-match-wins. PR #74's ADR coverage check becomes unreachable for these cases.

**R-3 (MEDIUM)** — §0a unconditionally invokes `python check_adr_coverage.py`. On Python-less hosts bootstrap hard-fails instead of degrading to advisory mode (contradicts AGENTS.md's documented "Python-unavailable fallback" doctrine).

## What changed

- **R-2 fix**: append `AND target paths do NOT match any ADR's applies_to: glob` to the `<3 files tiny-fix` row predicate. Escalation: covered files → at least quick-win so §0a can run.
- **R-3 fix**: add explicit "Python-unavailable fallback" paragraph at top of §0a — record skip in Drift Log, proceed to Step 1, never hard-fail.

## Verification

- `bash .agentcortex/bin/validate.sh` → pass=69 warn=5 fail=0 (no change; doc-only)
- `python -m unittest discover -s tests/guard` → all green

## Why zero-regression-risk

- **R-2**: strictly NARROWS tiny-fix. Escalating to quick-win adds Work Log + brief plan, never blocks. No path that was tiny-fix before becomes hard-failed; just promoted to lighter ceremony when ADR coverage exists.
- **R-3**: strictly MORE PERMISSIVE than today. Hosts with Python: unaffected. Python-less hosts: instead of hard-fail, get graceful skip + Drift Log entry.

## Test plan

- [ ] CI validate.sh exits 0
- [ ] Manual: `PATH=/empty bash -c 'true'` style env should now degrade gracefully if §0a is exercised

## Related

- Closes R-2 + R-3 from 3-expert regression audit
- Companion: PR #77 (R-1 BLOCKER ship chain integration), PR #79 (R-4 ADR self-frontmatter), PR #80 (R-5 + R-6 lint/sentinel UX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

⚡ ACX