### PR TITLE
fix: repair silently-broken work-log gate-progression check in validate.sh

### DIFF
--- a/.agentcortex/bin/validate.sh
+++ b/.agentcortex/bin/validate.sh
@@ -989,7 +989,12 @@ if [[ -d "$WORKLOG_DIR" ]]; then
       # run_python_check — silent skips here previously produced PASS by
       # accident when Python was unavailable.
       if [[ -n "$PYTHON_BIN" ]]; then
-        gate_check="$("$PYTHON_BIN" -c "
+        # Python source passed via single-quoted heredoc → variable so that
+        # shell-special characters in the code (", `, $, ->) are NOT interpreted
+        # by bash. Previously this was an inline -c "..." double-quoted string;
+        # the embedded `"` and `->` leaked to the shell (created a stray file and
+        # corrupted the -c argument), silently disabling this entire check.
+        _acx_gate_py=$(cat <<'PYEOF'
 import sys, re
 # quick-win / unknown: implement can go directly to ship (fast path)
 LEGAL_DEFAULT = {
@@ -1167,7 +1172,7 @@ if has_ship_receipt or 'ship' in gate_set:
         required = {'bootstrap','plan','implement','review','test','handoff'}
     missing_phases = required - gate_set
     if missing_phases:
-        print(f'incomplete:{\",\".join(sorted(missing_phases))} (classification:{wl_class or \"unknown\"})')
+        print(f'incomplete:{",".join(sorted(missing_phases))} (classification:{wl_class or "unknown"})')
         sys.exit(0)
 # NOT READY reverse-edge check: if review_not_ready is still set (no subsequent review
 # PASS cleared it), any test/handoff/ship in gates = re-review was skipped
@@ -1183,7 +1188,7 @@ for i in range(1, len(gates)):
     prev, curr = gates[i-1], gates[i]
     allowed = LEGAL.get(prev, [])
     if curr not in allowed:
-        print(f'illegal:{prev}->{curr} (classification:{wl_class or \"unknown\"})')
+        print(f'illegal:{prev}->{curr} (classification:{wl_class or "unknown"})')
         sys.exit(0)
 # M10: stale-review check — if most recent implement follows most recent review,
 # then test/handoff/ship without a new review = stale review violation
@@ -1200,7 +1205,9 @@ if wl_class not in ('quick-win', 'tiny-fix'):
             print(f'illegal:implement-after-review->{bad_next} (stale review: implement occurred after last review PASS; re-review required)')
             sys.exit(0)
 print('ok')
-" <<< "$wl_content" 2>/dev/null)"
+PYEOF
+)
+        gate_check="$("$PYTHON_BIN" -c "$_acx_gate_py" <<< "$wl_content" 2>/dev/null)"
         if [[ "$gate_check" == illegal:* ]]; then
           printf '  illegal gate progression in %s: %s\n' "$(basename "$wl")" "${gate_check#illegal:}"
           gate_progression_illegal=$((gate_progression_illegal + 1))


### PR DESCRIPTION
## Summary

`validate.sh`'s work-log **gate-progression / completeness integrity check was a silent no-op** on the bash (Linux/CI) path. This is the root cause of the stray file named `feature matches; reclassification` that kept reappearing in `git status`.

### Root cause

The check passed its ~210-line Python via an inline `python -c "..."` **double-quoted bash string** (validate.sh:992). The Python source contains characters that are special inside a bash double-quote:

- A comment line had an unescaped `"` and `->`. Bash exited the quote, parsed `quick-win -> feature" matches; "reclassification` and treated the `>` as a **redirect**, creating an empty file literally named `feature matches; reclassification` on every run.
- The same break corrupted the `-c` argument, so Python raised a `SyntaxError`.
- The call ended in `2>/dev/null`, so the error was swallowed and `gate_check` was **always empty** → no illegal/incomplete progression was ever reported.

`validate.ps1` was unaffected, which is exactly why the two validators disagreed on identical work logs (`validate.sh` `fail=0` vs `validate.ps1` `fail=1`).

### Fix

Pass the Python source via a **single-quoted heredoc into a variable**, then `python -c "$_acx_gate_py"`. The body is now opaque to bash — no metacharacter leaks. Also un-escaped the two `\"` f-string quotes that were only needed for the old double-quoted context. Python logic is otherwise untouched.

## Evidence

Before — `validate.sh` misses an illegal work log that `validate.ps1` catches:
```
sh:  (nothing reported about gate progression)
ps1: illegal gate progression ... plan->ship  +  incomplete gate receipts ...
```

After — `validate.sh` now matches `validate.ps1` and creates no stray file:
```
incomplete gate receipts in <log>: missing bootstrap,implement,review,test (classification:...)
[FAIL] work logs with illegal gate phase progression: N
no junk file created
```

- `bash -n validate.sh` → OK
- Deploy+validate test suite passes, including `test_ssot_completeness::test_clean_state_passes` (clean state exits 0).
- The 25 other suite failures are pre-existing (identical with this change stashed; they live in trigger-registry / skill-activation / token-budget / metadata tests, unrelated to this block).

## Follow-up (not in this PR)

The `wl_class`, stale-lock, and archive broken-link blocks (validate.sh:1246/1439/1567) use the same fragile inline `-c "..."` pattern. They work today only because their Python contains no shell-special chars. Hardening them to the heredoc pattern would prevent a future regression of this class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)