### PR TITLE
fix: harden remaining inline python -c blocks in validate.sh

### DIFF
--- a/.agentcortex/bin/validate.sh
+++ b/.agentcortex/bin/validate.sh
@@ -1243,13 +1243,16 @@ print('ok')
     # to auditable evidence requirement.
     # Parse classification from list form ("- Classification:") or table form ("| Classification |")
     if [[ -n "$PYTHON_BIN" ]]; then
-      wl_class="$(printf '%s' "$wl_content" | "$PYTHON_BIN" -c "
+      # Python via single-quoted heredoc -> variable (verbatim; no bash metachar parsing)
+      _acx_wlclass_py=$(cat <<'PYEOF'
 import re,sys
 for l in sys.stdin:
     m=re.match(r'^-\s+\*{0,2}[Cc]lassification\*{0,2}\s*:\s*\x60?([a-zA-Z][\w-]*)',l)
     if not m: m=re.match(r'^\|\s*\*{0,2}[Cc]lassification\*{0,2}\s*\|\s*\x60?([a-zA-Z][\w-]*)',l)
     if m: print(m.group(1).lower()); break
-" 2>/dev/null)"
+PYEOF
+)
+      wl_class="$(printf '%s' "$wl_content" | "$PYTHON_BIN" -c "$_acx_wlclass_py" 2>/dev/null)"
     else
       # Python unavailable: list-form-only fallback
       wl_class="$(printf '%s' "$wl_content" | sed -n 's/^- \(**\)\?Classification\1\?:[[:space:]]*//p' | head -n 1 | tr -d '\r\`')"
@@ -1436,7 +1439,8 @@ for l in sys.stdin:
     [[ -f "$lockf" ]] || continue
     lock_files_present=1
     if [[ -n "$PYTHON_BIN" ]]; then
-      stale_verdict="$("$PYTHON_BIN" -c "
+      # Python via single-quoted heredoc -> variable (verbatim; no bash metachar parsing)
+      _acx_stale_py=$(cat <<'PYEOF'
 import json, sys, datetime
 try:
     with open(sys.argv[1]) as f:
@@ -1452,7 +1456,9 @@ try:
     print('stale' if age_min > tm else 'fresh')
 except Exception:
     print('unreadable')
-" "$lockf" 2>/dev/null)"
+PYEOF
+)
+      stale_verdict="$("$PYTHON_BIN" -c "$_acx_stale_py" "$lockf" 2>/dev/null)"
       case "$stale_verdict" in
         stale)
           printf '  stale advisory lock: %s\n' "$(basename "$lockf")"
@@ -1564,7 +1570,8 @@ elif [[ -n "$PYTHON_BIN" ]] && [[ -d "$ARCHIVE_DIR" ]]; then
   archive_broken_links=0
   archive_broken_link_list=""
   while IFS= read -r -d '' arch_file; do
-    broken_output="$("$PYTHON_BIN" -c "
+    # Python via single-quoted heredoc -> variable (verbatim; no bash metachar parsing)
+    _acx_brokenlink_py=$(cat <<'PYEOF'
 import re, sys
 from pathlib import Path
 f = Path(sys.argv[1])
@@ -1591,7 +1598,9 @@ for m in link_re.finditer(text):
         count += 1
 # Print count as last line so caller reads from stdout (exit-code wraps at 256)
 print(count)
-" "$arch_file" 2>/dev/null)"
+PYEOF
+)
+    broken_output="$("$PYTHON_BIN" -c "$_acx_brokenlink_py" "$arch_file" 2>/dev/null)"
     file_count=$(printf '%s\n' "$broken_output" | tail -1)
     file_count=${file_count:-0}
     if [[ "$file_count" =~ ^[0-9]+$ ]] && [[ "$file_count" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Follow-up to #110. Three checks in `validate.sh` still passed their Python via an inline `python -c "..."` **double-quoted bash string**:

- work-log classification extractor (`wl_class=`, ~L1246)
- advisory-lock staleness check (`stale_verdict=`, ~L1439)
- archived-markdown broken-link check (`broken_output=`, ~L1567)

They work **today** only because their Python happens to contain no characters special to a bash double-quote (`"`, backtick, `$`, `->`). #110 showed how nasty this pattern is: the gate-progression block had exactly one such character and was a **silent no-op** for an unknown amount of time. This PR removes the latent footgun before it bites.

## Change

Each block is converted to the single-quoted heredoc → variable pattern:

```bash
_acx_*_py=$(cat <<'PYEOF'
<python verbatim>
PYEOF
)
... "$PYTHON_BIN" -c "$_acx_*_py" ...
```

The single-quoted `PYEOF` delimiter means bash performs **no** expansion on the body, so the Python is passed verbatim regardless of its contents. Python bodies are byte-for-byte unchanged; stdin (block 1) and `argv[1]` (blocks 2 & 3) feeding is preserved. No escapes needed changing — all three used only `\<non-special>` escapes (`\s`, `\x60`, `\[`…) that already behave identically in both contexts. `validate.ps1` is unaffected and untouched.

## Evidence

`bash -n validate.sh` → OK.

Each block verified standalone:
```
Block 2 (wl_class):   "- Classification: feature"      -> feature
                      "| Classification | quick-win |" -> quick-win
Block 3 (stale lock): stale-fixture -> stale ; fresh-fixture -> fresh
Block 4 (links):      [bad](./does-not-exist.md) -> reported + count 1 ; clean -> 0
```

Full validate.sh runs clean (`pass=93 warn=6 fail=0 skip=2`). Test suite: **25 failed, 155 passed** — identical to the pre-existing baseline (same trigger-registry / skill-activation / token-budget / metadata failures, present on `main` and unrelated to this block). The deploy+validate tests, including `test_ssot_completeness`, pass.

> Note: this branch is cut from `main`, so it does not include #110's block-1 fix; the `feature matches; reclassification` stray file is still produced here by the unfixed block 1 and is resolved by #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)