### PR TITLE
Fix R-5 + R-6: lint summary-first UX + sentinel could-not-verify telemetry

### DIFF
--- a/.agentcortex/tools/lint_governed_writes.py
+++ b/.agentcortex/tools/lint_governed_writes.py
@@ -309,6 +309,11 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("--root", default=".", help="Repo root (default: cwd)")
     ap.add_argument("--json", action="store_true", help="Emit findings as JSON")
     ap.add_argument("--verbose", action="store_true", help="Print per-file scan info")
+    ap.add_argument(
+        "--show-warn",
+        action="store_true",
+        help="Print every WARN line (default: print only FAILs and the summary). WARNs were drowning real signal — see R-5 in 3-expert post-merge audit.",
+    )
     return ap.parse_args()
 
 
@@ -350,13 +355,19 @@ def main() -> int:
         }
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
-        for f in findings:
-            print(f"  [{f.severity}] {f.file}:{f.line_no}  {f.pattern} — {f.detail}", file=sys.stderr)
-            print(f"           {f.matched}", file=sys.stderr)
+        # R-5 fix: print summary FIRST so it's not buried under 70 WARN lines.
+        # FAILs are always shown (action required). WARNs are silent unless
+        # --show-warn is passed (most are dynamic-path false-positives in tests/).
         print(
             f"governed-write lint: {files_scanned} file(s) scanned; "
             f"{fail_count} FAIL, {warn_count} WARN"
+            + (" (use --show-warn to see WARN lines)" if warn_count and not args.show_warn else "")
         )
+        for f in findings:
+            if f.severity == "WARN" and not args.show_warn:
+                continue
+            print(f"  [{f.severity}] {f.file}:{f.line_no}  {f.pattern} — {f.detail}", file=sys.stderr)
+            print(f"           {f.matched}", file=sys.stderr)
 
     return 1 if fail_count else 0
 

--- a/.claude/hooks/check-sentinel.py
+++ b/.claude/hooks/check-sentinel.py
@@ -107,14 +107,48 @@ def write_violation(payload: dict, last_text: str, receipt_path: Path | None = N
         os.close(fd)
 
 
+def write_could_not_verify(payload: dict, reason: str, receipt_path: Path | None = None) -> None:
+    """R-6 fix: log explicit 'could-not-verify' instead of silent EXIT 0.
+
+    Without this telemetry, a misconfigured transcript_path on Windows or
+    cross-platform mounts silently disables sentinel enforcement.
+    """
+    if receipt_path is None:
+        receipt_path = RECEIPT
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "timestamp": int(time.time()),
+        "session_id": payload.get("session_id"),
+        "violation": "could_not_verify",
+        "reason": reason,
+        "stop_hook_active": payload.get("stop_hook_active", False),
+    }
+    line = json.dumps(record, sort_keys=True, ensure_ascii=False) + "\n"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+    fd = os.open(str(receipt_path), flags, 0o644)
+    try:
+        os.write(fd, line.encode("utf-8"))
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
 def main() -> int:
     payload = read_payload()
     transcript_str = payload.get("transcript_path", "")
     if not transcript_str:
+        # R-6: silent EXIT 0 left no trace; now logs could_not_verify.
+        write_could_not_verify(payload, reason="missing_transcript_path")
         return 0
-    last_text = last_assistant_text(Path(transcript_str))
+    transcript_path = Path(transcript_str)
+    if not transcript_path.exists():
+        write_could_not_verify(
+            payload, reason=f"transcript_unreadable: {transcript_str}"
+        )
+        return 0
+    last_text = last_assistant_text(transcript_path)
     if not last_text:
-        # No assistant text yet — nothing to check.
+        # No assistant text yet — nothing to check (legitimate first turn).
         return 0
     if has_sentinel(last_text):
         return 0

--- a/tests/guard/test_sentinel_hook.py
+++ b/tests/guard/test_sentinel_hook.py
@@ -158,15 +158,40 @@ class TestEndToEnd(unittest.TestCase):
         self.assertFalse(receipt.exists())
 
     def test_no_transcript_path_returns_zero(self) -> None:
-        # Direct call with empty payload
+        # R-6 fix: silent EXIT 0 left no trace; now logs could_not_verify.
         saved_stdin = sys.stdin
+        saved_receipt = hook.RECEIPT
+        hook.RECEIPT = self.base / "viol-no-path.jsonl"
         try:
             from io import StringIO
             sys.stdin = StringIO("{}")
             rc = hook.main()
         finally:
+            hook.RECEIPT = saved_receipt
             sys.stdin = saved_stdin
         self.assertEqual(rc, 0)
+        self.assertTrue((self.base / "viol-no-path.jsonl").exists())
+        obj = json.loads((self.base / "viol-no-path.jsonl").read_text(encoding="utf-8").strip())
+        self.assertEqual(obj["violation"], "could_not_verify")
+        self.assertEqual(obj["reason"], "missing_transcript_path")
+
+    def test_unreadable_transcript_path_logs_could_not_verify(self) -> None:
+        # R-6: transcript_path provided but file doesn't exist (Windows path
+        # mismatch, deleted file). Was silent EXIT 0; now leaves a trace.
+        saved_stdin = sys.stdin
+        saved_receipt = hook.RECEIPT
+        hook.RECEIPT = self.base / "viol-unreadable.jsonl"
+        try:
+            from io import StringIO
+            sys.stdin = StringIO(json.dumps({"transcript_path": "/no/such/path.jsonl", "session_id": "x"}))
+            rc = hook.main()
+        finally:
+            hook.RECEIPT = saved_receipt
+            sys.stdin = saved_stdin
+        self.assertEqual(rc, 0)
+        obj = json.loads((self.base / "viol-unreadable.jsonl").read_text(encoding="utf-8").strip())
+        self.assertEqual(obj["violation"], "could_not_verify")
+        self.assertIn("transcript_unreadable", obj["reason"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two zero-regression UX/telemetry fixes from the 3-expert post-merge audit.

**R-5** — `lint_governed_writes.py` prints 74 WARN lines on a clean tree, burying the 5 actually-actionable WARNs about work log hygiene (Auditor REGRESSION-2 + Simulator Scenario 6).

**R-6** — `check-sentinel.py` exits 0 silently when `transcript_path` is missing OR the file is unreadable. A misconfigured Windows mount could silently disable enforcement with zero trace (Simulator Scenario 4).

## What changed

- **R-5**: Lint summary printed FIRST (single line). WARNs hidden by default; `--show-warn` opts back in. FAILs always shown. Detection logic + exit codes + JSON output all unchanged.
- **R-6**: New `write_could_not_verify()` helper. When transcript can't be inspected, writes a `violation: "could_not_verify"` JSONL record naming the failure mode (`missing_transcript_path` / `transcript_unreadable: <path>`). Still exits 0 (don't break legitimate sessions), but leaves a discoverable trail `validate.sh` can surface.

## Verification

- `python -m unittest discover -s tests/guard` → all green (incl. 1 new test for R-6 unreadable transcript)
- `bash .agentcortex/bin/validate.sh` → pass=69 warn=5 fail=0
- Lint default output now: `governed-write lint: 45 file(s) scanned; 0 FAIL, 74 WARN (use --show-warn to see WARN lines)` — summary at top, noise opt-in
- Sentinel: missing-path and unreadable-path scenarios both produce `could_not_verify` entries in violations log

## Why zero-regression-risk

- **R-5**: UX-only. Detection logic unchanged. CI integration via validate.sh continues to pass/fail identically. Power users who want WARN detail pass `--show-warn`.
- **R-6**: Purely additive telemetry. Silent EXIT 0 case now writes a log entry of a new violation type BEFORE exiting 0 the same way. No new failure modes; no existing behavior changed.

## Out of scope (deferred)

- A `validate.sh` check that fails when violations log contains `could_not_verify` entries — that escalates the receipt into enforcement; left as a separate small PR after this lands and we have data on whether `could_not_verify` events fire in normal use.

## Related

- Closes R-5 + R-6 from 3-expert regression audit
- Companion: PR #77 (R-1 BLOCKER ship chain), PR #78 (R-2 + R-3 bootstrap), PR #79 (R-4 ADR self-frontmatter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

⚡ ACX