### PR TITLE
fix(deploy): preserve scaffold-tier files with no manifest entry via sidecar

### DIFF
--- a/.agentcortex/bin/deploy.sh
+++ b/.agentcortex/bin/deploy.sh
@@ -151,10 +151,23 @@ deploy_file() {
         else
             # Scaffold/wrapper: check if user modified
             if [ -z "$old_manifest_hash" ]; then
-                # File exists in target but not in old manifest — treat as new
-                cp ${CP_FLAG:+"$CP_FLAG"} "$src" "$dst"
-                [ -n "$do_chmod" ] && chmod +x "$dst"
-                COUNT_NEW=$((COUNT_NEW + 1))
+                # File exists in target but not in old manifest. The file
+                # likely carries user content (legacy migration, pre-manifest
+                # era, or content brought in out-of-band). Preserve it via
+                # sidecar when content differs from the framework version —
+                # never silently overwrite scaffold-tier user content.
+                local dst_hash
+                dst_hash="$(compute_sha256 "$dst")"
+                if [ "$src_hash" != "$dst_hash" ]; then
+                    cp ${CP_FLAG:+"$CP_FLAG"} "$src" "$dst.acx-incoming"
+                    echo "  [SKIP] $rel (pre-existing/migrated; new version at $rel.acx-incoming — merge manually or ask AI agent to merge)"
+                    COUNT_SKIPPED=$((COUNT_SKIPPED + 1))
+                    # Record the user's current hash so future updates still detect modification.
+                    record_deployed "$tier" "$rel" "$dst_hash"
+                    return 0
+                fi
+                # Same content — no-op; record the matching hash for future runs.
+                COUNT_UPDATED=$((COUNT_UPDATED + 1))
             else
                 local dst_hash
                 dst_hash="$(compute_sha256 "$dst")"


### PR DESCRIPTION
## Summary

Surfaced during a multi-angle downstream-UX audit after #99/#100 merged: the legacy v5 → v6 upgrade path silently destroys user content in `.agentcortex/context/current_state.md`.

### The bug

When `deploy_file` runs in update mode (`.agentcortex-manifest` exists) on a scaffold-tier file (`current_state.md`, `AGENTS.md`, `CLAUDE.md`, `.gitattributes`, ADRs/templates), and the manifest has **no entry** for that file's path, the previous code took the "treat as new" branch:

```bash
if [ -z "$old_manifest_hash" ]; then
    # File exists in target but not in old manifest — treat as new
    cp ${CP_FLAG:+"$CP_FLAG"} "$src" "$dst"
```

That `cp` overwrites the user's file unconditionally — no sidecar, no skip, no warning.

### How users hit it

1. **Legacy v5 → v6 upgrades**: `migrate_if_exists` moves `docs/context/current_state.md` → `.agentcortex/context/current_state.md`. The legacy `.agentcortex-manifest` only indexes the OLD path, so `manifest_lookup_hash` for the NEW path returns empty — and the just-migrated user SSoT content gets clobbered by the template.
2. **Out-of-band file creation**: User hand-creates `AGENTS.md` before running the installer; re-run wipes it.

### Fix

In the no-manifest-entry branch, compute the dst hash and compare to src; on mismatch write a `.acx-incoming` sidecar and SKIP. Same shape as the existing `!$is_update` branch a few lines below.

```bash
if [ "$src_hash" != "$dst_hash" ]; then
    cp ${CP_FLAG:+"$CP_FLAG"} "$src" "$dst.acx-incoming"
    echo "  [SKIP] $rel (pre-existing/migrated; new version at $rel.acx-incoming — merge manually or ask AI agent to merge)"
    COUNT_SKIPPED=$((COUNT_SKIPPED + 1))
    record_deployed "$tier" "$rel" "$dst_hash"
    return 0
fi
```

Core tier is unchanged — those are framework files the user shouldn't customize.

## Test plan

- [x] Reproduced legacy-upgrade scenario: planted user-customized `docs/context/current_state.md` with header `# legacy current_state with my customizations` + content lines → with fix, user content stays at the migrated path; framework template lands at `.agentcortex/context/current_state.md.acx-incoming`.
- [x] Regression: the modified-user-content path (manifest entry exists, dst hash != manifest hash) is untouched — Test 5 (`AGENTS.md` user edit + framework new line → sidecar) behaviour preserved.
- [x] Regression: normal re-deploy (manifest matches dst) is untouched — proceeds to "User didn't modify — safe to update" branch.
- [x] `bash -n .agentcortex/bin/deploy.sh` — syntax OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)