### PR TITLE
Fix R-4: ADR-001 lifecycle + ADR-002 applies_to self-backfill (close the irony)

### DIFF
--- a/docs/adr/ADR-001-governance-friction-tuning.md
+++ b/docs/adr/ADR-001-governance-friction-tuning.md
@@ -10,6 +10,12 @@ applies_to:
   - ".agentcortex/docs/guides/token-governance.md"
   - ".agentcortex/docs/guides/token-optimization-quickstart.md"
   - "docs/guides/token-optimization-quickstart*.md"
+lifecycle:
+  owner: "/adr"
+  review_cadence: on-event
+  review_trigger: "When friction-tuning rules are amended (new directory exemption, evidence truncation threshold change, prompt-cache policy update), OR when a downstream fork hits a token-cost regression attributable to these decisions"
+  supersedes: none
+  superseded_by: none
 ---
 
 # ADR-001: Governance Friction Tuning

--- a/docs/adr/ADR-002-guarded-governance-writes.md
+++ b/docs/adr/ADR-002-guarded-governance-writes.md
@@ -4,6 +4,15 @@ date: 2026-04-25
 classification: architecture-change
 primary_domain: document-governance
 deciders: "@kbwen + Claude Opus 4.7 + 4-expert roundtable (Lock Designer / Doc Lifecycle Architect / Future-Proofing Skeptic / Pragmatist v2)"
+applies_to:
+  - ".agentcortex/tools/guard_context_write.py"
+  - ".agentcortex/tools/lint_governed_writes.py"
+  - ".agentcortex/tools/check_lifecycle_frontmatter.py"
+  - ".agentcortex/bin/validate.sh"
+  - ".agentcortex/bin/validate.ps1"
+  - ".agent/config.yaml"
+  - ".agentcortex/context/.guard_receipts/**"
+  - ".agentcortex/context/.guard_locks/**"
 lifecycle:
   owner: "/adr"
   review_cadence: on-event


### PR DESCRIPTION
## Summary

The very ADRs that introduced these governance rules don't comply with them. Two checkers report this on every validate run:

- `check_lifecycle_frontmatter.py` → ADR-001 missing `lifecycle:` block (WARN, grandfathered)
- `check_adr_coverage.py` → ADR-002 missing `applies_to:` (auxiliary stderr)

Real-World Simulator scenarios 2 + 5 caught both as "the ADR that defined the rule fails it."

## What changed

- **ADR-001** + `lifecycle:` block (owner /adr, on-event cadence, trigger naming friction-tuning amendments + downstream token-cost regressions)
- **ADR-002** + `applies_to:` list — the 8 actual files D2.1+D2.2+D2.3 govern (guard_context_write.py, lint_governed_writes.py, check_lifecycle_frontmatter.py, validate.sh/.ps1, .agent/config.yaml, .guard_receipts/, .guard_locks/)

## Verification

- `check_lifecycle_frontmatter.py` → **4 PASS / 2 WARN / 0 FAIL** (was 3 PASS / 3 WARN; ADR-001 promoted)
- `check_adr_coverage.py --paths AGENTS.md` → covered_by:ADR-001 (no aux stderr about ADR-002)
- `bash .agentcortex/bin/validate.sh` → pass=69 warn=5 fail=0

## Why zero-regression-risk

- Pure additive frontmatter metadata. Only 2 checkers parse these fields, and both REDUCE warn count after this PR.
- ADRs remain conceptually Accepted and append-only — modifying frontmatter metadata without altering decisions, status, or rationale is the documented Phase-1 retro-fit pattern from PR #74.

## Out of scope

The 2 remaining `check_lifecycle_frontmatter.py` WARNs are L1 Domain Docs (`document-governance.md`, `skill-ecosystem.md`) — different file class. Separate retro-fit if you want to clear them too.

## Related

- Closes R-4 from 3-expert regression audit (Real-World Simulator scenarios 2 + 5)
- Companion: PR #77 (R-1 BLOCKER), PR #78 (R-2 + R-3), PR #80 (R-5 + R-6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

⚡ ACX