### PR TITLE
docs: align version banners to v1.1.2 and correct skill count 17→14

### DIFF
--- a/.agentcortex/bin/deploy.sh
+++ b/.agentcortex/bin/deploy.sh
@@ -26,7 +26,7 @@ TARGET="${TARGET:-.}"
 TARGET="${TARGET%/}"
 
 MANIFEST_FILE="$TARGET/.agentcortex-manifest"
-ACX_VERSION="1.0.0"
+ACX_VERSION="1.1.2"
 
 # --- Self-deploy guard ---
 TARGET_ABS="$(cd "$TARGET" 2>/dev/null && pwd || echo "$TARGET")"

--- a/.agentcortex/docs/TESTING_PROTOCOL.md
+++ b/.agentcortex/docs/TESTING_PROTOCOL.md
@@ -1,4 +1,4 @@
-# Testing Protocol v1.1
+# Testing Protocol v1.1.2
 
 > **This document guides the AI Agent to produce high-quality, trustworthy, and defensive test code.**
 

--- a/.agentcortex/docs/TESTING_PROTOCOL_zh-TW.md
+++ b/.agentcortex/docs/TESTING_PROTOCOL_zh-TW.md
@@ -1,4 +1,4 @@
-# Testing Protocol (測試教戰守則) v1.1
+# Testing Protocol (測試教戰守則) v1.1.2
 >
 > **本文件旨在指引 AI Agent 產出高品質、可信任、且具備防禦性的測試程式碼。**
 

--- a/.agentcortex/docs/guides/antigravity-v5-runtime.md
+++ b/.agentcortex/docs/guides/antigravity-v5-runtime.md
@@ -2,8 +2,8 @@
 
 ## Antigravity Hard-Path Enforcement Overlay
 
-Version: v1.1
-Date: 2026-04-16
+Version: v1.1.2
+Date: 2026-04-17
 Scope: **Antigravity environments** (token-generation agents where shell exit codes don’t halt execution)
 
 ### Why v5 exists

--- a/.agentcortex/docs/guides/migration.md
+++ b/.agentcortex/docs/guides/migration.md
@@ -25,7 +25,7 @@ Instruct the AI to perform a migration scan:
 
 ```text
 Please run /bootstrap.
-We've just upgraded to Agentic OS v1.1.
+We've just upgraded to Agentic OS v1.1.2.
 Please scan the project for existing documentation and perform the following:
 1. Identify scattered notes, specs, and ADRs; move them to correct directories and rename.
 2. Initialize .agentcortex/context/current_state.md.

--- a/.agentcortex/docs/guides/migration_zh-TW.md
+++ b/.agentcortex/docs/guides/migration_zh-TW.md
@@ -25,7 +25,7 @@
 
 ```text
 請執行 /bootstrap。
-我們剛升級到 Agentic OS v1.1。
+我們剛升級到 Agentic OS v1.1.2。
 請掃描專案中的既有文件，並自動完成以下工作：
 1. 識別散亂的筆記、規格、ADR，移動到正確目錄並重新命名
 2. 初始化 .agentcortex/context/current_state.md

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/Agentic OS-v1.1-blueviolet?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJ3aGl0ZSI+PHBhdGggZD0iTTEyIDJDNi40OCAyIDIgNi40OCAyIDEyczQuNDggMTAgMTAgMTAgMTAtNC40OCAxMC0xMFMxNy41MiAyIDEyIDJ6bTAgMThjLTQuNDEgMC04LTMuNTktOC04czMuNTktOCA4LTggOCAzLjU5IDggOC0zLjU5IDgtOCA4eiIvPjwvc3ZnPg==" alt="Agentic OS v1.1"/>
+  <img src="https://img.shields.io/badge/Agentic OS-v1.1.2-blueviolet?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJ3aGl0ZSI+PHBhdGggZD0iTTEyIDJDNi40OCAyIDIgNi40OCAyIDEyczQuNDggMTAgMTAgMTAgMTAtNC40OCAxMC0xMFMxNy41MiAyIDEyIDJ6bTAgMThjLTQuNDEgMC04LTMuNTktOC04czMuNTktOCA4LTggOCAzLjU5IDggOC0zLjU5IDgtOCA4eiIvPjwvc3ZnPg==" alt="Agentic OS v1.1.2"/>
 </p>
 
 <h1 align="center">Agentic OS</h1>
 
 <p align="center">
   <strong>The governance-first operating system for AI coding agents.</strong><br/>
-  Structured workflows, delivery gates, engineering guardrails, and 17 professional skills<br/>
+  Structured workflows, delivery gates, engineering guardrails, and 14 professional skills<br/>
   that work across Claude Code, Cursor, GitHub Copilot, Google Antigravity, and Codex.
 </p>
 
@@ -338,7 +338,7 @@ your-project/
 │   ├── skills/                  # Skill metadata (auto-trigger defs)
 │   └── workflows/               # Workflow definitions (35 workflows)
 │
-├── .agents/skills/              # Full skill implementations (17 skills)
+├── .agents/skills/              # Full skill implementations (14 skills)
 │   ├── test-driven-development/
 │   ├── systematic-debugging/
 │   └── ...

--- a/docs/AGENT_MODEL_GUIDE.md
+++ b/docs/AGENT_MODEL_GUIDE.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.1 — Model Selection Guide
+# Agentic OS v1.1.2 — Model Selection Guide
 
 > For human reference only — this file is not loaded into AI context.
 

--- a/docs/AGENT_MODEL_GUIDE_zh-TW.md
+++ b/docs/AGENT_MODEL_GUIDE_zh-TW.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.1 — 模型選擇指南
+# Agentic OS v1.1.2 — 模型選擇指南
 
 > 人類參考用 — 此檔案不會被載入 AI context。
 

--- a/docs/README_zh-TW.md
+++ b/docs/README_zh-TW.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.1 (Runtime v1.1 Anti-Drift Edition)
+# Agentic OS v1.1.2 (Runtime v1.1 Anti-Drift Edition)
 
 [English Version](../README.md)
 


### PR DESCRIPTION
## Summary

Downstream-facing version banners and the README's skill count drifted from the actual project state. A user installing the framework saw the install line `Installing Agentic OS v1.0.0 ...` (4 patch releases behind), the README badge `v1.1`, and a claim of "17 professional skills" that hasn't been true since `f3d97fc` consolidated skills 19 → 14.

### Drift sources

- `CHANGELOG.md` most recent entry: **[1.1.2] — 2026-04-17** ← source of truth
- `.agentcortex/bin/deploy.sh:29` `ACX_VERSION="1.0.0"` ← stale
- 8 deployed docs say `v1.1` (badges, titles, migration prompts) ← partial
- `README.md` lines 9 + 341 say "17 skills" ← incorrect

### Fixes (single batch)

| File | Change |
|---|---|
| `.agentcortex/bin/deploy.sh:29` | `ACX_VERSION` `"1.0.0"` → `"1.1.2"` |
| `README.md:2,9,341` | Badge `v1.1` → `v1.1.2`; "17 professional skills" / "(17 skills)" → "14" |
| `docs/README_zh-TW.md:1` | `v1.1` → `v1.1.2` |
| `docs/AGENT_MODEL_GUIDE.md:1` + zh-TW | title bump |
| `.agentcortex/docs/TESTING_PROTOCOL.md:1` + zh-TW | title bump |
| `.agentcortex/docs/guides/antigravity-v5-runtime.md:5` | `Version: v1.1` → `v1.1.2`, date updated |
| `.agentcortex/docs/guides/migration.md:28` + zh-TW | upgrade prompt text |

### Out of scope

- `docs/specs/skill-research-integration.md` still says "Current inventory: 19 skills". This is a historical, frozen spec snapshot from before the consolidation; not deployed downstream. Leaving as-is.
- README.md line 411 says "Upgrade to v1.1+" — `+` suffix already means "v1.1 series or later" so it's still correct after the bump.

## Test plan

- [x] `validate.sh` (full python): 77 PASS / 0 WARN / 0 FAIL / 2 SKIP
- [x] Fresh downstream deploy header now reads `Installing Agentic OS v1.1.2 (e8b5869) to ...`
- [x] Deployed `.agentcortex/docs/README.md` badge alt-text `Agentic OS v1.1.2`
- [x] Deployed README prose now says "14 professional skills" and "(14 skills)"
- [x] `grep "Agentic OS v1\.1[^.]"` across downstream-deployed files → 0 matches
- [x] `grep "17 (professional )?skills"` → 0 matches in downstream-deployed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)