### PR TITLE
chore: normalize forward slashes in validate.ps1 path helpers (#19)

### DIFF
--- a/.agentcortex/bin/validate.ps1
+++ b/.agentcortex/bin/validate.ps1
@@ -7,8 +7,10 @@ $ErrorActionPreference = 'Stop'
 
 function Normalize-PathString {
     param([Parameter(Mandatory = $true)][string]$Path)
-    if ($Path.StartsWith('\\?\')) { return $Path.Substring(4) }
-    return $Path
+    # Strip Windows long-path prefix (\\?\) before any further normalization.
+    if ($Path.StartsWith('\\?\')) { $Path = $Path.Substring(4) }
+    # Unify mixed separators to backslash so string-based comparisons are stable on Windows.
+    return $Path -replace '/', '\'
 }
 
 function Join-NormalPath {
@@ -16,7 +18,7 @@ function Join-NormalPath {
         [Parameter(Mandatory = $true)][string]$Base,
         [Parameter(Mandatory = $true)][string]$Child
     )
-    return [System.IO.Path]::Combine((Normalize-PathString $Base), $Child)
+    return Normalize-PathString ([System.IO.Path]::Combine((Normalize-PathString $Base), $Child))
 }
 
 function Add-Result {


### PR DESCRIPTION
## Summary

> **Scope note**: This is **preventive hardening**, not a bug fix. No current call site in `validate.ps1` does string-based path comparison — all paths flow through `Test-Path` / `Get-Content`, which already tolerate mixed separators. The change closes a latent footgun for any future code that compares paths as strings (`-eq`, `Compare-Object`, hash-key lookup).

`Normalize-PathString` previously only stripped the `\?\` long-path prefix. On Windows, `[System.IO.Path]::Combine` (used inside `Join-NormalPath`) preserves input slashes as-is, so `Join-NormalPath 'C:\repo' 'docs/specs/foo.md'` returned the mixed-separator string `C:\repo\docs/specs/foo.md`.

This change:
- Adds `'/' -> '\'` substitution to `Normalize-PathString` after the `\?\` strip.
- Routes the `Join-NormalPath` result through `Normalize-PathString` so combined output is always uniform.

`Test-Path` / `Get-Content` already accepted both separators, so no existing call site changes behavior.

## Evidence

Smoke test of the helper functions after the change:

```
Normalize-PathString 'C:\repo/docs/specs/foo.md' -> C:\repo\docs\specs\foo.md
Join-NormalPath 'C:\repo' 'docs/specs/foo.md'    -> C:\repo\docs\specs\foo.md
Normalize-PathString '\?\C:\repo/docs/foo.md'   -> C:\repo\docs\foo.md
```

Validation runs unchanged:

- `.agentcortex/bin/validate.ps1`: `Summary: pass=77 warn=1 fail=0 skip=2`
- `.agentcortex/bin/validate.sh`: `Summary: pass=80 warn=0 fail=0 skip=2`

## Test plan
- [x] Run `validate.ps1` on Windows — no new failures
- [x] Run `validate.sh` on bash — no regressions
- [x] Spot-check function output with mixed-separator inputs

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)