### PR TITLE
fix(validate.ps1): UTF-8 BOM + strict-mode empty-archive crash (#21)

### DIFF
--- a/.agentcortex/bin/validate.ps1
+++ b/.agentcortex/bin/validate.ps1
@@ -1,4 +1,4 @@
-param(
+﻿param(
     [switch]$NoPython
 )
 
@@ -828,8 +828,16 @@ if (Test-Path -Path $worklogDir -PathType Container) {
     # Archive directory size — surface unbounded growth before ingestion hazard. WARN-only.
     $archiveDir = Join-NormalPath $root '.agentcortex/context/archive'
     if ((Test-Path -Path $archiveDir -PathType Container) -and ($archiveSizeWarnKb -gt 0)) {
-        $archiveKb = [int]((Get-ChildItem -Path $archiveDir -Recurse -File -ErrorAction SilentlyContinue |
-            Measure-Object -Property Length -Sum).Sum / 1024)
+        # Under Set-StrictMode -Version Latest, an empty pipeline through Measure-Object
+        # yields an object whose Sum property strict-mode treats as missing — guard via
+        # explicit array materialization so empty archives report 0 KB cleanly.
+        $archiveFiles = @(Get-ChildItem -Path $archiveDir -Recurse -File -ErrorAction SilentlyContinue)
+        if ($archiveFiles.Count -gt 0) {
+            $archiveKb = [int](($archiveFiles | Measure-Object -Property Length -Sum).Sum / 1024)
+        }
+        else {
+            $archiveKb = 0
+        }
         if ($archiveKb -gt $archiveSizeWarnKb) {
             Add-Result -Level 'WARN' -Message "archive size ${archiveKb}KB exceeds threshold ${archiveSizeWarnKb}KB; consider /retro-driven cold-tier rotation"
         }

--- a/.agentcortex/tools/check_text_integrity.ps1
+++ b/.agentcortex/tools/check_text_integrity.ps1
@@ -57,7 +57,11 @@ function Inspect-File {
     param([string]$FilePath)
     $issues = @()
     $bytes = [System.IO.File]::ReadAllBytes($FilePath)
-    if ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
+    # UTF-8 BOM is REQUIRED on .ps1 scripts containing non-ASCII characters,
+    # otherwise Windows PowerShell 5.1 reads them as the system ANSI code page
+    # (e.g. CP950/Big5 on Taiwan locale) and the parser breaks on the mojibake.
+    $ext = [System.IO.Path]::GetExtension($FilePath).ToLower()
+    if ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF -and $ext -ne ".ps1") {
         $issues += "utf8-bom"
     }
     try {

--- a/.agentcortex/tools/check_text_integrity.py
+++ b/.agentcortex/tools/check_text_integrity.py
@@ -92,7 +92,10 @@ def has_mixed_eol_bytes(data: bytes) -> bool:
 def inspect_file(path: pathlib.Path, root: pathlib.Path) -> list[str]:
     issues: list[str] = []
     data = path.read_bytes()
-    if data.startswith(UTF8_BOM):
+    # UTF-8 BOM is REQUIRED on .ps1 scripts that contain non-ASCII characters,
+    # otherwise Windows PowerShell 5.1 reads them as the system ANSI code page
+    # (e.g. CP950/Big5 on Taiwan locale) and the parser breaks on the mojibake.
+    if data.startswith(UTF8_BOM) and path.suffix.lower() != '.ps1':
         issues.append('utf8-bom')
     try:
         text = data.decode('utf-8')


### PR DESCRIPTION
## Summary

Two bugs in `validate.ps1` caused all 8 `SSOTCompletenessTests` to fail on Windows when the test harness invoked the deployed validator via `powershell.exe` (Windows PowerShell 5.1):

1. **Missing UTF-8 BOM.** Windows PowerShell 5.1 reads scripts with no BOM using the system ANSI code page. On a CJK locale (Taiwan = CP950/Big5) the embedded Chinese characters in the encoding-health checks (lines 759/775/791) become mojibake and the parser aborts with `Missing closing '}'` at line 756. Prepending `EF BB BF` to the file makes PS 5.1 read it as UTF-8 unconditionally.
2. **Strict-mode crash on empty archive directory.** Line 831 piped `Get-ChildItem -Recurse` into `Measure-Object -Sum`. Under `Set-StrictMode -Version Latest`, when the archive dir is empty (always true on a fresh deploy), accessing `.Sum` on the result throws `PropertyNotFoundStrict`. The exception short-circuited the remainder of the validator — including the SSoT-completeness checks at line 1071+ — which is the symptom Issue #21 reported (validator output missing `SSoT ADR Index completeness`, `Spec Index completeness`, `Active Backlog consistency`).

The text-integrity tools (`check_text_integrity.{py,ps1}`) are also updated to permit UTF-8 BOM on `.ps1` files. BOM is the documented Microsoft recommendation for cross-version PowerShell compatibility on scripts containing non-ASCII content, and treating it as a regression would block the BOM fix above.

Note: Issue #21's described root cause (deploy script missing files) was a misdiagnosis — the deploy script already copies all the listed paths. The actual blocker was the parser failure preventing `validate.ps1` from running at all on Windows.

## Evidence

- `bash .agentcortex/bin/validate.sh` → `pass=80 warn=1 fail=0 skip=2` ✓
- `python -m unittest test_ssot_completeness` → `Ran 8 tests in 228.288s — OK` ✓ (previously 8/8 FAIL)

## Test plan

- [x] Framework validator passes locally
- [x] All 8 SSoT completeness tests pass on Windows + CJK locale
- [ ] CI verifies the same on Linux runners (cross-platform regression)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)