### PR TITLE
chore: gitignore runtime hook telemetry and scheduled-task lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@
 .agentcortex/context/.guard_locks/
 .agentcortex/context/private/
 .agent/private/
+# Governance hook telemetry (sentinel / precompact violation logs)
+.agentcortex/context/*-violations.jsonl
+
+# Claude Code local state
+.claude/scheduled_tasks.lock
 
 # Deploy artifacts
 .agentcortex-src/


### PR DESCRIPTION
## Summary

Three session-local runtime artifacts were showing up as untracked in `git status` and could be committed by accident. They are generated at runtime and are not source — ignore them alongside the already-ignored work logs (`.agentcortex/context/work/*.md`).

Added to `.gitignore`:
- `.agentcortex/context/*-violations.jsonl` — sentinel / precompact governance hook telemetry logs
- `.claude/scheduled_tasks.lock` — Claude Code scheduled-task runner lock

Also removed an accidental empty (0-byte) file named `feature matches; reclassification` from the working tree — a stray shell-redirect artifact, no data, untracked, so it produces no diff here.

## Evidence

```
.agentcortex/context/precompact-violations.jsonl        -> IGNORED
.agentcortex/context/sentinel-violations.jsonl          -> IGNORED
.claude/scheduled_tasks.lock                            -> IGNORED
```

`validate.sh`:
```
Summary: pass=93 warn=6 fail=0 skip=2
Agentic OS integrity check passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)