### PR TITLE
docs(onboarding): unify three entry-path signals across entry docs

### DIFF
--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -13,7 +13,7 @@
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
 - **Last Updated**: 2026-05-07
 - **Last Verified**: 2026-05-07
-- **Update Sequence**: 12
+- **Update Sequence**: 13
 - **ADR Index**:
   - docs/adr/ADR-001-governance-friction-tuning.md — ADR-001: Governance Friction Tuning, accepted 2026-04-23
   - docs/adr/ADR-002-guarded-governance-writes.md — ADR-002: Guarded Governance Writes (lock unification + CI lint + lifecycle frontmatter), accepted 2026-04-25
@@ -65,6 +65,14 @@
 - [Category: governance-proposal][Severity: MEDIUM][Trigger: plan-proposes-must-rule][prev: 7f5a25c3] When /plan proposes adding a MUST rule to AGENTS.md or .agent/rules/, cross-check the [enforcement][HIGH] Global Lesson immediately at plan time — not just at /implement. A MUST rule without a corresponding hook, validator, or test is honor-system theatre regardless of where in the workflow it is caught. Self-check: "What enforces this rule if the AI ignores it?" If the answer is "nothing", delete the rule or add the enforcement first.
 
 ## Ship History
+
+### Ship-claude-reverent-matsumoto-30a74e-2026-05-07
+- Feature shipped: Onboarding entry-point unification — three-path branching (greenfield raw idea / brownfield adoption / single concrete task) consistently signaled across `.codex/INSTALL.md`, `README.md`, `docs/README_zh-TW.md` (quick-win, doc-only).
+  - Closes the gap where `.codex/INSTALL.md` §3 told downstream LLMs to run `/bootstrap` first regardless of starting point, contradicting the routing-index Ambiguity Rule §1 (multi-feature input → `/spec-intake`).
+  - 8 sibling docs audited (PROJECT_EXAMPLES × 2, CODEX_PLATFORM_GUIDE × 2, CLAUDE_PLATFORM_GUIDE, NONLINEAR_SCENARIOS × 2, superpowers-playbook) — all confirmed task-context language, no edit needed.
+  - zh-TW §3–§6 renumbered to close the §4 hole created when "從零開始" + "帶入素材" were merged into §3.
+- Tests: validate 66 PASS / 0 WARN / 0 FAIL / 10 SKIP.
+- Commits: pending — see `claude/reverent-matsumoto-30a74e` branch.
 
 ### Ship-claude-modest-antonelli-da2aec-2026-05-07
 - Feature shipped: Zero-Python downstream + AGENTS.md trim + deploy-gap fix + skill cleanup (PR #91, quick-win, 4 commits).

--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -34,11 +34,54 @@ git clone https://github.com/KbWen/agentic-os.git
 > recent guard receipt before allowing staged changes to `current_state.md`.
 > This is advisory only — it does not block commits.
 
-## 3) Codex Opening Commands (Recommended paste)
+## 3) Opening Commands — Pick Your Entry Point
+
+The right first command depends on your starting point. **Always start with this preamble**:
 
 ```text
 Read and follow AGENTS.md first — it is the canonical governance for this repo.
-Then run /bootstrap to classify your task and load context.
-Use /brainstorm to clarify solutions, and /plan to generate an actionable plan.
 DO NOT claim completion until /review and /test have passed.
 ```
+
+Then add ONE of the three openers below:
+
+### A. Brand-new project, multi-feature idea
+
+> Use when you have a product idea with several features and no code yet.
+
+```text
+This is a brand-new project. My initial idea is:
+[1–2 paragraphs describing the product and its features]
+
+Please run /spec-intake to decompose this into a feature inventory.
+After I pick the first feature, run /bootstrap → /app-init to establish
+the tech stack ADR, then /plan and /implement.
+```
+
+**Why /spec-intake first**: a multi-feature raw idea must be decomposed into
+`docs/specs/_product-backlog.md` before any single feature is bootstrapped,
+otherwise classification and Work Log scope will be wrong.
+
+### B. Existing repository — adopting Agentic OS for the first time
+
+> Use when the framework was just deployed into a repo that already has code.
+
+```text
+This repo already has code but Agentic OS was just deployed.
+Please run /audit (read-only) to map the existing codebase,
+then /app-init to record the tech stack ADR,
+then /spec-intake when I'm ready to add features.
+```
+
+### C. Single, well-scoped task on an established project
+
+> Use when the project already has an ADR and you have one concrete task.
+
+```text
+Please run /bootstrap to classify and start this task.
+[Then describe the task — single feature, bug, or quick-win.]
+```
+
+> **Not sure which one?** Default to A for raw ideas, C for concrete tasks.
+> The AI's Intent Router will also auto-detect multi-feature input and
+> route to /spec-intake, but explicit beats inferred.

--- a/README.md
+++ b/README.md
@@ -144,13 +144,15 @@ Built for teams where multiple AI sessions work on the same codebase:
 - **Ship Guard** — checks for SSoT conflicts before merging
 - **Session Identity** — every AI session writes its model name and timestamp
 
-### 🚀 Recommended: Start with /audit
+### 🚀 Three Entry Paths
 
-New to Agentic OS? Run `/audit` first — it's a **read-only** traversal that maps your existing codebase with zero risk:
+Pick the one that matches your starting point (full opener templates in **Quick Start §2**):
 
-```
-/audit  →  /app-init  →  /spec-intake  →  pick a quick-win  →  full feature
-```
+| Starting point | First command | Full chain |
+|---|---|---|
+| 🆕 Brand-new project, multi-feature idea | `/spec-intake` | spec-intake → pick feature → bootstrap → app-init → plan → implement |
+| 🏗️ Existing repo, adopting Agentic OS | `/audit` (read-only, zero risk) | audit → app-init → spec-intake → quick-win → feature |
+| 🎯 Single concrete task on an established project | `/bootstrap` | bootstrap → plan → implement → review → test → ship |
 
 See the [Lifecycle Benchmark](docs/LIFECYCLE_BENCHMARK.md) ([繁體中文](docs/LIFECYCLE_BENCHMARK_zh-TW.md)) for real token consumption data across 6 development scenarios.
 
@@ -245,17 +247,44 @@ If you only want the governance templates (Markdown files) without running any t
 
 </details>
 
-### 2. Start Working
+### 2. Start Working — Pick Your Entry Point
 
-Tell your AI agent:
+The right first command depends on your starting point. **Always preface with**:
 
-> "Read `AGENTS.md` and bootstrap this task."
+> "Read `AGENTS.md` and follow it. Do not claim completion until /review and /test pass."
 
-Or use a slash command directly:
+Then add **one** of the following based on your situation:
 
+**A. Brand-new project, multi-feature idea** — `/spec-intake` first
+
+```text
+This is a brand-new project. My initial idea is:
+[1–2 paragraphs describing the product and its features]
+
+Please run /spec-intake to decompose this into a feature inventory.
+After I pick the first feature, run /bootstrap → /app-init to establish
+the tech stack ADR, then /plan and /implement.
 ```
+
+**B. Existing repository adopting Agentic OS** — `/audit` first
+
+```text
+This repo already has code; Agentic OS was just deployed.
+Run /audit (read-only) to map the codebase, then /app-init to record
+the tech stack ADR, then /spec-intake when I add features.
+```
+
+**C. Single concrete task on an established project** — `/bootstrap` directly
+
+```text
 /bootstrap
+[describe the single task]
 ```
+
+> **Why this matters**: a multi-feature raw idea routed straight to `/bootstrap`
+> is classified as a single task, skipping the Feature Inventory and
+> `_product-backlog.md` decomposition. The Intent Router auto-detects this in
+> most cases, but explicit beats inferred.
 
 ### 3. Follow the Flow
 

--- a/docs/README_zh-TW.md
+++ b/docs/README_zh-TW.md
@@ -19,13 +19,15 @@
 - **命名空間隔離**：下游專案可自由添加自定義 skill 和 workflow，框架用 `.agentcortex-manifest` 區分管理範圍，用戶指令永遠優先。
 - **17 項專業技能**：每個 skill metadata 都宣告在哪個 phase 自動啟用，AI 不需要人類提示就知道何時使用。
 
-## 🚀 推薦：從 /audit 開始
+## 🚀 三條起點路徑
 
-剛接觸 Agentic OS？先跑 `/audit` — **唯讀**遍歷你的 codebase，零風險：
+依你的專案狀態挑一條（詳細開場提示見「快速開始 §3」）：
 
-```
-/audit  →  /app-init  →  /spec-intake  →  挑一個 quick-win  →  完整 feature
-```
+| 起點 | 第一個指令 | 完整鏈 |
+|---|---|---|
+| 🆕 全新專案 + 多 feature 想法 | `/spec-intake` | spec-intake → 選 feature → bootstrap → app-init → plan → implement |
+| 🏗️ 既有 repo 首次導入 | `/audit`（唯讀掃描，零風險） | audit → app-init → spec-intake → quick-win → feature |
+| 🎯 單一明確任務 | `/bootstrap` | bootstrap → plan → implement → review → test → ship |
 
 詳見 [生命週期基準測試](LIFECYCLE_BENCHMARK_zh-TW.md)（[English](LIFECYCLE_BENCHMARK.md)）— 6 個真實場景的 token 消耗數據。
 
@@ -143,32 +145,69 @@ Fetch and follow instructions from <your-raw-url>/.codex/INSTALL.md
 
 > 若遇到 403 錯誤，請直接貼上 `.codex/INSTALL.md` 全文。
 
-### 3) 任務開場提示（從零開始）
+### 3) 開場提示 — 依你的起點挑一條
+
+> **共通前綴**（任何情境都先貼這一段）
+>
+> ```text
+> 請先閱讀並遵循 AGENTS.md — 這是本專案的治理憲法。
+> 在 /review 與 /test 通過前，禁止宣稱完成。
+> ```
+
+#### 情境 A：全新專案 + 多 feature 想法
+
+> 適用：有產品想法、有多個功能、還沒寫 code。
 
 ```text
-請先執行 /bootstrap。
+這是一個全新的專案。我的初步想法是：
+[一兩段描述產品和功能]
+
+請先執行 /spec-intake，把它拆成 Feature Inventory。
+我選定第一個 feature 後，再跑 /bootstrap → /app-init 建立技術棧 ADR，
+然後 /plan → /implement。
+```
+
+**為何 /spec-intake 先行**：多 feature 的 raw idea 必須先拆成 `docs/specs/_product-backlog.md`，
+否則 /bootstrap 的分類和 Work Log scope 都會錯位。
+
+#### 情境 B：既有 repo 首次導入 Agentic OS
+
+> 適用：repo 已經有程式碼，剛部署完框架。
+
+```text
+這個 repo 已有程式碼，剛部署完 Agentic OS。
+請先跑 /audit（唯讀掃描）建立既有結構的地圖，
+然後 /app-init 紀錄技術棧 ADR，
+等我準備加功能時再跑 /spec-intake。
+```
+
+#### 情境 C：已穩定專案 + 單一明確任務
+
+> 適用：專案已有 ADR，目前只想做一件具體的事。
+
+```text
+請先執行 /bootstrap 分類此任務。
 需求：[一句話]
 目標檔案：[path1, path2]
 限制：[不可改 API / 不可改 schema]
-驗收：[列 2-3 點可驗收條件]
+驗收：[列 2-3 點]
 ```
 
-### 4) 帶入前期討論素材（已與其他 AI 討論過）
+#### 情境 D：帶入前期討論素材（已與其他 AI 討論過）
 
-若已與其他 AI 模型完成規格討論、白皮書、技術文件等，不需要先自行整理——直接貼入即可，AI 會自行提取與歸檔。
+> 適用：手上有別的 AI 寫好的規格、白皮書、技術文件。直接貼入即可，AI 會自行提取與歸檔。
 
 ```text
-請先執行 /bootstrap。
-需求：[一句話總結]
-以下是前期討論的完整內容，請先消化後再開始規劃：
+請先執行 /spec-intake — 我帶來了前期討論的完整素材，請先消化後再決定流程。
 ---
 [直接貼上所有素材：對話記錄、規格書、技術文件等]
 ---
 ```
 
-> AI 會在 bootstrap 過程中自動：提取需求與限制 → 整理存入 `docs/specs/` → 分類任務 → 輸出標準 bootstrap 結果。
+> AI 在 /spec-intake 期間會自動：寫入 `docs/specs/_raw-intake.md` → 拆 Feature Inventory →
+> 寫入 `docs/specs/_product-backlog.md`。完成後再走 /bootstrap → /app-init 鏈。
 
-### 5) 跨回合交接提示（續做任務時使用）
+### 4) 跨回合交接提示（續做任務時使用）
 
 ```text
 以下是前一個模型留下的 handoff，請以此為「唯一真實狀態」繼續工作。
@@ -176,7 +215,7 @@ Fetch and follow instructions from <your-raw-url>/.codex/INSTALL.md
 [貼上 handoff 內容]
 ```
 
-### 6) 用指令驅動開發
+### 5) 用指令驅動開發
 
 1. `/bootstrap`：初始化任務並凍結分類
 2. `/plan`（或 `/write-plan`）：列檔案、步驟、風險、回退


### PR DESCRIPTION
## Summary

Resolves the inconsistency between `.codex/INSTALL.md`, `README.md`, and `docs/README_zh-TW.md` on what a downstream user / LLM should run first. Before this PR:

- `.codex/INSTALL.md` §3 told the LLM to run `/bootstrap` first, **regardless of starting point**.
- README banners recommended `/audit → /app-init → /spec-intake → quick-win → feature`, which is correct only for **brownfield** adoption.
- README "Start Working" templates also defaulted to `/bootstrap` for raw ideas.

This contradicted `.agent/workflows/routing.md` §4 Ambiguity Rule §1, which routes multi-feature raw input to `/spec-intake`. A downstream user pasting a multi-feature product idea would be classified as a single task, skipping Feature Inventory and `_product-backlog.md` decomposition.

## Changes

All three entry docs now surface the same three branches:

| Starting point | First command |
|---|---|
| 🆕 Brand-new project, multi-feature idea | `/spec-intake` |
| 🏗️ Existing repo adopting Agentic OS | `/audit` |
| 🎯 Single concrete task on an established project | `/bootstrap` |

### Files changed

- `.codex/INSTALL.md` §3 → split into A/B/C openers
- `README.md` §1 banner table + §2 "Start Working" three-branch openers
- `docs/README_zh-TW.md` §1 banner table + §3 開場提示 (含 A/B/C/D 情境); renumbered §4–§5 to close the §4 hole left when "從零開始" + "帶入素材" merged into §3
- `.agentcortex/context/current_state.md` SSoT update_seq 12 → 13 + Ship History entry

### Audit (no edits needed)

8 sibling docs verified to use task-context language (single-task scenarios where `/bootstrap` is correct):

- `PROJECT_EXAMPLES.md` / `_zh-TW.md` (Node.js + Python single-feature examples)
- `CODEX_PLATFORM_GUIDE.md` / `_zh-TW.md` (per-task platform workflow)
- `CLAUDE_PLATFORM_GUIDE.md` (command paths)
- `NONLINEAR_SCENARIOS.md` / `_zh-TW.md` (recovery scenarios)
- `docs/guides/superpowers-playbook.md` (workflow chain reference)

## Classification

`quick-win` — doc-only, no semantic change, no spec/handoff required.

## Test plan

- [x] `bash .agentcortex/bin/validate.sh --no-python` → 66 PASS / 0 WARN / 0 FAIL / 10 SKIP
- [x] `git diff --stat` matches plan (3 entry docs + SSoT)
- [x] zh-TW §1–§5 numbering continuous (no §4 hole)
- [x] Cross-doc chain consistency: A/B/C chains use identical command sequences across all 3 entry files
- [ ] Manual smoke: have a downstream LLM read the new `.codex/INSTALL.md` against a "raw idea" prompt and verify it routes to `/spec-intake`

🤖 Generated with [Claude Code](https://claude.com/claude-code)