### PR TITLE
Cleanup: backfill L1 Domain Doc lifecycle frontmatter (lifecycle WARN: 2 → 0)

### DIFF
--- a/docs/architecture/document-governance.md
+++ b/docs/architecture/document-governance.md
@@ -2,7 +2,13 @@
 status: living
 domain: document-governance
 created: 2026-03-29
-last_updated: 2026-03-29
+last_updated: 2026-04-25
+lifecycle:
+  owner: "/govern-docs"
+  review_cadence: on-event
+  review_trigger: "When a Domain Doc decision is added/superseded, OR when L2 Decision Log entry count exceeds restructure_threshold (.agent/config.yaml §domain_doc), OR when any new ADR amends document-governance scope"
+  supersedes: none
+  superseded_by: none
 ---
 
 # Document Governance — Layer 1 Synthesis

--- a/docs/architecture/skill-ecosystem.md
+++ b/docs/architecture/skill-ecosystem.md
@@ -2,7 +2,13 @@
 status: living
 domain: skill-ecosystem
 created: 2026-04-05
-last_updated: 2026-04-11
+last_updated: 2026-04-25
+lifecycle:
+  owner: "/govern-docs"
+  review_cadence: on-event
+  review_trigger: "When a new skill is added/retired, OR skill_conflict_matrix.md gains/removes entries, OR an ADR amends skill activation policy"
+  supersedes: none
+  superseded_by: none
 ---
 
 # Skill Ecosystem — Layer 1 Synthesis


### PR DESCRIPTION
## Summary

Last 2 grandfathered WARNs from `check_lifecycle_frontmatter.py` cleared. Both L1 docs pre-date 2026-04-25 lifecycle rule (PR #72), so they WARN on every validate run. Now backfilled.

## Changes

- `docs/architecture/document-governance.md` + `lifecycle:` (owner /govern-docs; on-event)
- `docs/architecture/skill-ecosystem.md` + `lifecycle:` (owner /govern-docs; on-event)
- `last_updated` bumped to 2026-04-25 (informational)

## Verification

- `check_lifecycle_frontmatter.py` → **6 PASS / 0 WARN / 0 FAIL** (was 4 PASS / 2 WARN)
- `bash .agentcortex/bin/validate.sh` → pass=69 warn=5 fail=0

## Why zero-regression-risk

- Pure additive frontmatter. No tool branches on these new fields.
- L1 doc body content unchanged.

## Cleanup batch summary (#81 + #82 + #83)

| | Pre-batch | Post-batch | Δ |
|---|---|---|---|
| Lint default WARN | 74 | 19 | -74% |
| Lifecycle WARN | 2 | 0 | -100% |
| AGENTS.md per-skill-load tokens | ~50 unused hash overhead | 0 | -100% |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

⚡ ACX