### PR TITLE
fix(deploy): match framework ADRs by filename, not ADR-001-* prefix

### DIFF
--- a/.agentcortex/bin/deploy.sh
+++ b/.agentcortex/bin/deploy.sh
@@ -305,11 +305,18 @@ if $_acx_legacy_confirmed || [ -f "$TARGET/tools/validate.sh" ] || \
             fi
         done
 
+        # Framework ADRs that historically lived under .agentcortex/adr/ — match
+        # by filename so a downstream project's own ADR-001 is never mistaken
+        # for the framework's. Keep in sync with .agentcortex/adr/ contents.
+        _framework_adrs="ADR-001-vnext-self-managed-architecture.md"
         for adr_file in "$TARGET/.agentcortex/adr"/*.md; do
             [ -f "$adr_file" ] || continue
             bname="$(basename "$adr_file")"
-            # ADR-001-* is the framework ADR; everything else is project-owned
-            case "$bname" in ADR-001-*) continue ;; esac
+            _is_framework=false
+            for fw in $_framework_adrs; do
+                [ "$bname" = "$fw" ] && _is_framework=true && break
+            done
+            $_is_framework && continue
             mkdir -p "$TARGET/docs/adr"
             if [ -e "$TARGET/docs/adr/$bname" ]; then
                 echo "  [SKIP] docs/adr/$bname already exists — orphaned copy left in .agentcortex/adr/$bname (resolve manually)"


### PR DESCRIPTION
## Summary

Real installer bug uncovered while preparing #99 (downstream-misleading wording cleanup).

The orphan-ADR-recovery path in `deploy.sh` (only fires when migrating a pre-v6 install) used `case "$bname" in ADR-001-*) continue ;;` to skip "the framework ADR." This was tied to the legacy `ADR-001-vnext-self-managed-architecture.md` that older versions shipped. In #99 we changed `/app-init` to create `ADR-001-project-architecture.md` as the downstream project's first ADR (was hardcoded to `ADR-002`, which silently assumed a fictional framework ADR-001 had pre-shipped). With that change, the prefix-based skip would wrongly classify the downstream's **own** ADR-001 as framework-owned and refuse to migrate it out of the legacy `.agentcortex/adr/` location.

Fix: replace the prefix-match with a known-filename match using the same `_framework_adrs` pattern already used a few lines above for `_framework_specs`. Today the list contains exactly one historical name (`ADR-001-vnext-self-managed-architecture.md`); future additions go there explicitly.

This is gated by `_acx_legacy_confirmed`, so it only fires for confirmed pre-v6 upgrades — blast radius is small. But the bug was real and the fix matches the established sibling pattern in the same function.

## Files changed
- `.agentcortex/bin/deploy.sh` (+9 / −2)

## Test plan

- [x] `bash -n .agentcortex/bin/deploy.sh` (syntax check) — OK
- [x] `bash .agentcortex/bin/deploy.sh --dry-run /tmp/target` — completes normally
- [ ] Manual: simulate legacy `.agentcortex/adr/ADR-001-project-architecture.md` → expect migration to `docs/adr/`
- [ ] Manual: simulate legacy `.agentcortex/adr/ADR-001-vnext-self-managed-architecture.md` → expect skip (still treated as framework)

## Relation to #99

Independent of #99 textually, but discovered while writing the `/app-init` change there. Either order of merge is fine; if #99 lands first the bug becomes reachable for any downstream that subsequently runs the legacy-upgrade path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)