### PR TITLE
fix: add product backlog structure validation (#18)

### DIFF
--- a/.agentcortex/bin/validate.ps1
+++ b/.agentcortex/bin/validate.ps1
@@ -1758,7 +1758,10 @@ if (Test-Path -Path $backlogFile -PathType Leaf) {
         Add-Result -Level 'WARN' -Message "backlog structure: missing column(s): $($structMissing -join ', ')"
     }
 
-    # (3) Status enum compliance: every numbered Feature Inventory row uses a known Status value
+    # (3) Status enum compliance: every numbered Feature Inventory row uses a known Status value.
+    # The enum token is matched as an isolated `| <status> |` cell anywhere in the row rather than
+    # by fixed column index — safe because no other column holds a bare enum word as an isolated
+    # cell (Dependencies use --/#N/dates, Spec File holds paths, Feature holds prose).
     $badStatus = @()
     foreach ($brow in $backlogStructLines) {
         if ($brow -notmatch '^\|\s*[0-9]+\s*\|') { continue }

--- a/.agentcortex/bin/validate.ps1
+++ b/.agentcortex/bin/validate.ps1
@@ -1719,6 +1719,78 @@ if (Test-Path -Path $backlogFile -PathType Leaf) {
     }
 }
 
+# Backlog structure validation (#18): frontmatter fields, structural columns, Status enum, spec links.
+# Catches structural corruption that would break /spec-intake feature matching but is invisible
+# to the existence-only checks above.
+if (Test-Path -Path $backlogFile -PathType Leaf) {
+    $backlogText = Get-NormalizedContent -Path $backlogFile
+    $backlogStructLines = Get-Content -Path $backlogFile -Encoding utf8
+
+    # (1) YAML frontmatter required fields: title, created, status
+    $fmMissing = @()
+    if ($backlogText -match '(?s)^---\s*\r?\n(.*?)\r?\n---\s*\r?\n') {
+        $fm = $Matches[1]
+        if ($fm -notmatch '(?m)^title:')   { $fmMissing += 'title' }
+        if ($fm -notmatch '(?m)^created:') { $fmMissing += 'created' }
+        if ($fm -notmatch '(?m)^status:')  { $fmMissing += 'status' }
+    }
+    else {
+        $fmMissing = @('title', 'created', 'status')
+    }
+    if ($fmMissing.Count -eq 0) {
+        Add-Result -Level 'PASS' -Message 'backlog frontmatter: required fields (title, created, status) present'
+    }
+    else {
+        Add-Result -Level 'FAIL' -Message "backlog frontmatter: missing required field(s): $($fmMissing -join ', ')"
+        Write-Output '  fix: add the missing field(s) to the YAML frontmatter of _product-backlog.md'
+    }
+
+    # (2) Feature Inventory structural columns: #, Status, Tier (complements Kind/Labels/Priority above)
+    $structHeader = $backlogStructLines | Where-Object { $_ -match '\|.*Feature.*\|' } | Select-Object -First 1
+    $structMissing = @()
+    if ($structHeader -notmatch '\|\s*#\s*\|') { $structMissing += '#' }
+    if ($structHeader -notmatch 'Status')      { $structMissing += 'Status' }
+    if ($structHeader -notmatch 'Tier')        { $structMissing += 'Tier' }
+    if ($structMissing.Count -eq 0) {
+        Add-Result -Level 'PASS' -Message 'backlog structure: #/Status/Tier columns present'
+    }
+    else {
+        Add-Result -Level 'WARN' -Message "backlog structure: missing column(s): $($structMissing -join ', ')"
+    }
+
+    # (3) Status enum compliance: every numbered Feature Inventory row uses a known Status value
+    $badStatus = @()
+    foreach ($brow in $backlogStructLines) {
+        if ($brow -notmatch '^\|\s*[0-9]+\s*\|') { continue }
+        if ($brow -notmatch '\|\s*(Pending|In Progress|Shipped|Deferred|Cancelled)\s*\|') {
+            $bnum = ([regex]'^\|\s*([0-9]+)').Match($brow).Groups[1].Value
+            $badStatus += "#$bnum"
+        }
+    }
+    if ($badStatus.Count -gt 0) {
+        Add-Result -Level 'FAIL' -Message "backlog Status enum: row(s) $($badStatus -join ' ') have a Status not in {Pending, In Progress, Shipped, Deferred, Cancelled}"
+        Write-Output '  fix: correct the Status cell to a valid enum value in _product-backlog.md'
+    }
+    else {
+        Add-Result -Level 'PASS' -Message 'backlog Status enum: all Feature Inventory rows use valid Status values'
+    }
+
+    # (4) Spec link existence: referenced docs/specs/*.md files should exist on disk
+    $specRefs = [regex]::Matches($backlogText, 'docs/specs/[A-Za-z0-9._/-]+\.md') | ForEach-Object { $_.Value } | Sort-Object -Unique
+    $missingSpecs = @()
+    foreach ($sref in $specRefs) {
+        if (-not (Test-Path -Path (Join-NormalPath $root $sref) -PathType Leaf)) {
+            $missingSpecs += $sref
+        }
+    }
+    if ($missingSpecs.Count -gt 0) {
+        Add-Result -Level 'WARN' -Message "backlog spec links: referenced spec file(s) not found: $($missingSpecs -join ' ') (pending features may not have specs yet)"
+    }
+    else {
+        Add-Result -Level 'PASS' -Message 'backlog spec links: all referenced spec files exist'
+    }
+}
+
 # Routing index governance split checks
 $routingIndex = Join-NormalPath $workflowsDir 'routing.md'
 if (Test-Path -Path $routingIndex -PathType Leaf) {

--- a/.agentcortex/bin/validate.sh
+++ b/.agentcortex/bin/validate.sh
@@ -1840,6 +1840,66 @@ if [[ -f "$BACKLOG_FILE" ]]; then
   fi
 fi
 
+# Backlog structure validation (#18): frontmatter fields, structural columns, Status enum, spec links.
+# Catches structural corruption that would break /spec-intake feature matching but is invisible
+# to the existence-only checks above.
+if [[ -f "$BACKLOG_FILE" ]]; then
+  # (1) YAML frontmatter required fields: title, created, status
+  backlog_fm="$(awk 'NR==1 && /^---[[:space:]]*$/ {infm=1; next} infm && /^---[[:space:]]*$/ {exit} infm {print}' "$BACKLOG_FILE")"
+  fm_missing=()
+  printf '%s\n' "$backlog_fm" | grep -qE '^title:'   || fm_missing+=("title")
+  printf '%s\n' "$backlog_fm" | grep -qE '^created:' || fm_missing+=("created")
+  printf '%s\n' "$backlog_fm" | grep -qE '^status:'  || fm_missing+=("status")
+  if [[ ${#fm_missing[@]} -eq 0 ]]; then
+    record_result PASS "backlog frontmatter: required fields (title, created, status) present"
+  else
+    record_result FAIL "backlog frontmatter: missing required field(s): ${fm_missing[*]}"
+    echo "  fix: add the missing field(s) to the YAML frontmatter of _product-backlog.md"
+  fi
+
+  # (2) Feature Inventory structural columns: #, Status, Tier (complements Kind/Labels/Priority above)
+  backlog_hdr="$(grep -m1 '|.*Feature.*|' "$BACKLOG_FILE" 2>/dev/null || true)"
+  struct_missing=()
+  echo "$backlog_hdr" | grep -qE '\|[[:space:]]*#[[:space:]]*\|' || struct_missing+=("#")
+  echo "$backlog_hdr" | grep -q 'Status' || struct_missing+=("Status")
+  echo "$backlog_hdr" | grep -q 'Tier'   || struct_missing+=("Tier")
+  if [[ ${#struct_missing[@]} -eq 0 ]]; then
+    record_result PASS "backlog structure: #/Status/Tier columns present"
+  else
+    record_result WARN "backlog structure: missing column(s): ${struct_missing[*]}"
+  fi
+
+  # (3) Status enum compliance: every numbered Feature Inventory row uses a known Status value
+  bad_status=""
+  while IFS= read -r brow; do
+    echo "$brow" | grep -qE '^\|[[:space:]]*[0-9]+[[:space:]]*\|' || continue
+    if ! echo "$brow" | grep -qE '\|[[:space:]]*(Pending|In Progress|Shipped|Deferred|Cancelled)[[:space:]]*\|'; then
+      bnum="$(echo "$brow" | sed -E 's/^\|[[:space:]]*([0-9]+).*/\1/')"
+      bad_status="${bad_status} #${bnum}"
+    fi
+  done < "$BACKLOG_FILE"
+  if [[ -n "$bad_status" ]]; then
+    record_result FAIL "backlog Status enum: row(s)${bad_status} have a Status not in {Pending, In Progress, Shipped, Deferred, Cancelled}"
+    echo "  fix: correct the Status cell to a valid enum value in _product-backlog.md"
+  else
+    record_result PASS "backlog Status enum: all Feature Inventory rows use valid Status values"
+  fi
+
+  # (4) Spec link existence: referenced docs/specs/*.md files should exist on disk
+  missing_specs=""
+  while IFS= read -r sref; do
+    [[ -z "$sref" ]] && continue
+    if [[ ! -f "$ROOT/$sref" ]]; then
+      case " $missing_specs " in *" $sref "*) ;; *) missing_specs="${missing_specs} $sref";; esac
+    fi
+  done < <(grep -oE 'docs/specs/[A-Za-z0-9._/-]+\.md' "$BACKLOG_FILE" 2>/dev/null | sort -u)
+  if [[ -n "$missing_specs" ]]; then
+    record_result WARN "backlog spec links: referenced spec file(s) not found:${missing_specs} (pending features may not have specs yet)"
+  else
+    record_result PASS "backlog spec links: all referenced spec files exist"
+  fi
+fi
+
 # Routing index governance split checks
 ROUTING_INDEX="$WORKFLOWS_DIR/routing.md"
 if [[ -f "$ROUTING_INDEX" ]]; then

--- a/.agentcortex/bin/validate.sh
+++ b/.agentcortex/bin/validate.sh
@@ -1869,7 +1869,10 @@ if [[ -f "$BACKLOG_FILE" ]]; then
     record_result WARN "backlog structure: missing column(s): ${struct_missing[*]}"
   fi
 
-  # (3) Status enum compliance: every numbered Feature Inventory row uses a known Status value
+  # (3) Status enum compliance: every numbered Feature Inventory row uses a known Status value.
+  # The enum token is matched as an isolated `| <status> |` cell anywhere in the row rather than
+  # by fixed column index — safe because no other column holds a bare enum word as an isolated
+  # cell (Dependencies use —/#N/dates, Spec File holds paths, Feature holds prose).
   bad_status=""
   while IFS= read -r brow; do
     echo "$brow" | grep -qE '^\|[[:space:]]*[0-9]+[[:space:]]*\|' || continue

--- a/.agentcortex/tests/test_backlog_validation.py
+++ b/.agentcortex/tests/test_backlog_validation.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+from test_helpers import sanitize_deployed_ssot
+from test_ssot_completeness import (
+    has_bash_launcher,
+    init_git_repo,
+    run_deploy,
+    run_validate,
+)
+
+VALID_BACKLOG = """---
+title: Product Backlog
+created: 2026-04-12
+status: living
+---
+
+# Product Backlog
+
+## Feature Inventory
+
+| # | Feature | Kind | Labels | Priority | Spec File | Tier | Status | Dependencies |
+|---|---|---|---|---|---|---|---|---|
+| 1 | Sample feature one | framework | core | P1 | — | feature | Pending | — |
+| 2 | Sample feature two | — | — | — | — | quick-win | Shipped | — |
+
+## Status Key
+
+- Pending: not yet started
+- Shipped: feature shipped
+"""
+
+# Same as VALID_BACKLOG but row 2 uses a Status outside the allowed enum.
+INVALID_ENUM_BACKLOG = VALID_BACKLOG.replace(
+    "| 2 | Sample feature two | — | — | — | — | quick-win | Shipped | — |",
+    "| 2 | Sample feature two | — | — | — | — | quick-win | Done | — |",
+)
+
+# Same as VALID_BACKLOG but the frontmatter is missing the `created` field.
+MISSING_FRONTMATTER_BACKLOG = VALID_BACKLOG.replace("created: 2026-04-12\n", "")
+
+
+def _write_backlog(target: Path, text: str) -> None:
+    (target / "docs/specs").mkdir(parents=True, exist_ok=True)
+    (target / "docs/specs/_product-backlog.md").write_text(text, encoding="utf-8")
+
+
+def _point_ssot_to_backlog(target: Path) -> None:
+    ssot = target / ".agentcortex" / "context" / "current_state.md"
+    content = ssot.read_text(encoding="utf-8")
+    content = re.sub(
+        r"(\*\*Active Backlog\*\*:)\s*none",
+        r"\1 `docs/specs/_product-backlog.md`",
+        content,
+    )
+    ssot.write_text(content, encoding="utf-8")
+
+
+@unittest.skipUnless(has_bash_launcher(), "shell launcher unavailable for validate smoke")
+class BacklogValidationTests(unittest.TestCase):
+    def test_invalid_status_enum_fails(self) -> None:
+        """A Feature Inventory row with an unknown Status → validator must fail."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir)
+            deploy = run_deploy(target)
+            self.assertEqual(deploy.returncode, 0, deploy.stderr or deploy.stdout)
+            sanitize_deployed_ssot(target)
+            init_git_repo(target)
+
+            _write_backlog(target, INVALID_ENUM_BACKLOG)
+
+            validate = run_validate(target)
+            self.assertNotEqual(validate.returncode, 0, validate.stdout)
+            self.assertIn("backlog Status enum", validate.stdout)
+            self.assertIn("FAIL", validate.stdout)
+
+    def test_missing_frontmatter_field_fails(self) -> None:
+        """A backlog whose frontmatter omits a required field → validator must fail."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir)
+            deploy = run_deploy(target)
+            self.assertEqual(deploy.returncode, 0, deploy.stderr or deploy.stdout)
+            sanitize_deployed_ssot(target)
+            init_git_repo(target)
+
+            _write_backlog(target, MISSING_FRONTMATTER_BACKLOG)
+
+            validate = run_validate(target)
+            self.assertNotEqual(validate.returncode, 0, validate.stdout)
+            self.assertIn("backlog frontmatter", validate.stdout)
+            self.assertIn("created", validate.stdout)
+
+    def test_valid_backlog_passes(self) -> None:
+        """A well-formed backlog referenced by SSoT → new structure checks must pass."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir)
+            deploy = run_deploy(target)
+            self.assertEqual(deploy.returncode, 0, deploy.stderr or deploy.stdout)
+            sanitize_deployed_ssot(target)
+
+            _write_backlog(target, VALID_BACKLOG)
+            _point_ssot_to_backlog(target)
+            init_git_repo(target)
+
+            validate = run_validate(target)
+            self.assertEqual(validate.returncode, 0, validate.stdout)
+            self.assertIn("backlog Status enum: all Feature Inventory rows use valid Status values", validate.stdout)
+            self.assertIn("backlog frontmatter: required fields", validate.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`validate.{sh,ps1}` previously verified only that the product backlog *exists* and is referenced by the SSoT — it never checked the backlog's internal structure. Structural corruption (bad frontmatter, an invalid Status value, a dangling spec link) would silently break `/spec-intake` feature matching and pass CI.

This PR adds four additive backlog-structure checks to both validators:

1. **Frontmatter required fields** (`FAIL`) — `title`, `created`, `status` must be present.
2. **Structural columns** (`WARN`) — `#`, `Status`, `Tier` present in the Feature Inventory header (complements the existing Kind/Labels/Priority check).
3. **Status enum compliance** (`FAIL`) — every numbered Feature Inventory row uses a value in `{Pending, In Progress, Shipped, Deferred, Cancelled}`. The enum was derived from the live backlog's actual usage (the issue body's `shipped/pending/deferred` set was incomplete — rows 9 and 26 use `Cancelled`).
4. **Spec-link existence** (`WARN`) — referenced `docs/specs/*.md` files should exist (advisory, since a pending feature may not have a spec yet).

Changes are purely additive — no existing check logic was modified. A new integration test (`test_backlog_validation.py`) follows the existing deploy→validate harness and covers invalid enum, missing frontmatter, and the valid baseline.

## Evidence

`validate.sh` on the repo (all four new checks pass, suite green):
```
[PASS] backlog frontmatter: required fields (title, created, status) present
[PASS] backlog structure: #/Status/Tier columns present
[PASS] backlog Status enum: all Feature Inventory rows use valid Status values
[PASS] backlog spec links: all referenced spec files exist
Summary: pass=97 warn=6 fail=0 skip=2
Agentic OS integrity check passed
```

New test (runs against `validate.ps1` on Windows, exercising the parity path):
```
test_backlog_validation.py::BacklogValidationTests::test_invalid_status_enum_fails PASSED
test_backlog_validation.py::BacklogValidationTests::test_missing_frontmatter_field_fails PASSED
test_backlog_validation.py::BacklogValidationTests::test_valid_backlog_passes PASSED
3 passed
```

> Note: a pre-existing, unrelated `validate.ps1` work-log gate-progression FAIL was confirmed to exist on the base state (work logs are gitignored / local-only, so it is invisible to CI). It is out of scope for this PR.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)