### PR TITLE
docs: make README/cross-doc links work in both GitHub and deployed contexts

### DIFF
--- a/.agentcortex/bin/deploy.sh
+++ b/.agentcortex/bin/deploy.sh
@@ -637,6 +637,12 @@ for f in "$REPO_ROOT"/.agentcortex/docs/guides/*.md; do
     [ -f "$f" ] || continue
     deploy_file "$f" ".agentcortex/docs/guides/$(basename "$f")"
 done
+# Downstream-facing quickstart guides live in framework's docs/guides/ (root-style path).
+# Deploy them to .agentcortex/docs/guides/ alongside the framework-internal guides.
+for f in "$REPO_ROOT"/docs/guides/token-optimization-quickstart*.md; do
+    [ -f "$f" ] || continue
+    deploy_file "$f" ".agentcortex/docs/guides/$(basename "$f")"
+done
 
 # --- Deploy: .claude/commands (core) ---
 if [ -d "$REPO_ROOT/.claude/commands" ]; then

--- a/.agentcortex/docs/NONLINEAR_SCENARIOS.md
+++ b/.agentcortex/docs/NONLINEAR_SCENARIOS.md
@@ -158,4 +158,4 @@ When turn count exceeds 8, the existing rule says _suggest_ handoff. This enhanc
 
 - [Project Examples (Linear Workflows)](./PROJECT_EXAMPLES.md)
 - [Engineering Guardrails (Constitution)](../../.agent/rules/engineering_guardrails.md)
-- [Agent Model Guide (Model Selection)](../../docs/AGENT_MODEL_GUIDE.md)
+- [Agent Model Guide (Model Selection)](https://github.com/KbWen/agentic-os/blob/main/docs/AGENT_MODEL_GUIDE.md)

--- a/.agentcortex/docs/NONLINEAR_SCENARIOS_zh-TW.md
+++ b/.agentcortex/docs/NONLINEAR_SCENARIOS_zh-TW.md
@@ -157,4 +157,4 @@
 
 - [導入範例（線性流程）](./PROJECT_EXAMPLES_zh-TW.md)
 - [工程護欄（憲法）](../../.agent/rules/engineering_guardrails.md)
-- [模型選擇指南](../../docs/AGENT_MODEL_GUIDE_zh-TW.md)
+- [模型選擇指南](https://github.com/KbWen/agentic-os/blob/main/docs/AGENT_MODEL_GUIDE_zh-TW.md)

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
 
 <p align="center">
   <a href="docs/README_zh-TW.md">繁體中文</a> &middot;
-  <a href="CONTRIBUTING.md">Contributing</a> &middot;
-  <a href="CHANGELOG.md">Changelog</a>
+  <a href="https://github.com/KbWen/agentic-os/blob/main/CONTRIBUTING.md">Contributing</a> &middot;
+  <a href="https://github.com/KbWen/agentic-os/blob/main/CHANGELOG.md">Changelog</a>
 </p>
 
 ---
@@ -155,7 +155,7 @@ Pick the one that matches your starting point (full opener templates in **Quick 
 | 🏗️ Existing repo, adopting Agentic OS | `/audit` (read-only, zero risk) | audit → app-init → spec-intake → quick-win → feature |
 | 🎯 Single concrete task on an established project | `/bootstrap` | bootstrap → plan → implement → review → test → ship |
 
-See the [Lifecycle Benchmark](docs/LIFECYCLE_BENCHMARK.md) ([繁體中文](docs/LIFECYCLE_BENCHMARK_zh-TW.md)) for real token consumption data across 6 development scenarios.
+See the [Lifecycle Benchmark](https://github.com/KbWen/agentic-os/blob/main/docs/LIFECYCLE_BENCHMARK.md) ([繁體中文](https://github.com/KbWen/agentic-os/blob/main/docs/LIFECYCLE_BENCHMARK_zh-TW.md)) for real token consumption data across 6 development scenarios.
 
 ### 📉 Token Efficiency
 
@@ -402,24 +402,24 @@ Agentic OS is built on [10 non-negotiable principles](.agentcortex/docs/AGENT_PH
 | Document | Description |
 |:---|:---|
 | [Agent Philosophy](.agentcortex/docs/AGENT_PHILOSOPHY.md) | 10 core principles |
-| [Model Selection Guide](docs/AGENT_MODEL_GUIDE.md) | Flash vs. Pro guidance |
+| [Model Selection Guide](https://github.com/KbWen/agentic-os/blob/main/docs/AGENT_MODEL_GUIDE.md) | Flash vs. Pro guidance |
 | [Testing Protocol](.agentcortex/docs/TESTING_PROTOCOL.md) | Testing standards |
 | [Project Examples](.agentcortex/docs/PROJECT_EXAMPLES.md) | Node.js & Python examples |
 | [Token Governance](.agentcortex/docs/guides/token-governance.md) | Token optimization strategies |
-| [Token Optimization Quickstart](docs/guides/token-optimization-quickstart.md) | Reduce token costs immediately ([繁體中文](docs/guides/token-optimization-quickstart_zh-TW.md)) |
+| [Token Optimization Quickstart](https://github.com/KbWen/agentic-os/blob/main/docs/guides/token-optimization-quickstart.md) | Reduce token costs immediately ([繁體中文](https://github.com/KbWen/agentic-os/blob/main/docs/guides/token-optimization-quickstart_zh-TW.md)) |
 | [Context Budget](.agentcortex/docs/guides/context-budget.md) | Context window management |
 | [Migration Guide](.agentcortex/docs/guides/migration.md) | Upgrade to v1.1+ |
 | [Codex Platform Guide](.agentcortex/docs/CODEX_PLATFORM_GUIDE.md) | Codex Web/App adaptation |
 | [Claude Platform Guide](.agentcortex/docs/CLAUDE_PLATFORM_GUIDE.md) | Claude Code integration |
 | [Nonlinear Scenarios](.agentcortex/docs/NONLINEAR_SCENARIOS.md) | Recovery from interrupted sessions |
-| [Lifecycle Benchmark](docs/LIFECYCLE_BENCHMARK.md) | 6 real scenarios with token costs |
-| [生命週期基準測試](docs/LIFECYCLE_BENCHMARK_zh-TW.md) | Token 消耗量測（繁體中文） |
+| [Lifecycle Benchmark](https://github.com/KbWen/agentic-os/blob/main/docs/LIFECYCLE_BENCHMARK.md) | 6 real scenarios with token costs |
+| [生命週期基準測試](https://github.com/KbWen/agentic-os/blob/main/docs/LIFECYCLE_BENCHMARK_zh-TW.md) | Token 消耗量測（繁體中文） |
 
 ---
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on contributing as a human or AI agent.
+See [CONTRIBUTING.md](https://github.com/KbWen/agentic-os/blob/main/CONTRIBUTING.md) for guidelines on contributing as a human or AI agent.
 
 ## License
 

--- a/docs/guides/token-optimization-quickstart.md
+++ b/docs/guides/token-optimization-quickstart.md
@@ -2,7 +2,7 @@
 
 > **Audience**: Developers who cloned Agentic OS and want to reduce token consumption immediately.
 >
-> **Prerequisite knowledge**: None — this guide is self-contained. For deep dives, see [Token Governance](../../.agentcortex/docs/guides/token-governance.md) and [Context Budget](../../.agentcortex/docs/guides/context-budget.md).
+> **Prerequisite knowledge**: None — this guide is self-contained. For deep dives, see [Token Governance](https://github.com/KbWen/agentic-os/blob/main/.agentcortex/docs/guides/token-governance.md) and [Context Budget](https://github.com/KbWen/agentic-os/blob/main/.agentcortex/docs/guides/context-budget.md).
 
 ---
 
@@ -127,7 +127,7 @@ Agentic OS already enforces this (see `AGENTS.md §Response Brevity`), but you c
 
 ### Reduce File Reads at Bootstrap
 
-The [Context Budget Guide](../../.agentcortex/docs/guides/context-budget.md) defines exactly which files are read per classification:
+The [Context Budget Guide](https://github.com/KbWen/agentic-os/blob/main/.agentcortex/docs/guides/context-budget.md) defines exactly which files are read per classification:
 
 | Classification | Max File Reads |
 |:---|:---|
@@ -170,8 +170,8 @@ Agentic OS is designed to improve over time. Here's how the framework evolves wi
 3. **Work Log compaction** — Old entries are automatically archived, keeping context lean.
 4. **Classification accuracy improves** — As the SSoT accumulates ship history, the AI gets better at pattern-matching task types.
 
-> **For framework contributors**: If you want to propose structural token optimizations (e.g., merging workflow files, slimming guardrails), open an issue or submit a PR. The [Lifecycle Benchmark](../LIFECYCLE_BENCHMARK.md) provides baseline measurements for comparison.
+> **For framework contributors**: If you want to propose structural token optimizations (e.g., merging workflow files, slimming guardrails), open an issue or submit a PR. The [Lifecycle Benchmark](https://github.com/KbWen/agentic-os/blob/main/docs/LIFECYCLE_BENCHMARK.md) provides baseline measurements for comparison.
 
 ---
 
-*See also: [Token Governance (internal)](../../.agentcortex/docs/guides/token-governance.md) · [Context Budget (internal)](../../.agentcortex/docs/guides/context-budget.md) · [Lifecycle Benchmark](../LIFECYCLE_BENCHMARK.md)*
+*See also: [Token Governance (internal)](https://github.com/KbWen/agentic-os/blob/main/.agentcortex/docs/guides/token-governance.md) · [Context Budget (internal)](https://github.com/KbWen/agentic-os/blob/main/.agentcortex/docs/guides/context-budget.md) · [Lifecycle Benchmark](https://github.com/KbWen/agentic-os/blob/main/docs/LIFECYCLE_BENCHMARK.md)*

--- a/docs/guides/token-optimization-quickstart_zh-TW.md
+++ b/docs/guides/token-optimization-quickstart_zh-TW.md
@@ -2,7 +2,7 @@
 
 > **對象**：Clone Agentic OS 後想立即降低 Token 消耗的開發者。
 >
-> **前置知識**：不需要。本指南自成一體。深入了解請參考 [Token Governance](../../.agentcortex/docs/guides/token-governance.md) 和 [Context Budget](../../.agentcortex/docs/guides/context-budget.md)。
+> **前置知識**：不需要。本指南自成一體。深入了解請參考 [Token Governance](https://github.com/KbWen/agentic-os/blob/main/.agentcortex/docs/guides/token-governance.md) 和 [Context Budget](https://github.com/KbWen/agentic-os/blob/main/.agentcortex/docs/guides/context-budget.md)。
 
 ---
 
@@ -127,7 +127,7 @@ Agentic OS 已經強制執行這個規則（參見 `AGENTS.md §Response Brevity
 
 ### 減少 Bootstrap 時的檔案讀取
 
-[Context Budget Guide](../../.agentcortex/docs/guides/context-budget.md) 定義了每個分類可以讀取的檔案數量上限：
+[Context Budget Guide](https://github.com/KbWen/agentic-os/blob/main/.agentcortex/docs/guides/context-budget.md) 定義了每個分類可以讀取的檔案數量上限：
 
 | 分類 | 最大檔案讀取數 |
 |:---|:---|
@@ -170,8 +170,8 @@ Agentic OS 的設計允許它隨著使用而自動改進：
 3. **Work Log 自動壓縮** — 舊條目自動歸檔，保持 Context 精簡。
 4. **分類精準度提升** — 隨著 SSoT 累積交付歷史，AI 能更好地進行任務類型的模式匹配。
 
-> **給框架貢獻者**：如果你想提議結構性的 Token 優化（例如合併 Workflow 檔案、精簡 Guardrails），請開 Issue 或提交 PR。[生命週期基準測試](../LIFECYCLE_BENCHMARK_zh-TW.md) 提供了可量測的基線數據。
+> **給框架貢獻者**：如果你想提議結構性的 Token 優化（例如合併 Workflow 檔案、精簡 Guardrails），請開 Issue 或提交 PR。[生命週期基準測試](https://github.com/KbWen/agentic-os/blob/main/docs/LIFECYCLE_BENCHMARK_zh-TW.md) 提供了可量測的基線數據。
 
 ---
 
-*另見：[Token Governance（內部）](../../.agentcortex/docs/guides/token-governance.md) · [Context Budget（內部）](../../.agentcortex/docs/guides/context-budget.md) · [生命週期基準測試](../LIFECYCLE_BENCHMARK_zh-TW.md)*
+*另見：[Token Governance（內部）](https://github.com/KbWen/agentic-os/blob/main/.agentcortex/docs/guides/token-governance.md) · [Context Budget（內部）](https://github.com/KbWen/agentic-os/blob/main/.agentcortex/docs/guides/context-budget.md) · [生命週期基準測試](https://github.com/KbWen/agentic-os/blob/main/docs/LIFECYCLE_BENCHMARK_zh-TW.md)*


### PR DESCRIPTION
## Summary

The framework's `README.md` is dual-purpose:
1. **GitHub face** — rendered at github.com/KbWen/agentic-os from the repo root.
2. **Downstream reference** — `deploy.sh` ships it to `<downstream>/.agentcortex/docs/README.md`.

Relative-path `.md` links can't satisfy both contexts simultaneously. A multi-angle audit found 6 broken `.md` links in the deployed README (33% of all internal links).

### Investigation: is this real?

Each broken-link target was assessed for actual downstream value:

| Link | Content | Downstream needs? |
|---|---|---|
| `CONTRIBUTING.md` | Framework contribution guide (92 lines) | ❌ For framework contributors, not users |
| `docs/AGENT_MODEL_GUIDE.md` (+ zh-TW) | Sonnet vs Opus model selection | ✅ **File IS deployed** at `.agentcortex/docs/AGENT_MODEL_GUIDE.md` — just wrong path in README |
| `docs/LIFECYCLE_BENCHMARK.md` (+ zh-TW) | Token benchmark report (261 lines) | ❌ Pre-adoption evaluation material |
| `docs/guides/token-optimization-quickstart.md` (+ zh-TW) | "Reduce token costs immediately" (177 lines) | ✅ **Should be deployed but wasn't** — explicitly targets downstream users |

### Expert recommendation (Plan subagent)

> "Option 1 (surgical edit) + targeted whitelist addition. Option 2 (sed rewriter) violates the 'no clever build-step trickery' constraint and creates encoding/quoting risk. Options 3/4 fragment doc governance and break the offline-reading promise for AI agents. Option 5 leaves agents tripping on dead links during work."

Approach: rewrite the 6 broken links to absolute `https://github.com/...` URLs (works in both contexts), AND add `token-optimization-quickstart.md` to the deploy whitelist so the genuinely-needed guide ships.

## Files changed (6)

- `README.md` — 6 broken links → absolute GitHub URLs
- `.agentcortex/bin/deploy.sh` — add `docs/guides/token-optimization-quickstart*.md` to docs deploy loop (deployed to `.agentcortex/docs/guides/`)
- `docs/guides/token-optimization-quickstart.md` (+ zh-TW) — 4 internal cross-refs each: `../../.agentcortex/docs/guides/{token-governance,context-budget}.md` and `../LIFECYCLE_BENCHMARK.md` had the same source-vs-deployed mismatch. Rewritten to absolute URLs so the file is correct in both `docs/guides/` (source) and `.agentcortex/docs/guides/` (deployed) contexts.
- `.agentcortex/docs/NONLINEAR_SCENARIOS.md` (+ zh-TW) — single `../../docs/AGENT_MODEL_GUIDE.md` ref had the same issue, rewritten.

## Decisions deliberately NOT taken

- **Not moving** `docs/guides/token-optimization-quickstart.md` → `.agentcortex/docs/guides/` in source. Would touch ADR-001 `applies_to:` (already covers both via glob, but cleaner to leave) and invalidate external bookmarks. Keep at source path, deploy via whitelist.
- **Not splitting** source README into framework + downstream variants. Fragments doc governance, ongoing sync cost.
- **Not adding** a sed/awk link rewriter in `deploy.sh`. The framework explicitly avoids clever build-step trickery (Plan subagent flagged encoding/quoting risk).
- **Not deploying** `CONTRIBUTING.md` / `LIFECYCLE_BENCHMARK.md`. These are framework-internal; downstream users can still click through to GitHub.

## Governance

Per the framework's "Document-first" rule, this is **doc-content correction**, not a core-logic or structural change. No Spec/ADR required. ADR-001's `applies_to:` glob (`docs/guides/token-optimization-quickstart*.md`) already covers the file's source location.

## Test plan

- [x] `validate.sh` full Python: 77 PASS / 0 WARN / 0 FAIL / 2 SKIP
- [x] Fresh downstream deploy: 183 files (was 181, +2 for token-optimization-quickstart and zh-TW)
- [x] Broken relative `.md` links in deployed README: **0** (was 6)
- [x] `token-optimization-quickstart.md` + zh-TW present at `.agentcortex/docs/guides/`
- [x] All internal cross-refs in the quickstart guide use absolute URLs (works in both source and deployed contexts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)