### PR TITLE
chore(release): v1.2.0 — version bump + README/docs/CHANGELOG refresh

### DIFF
--- a/.agentcortex/bin/deploy.sh
+++ b/.agentcortex/bin/deploy.sh
@@ -26,7 +26,7 @@ TARGET="${TARGET:-.}"
 TARGET="${TARGET%/}"
 
 MANIFEST_FILE="$TARGET/.agentcortex-manifest"
-ACX_VERSION="1.1.2"
+ACX_VERSION="1.2.0"
 
 # --- Self-deploy guard ---
 TARGET_ABS="$(cd "$TARGET" 2>/dev/null && pwd || echo "$TARGET")"

--- a/.agentcortex/docs/TESTING_PROTOCOL.md
+++ b/.agentcortex/docs/TESTING_PROTOCOL.md
@@ -1,4 +1,4 @@
-# Testing Protocol v1.1.2
+# Testing Protocol v1.2.0
 
 > **This document guides the AI Agent to produce high-quality, trustworthy, and defensive test code.**
 

--- a/.agentcortex/docs/TESTING_PROTOCOL_zh-TW.md
+++ b/.agentcortex/docs/TESTING_PROTOCOL_zh-TW.md
@@ -1,4 +1,4 @@
-# Testing Protocol (測試教戰守則) v1.1.2
+# Testing Protocol (測試教戰守則) v1.2.0
 >
 > **本文件旨在指引 AI Agent 產出高品質、可信任、且具備防禦性的測試程式碼。**
 

--- a/.agentcortex/docs/guides/antigravity-v5-runtime.md
+++ b/.agentcortex/docs/guides/antigravity-v5-runtime.md
@@ -2,7 +2,7 @@
 
 ## Antigravity Hard-Path Enforcement Overlay
 
-Version: v1.1.2
+Version: v1.2.0
 Date: 2026-04-17
 Scope: **Antigravity environments** (token-generation agents where shell exit codes don’t halt execution)
 

--- a/.agentcortex/docs/guides/migration.md
+++ b/.agentcortex/docs/guides/migration.md
@@ -25,7 +25,7 @@ Instruct the AI to perform a migration scan:
 
 ```text
 Please run /bootstrap.
-We've just upgraded to Agentic OS v1.1.2.
+We've just upgraded to Agentic OS v1.2.0.
 Please scan the project for existing documentation and perform the following:
 1. Identify scattered notes, specs, and ADRs; move them to correct directories and rename.
 2. Initialize .agentcortex/context/current_state.md.

--- a/.agentcortex/docs/guides/migration_zh-TW.md
+++ b/.agentcortex/docs/guides/migration_zh-TW.md
@@ -25,7 +25,7 @@
 
 ```text
 請執行 /bootstrap。
-我們剛升級到 Agentic OS v1.1.2。
+我們剛升級到 Agentic OS v1.2.0。
 請掃描專案中的既有文件，並自動完成以下工作：
 1. 識別散亂的筆記、規格、ADR，移動到正確目錄並重新命名
 2. 初始化 .agentcortex/context/current_state.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 
-## [Unreleased] - 2026-05-18
+## [1.2.0] - 2026-05-31
+
+Consolidated release covering PRs #98–#122 since v1.1.2. Highlights:
+
+**Governance model**
+- **Handoff-trigger overhaul (#121)**: replaced the turn-count handoff trigger with a **context-occupancy + phase-boundary** advisory model, converged four scattered/contradictory turn constants into one SSoT (`AGENTS.md §Context Pruning`), and added a cross-platform caching/compaction reference (`token-governance.md §6.1`) for Claude / OpenAI Codex / Google Gemini. Stays advisory — no enforced gate added.
+- **Doc-consistency cleanup (#122)**: unified the tiny-fix threshold (`< 5 lines` → canonical `< 3 files, no semantic change`), unified the runtime sentinel (`[ACX-READ-OK]` → `⚡ ACX`), genericized stale exact model-version strings to drift-proof tier descriptors (EN + zh-TW + bug-report template), and aligned `ai-development-pitfalls.md` with the occupancy model + platform-neutral wording.
+
+**Security & integrity**
+- **CI security scanning (#20)**: Semgrep SAST + TruffleHog secret detection + pip-audit dependency audit, all tools pinned.
+- **Audit-chain tamper-evidence hardening (#117, ADR-003)**: git append-only witness for tail-truncation detection + `migrate` fail-closed against re-blessing forged history.
+- **Framework self-test integrity (#116)**: restored `tests/guard` collection and gated 82 governance-tool tests in CI.
+
+**Tooling & reliability**
+- validate.sh / validate.ps1: gate-injection hardening (#104), gate-progression repair (#110), inline-python hardening (#111), PS1↔SH parity backfill (#119), `--list-checks`, SSoT atomic writes, gate-receipt schema (#114).
+- Downstream/install: cross-session path alignment for zero-Python downstream (#106), scaffold-tier sidecar preservation (#101), framework-ADR filename matching (#100), Windows `.cmd` install/update repair (#120).
+
+**Docs**
+- README/cross-doc links work in both GitHub and deployed contexts (#103); version banners + skill count (17→14) corrected (#102); framework-internal refs removed from downstream guidance (#99).
 
 ### Adversarial Governance Audit + Downstream UX Hardening (PR #104)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/Agentic OS-v1.1.2-blueviolet?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJ3aGl0ZSI+PHBhdGggZD0iTTEyIDJDNi40OCAyIDIgNi40OCAyIDEyczQuNDggMTAgMTAgMTAgMTAtNC40OCAxMC0xMFMxNy41MiAyIDEyIDJ6bTAgMThjLTQuNDEgMC04LTMuNTktOC04czMuNTktOCA4LTggOCAzLjU5IDggOC0zLjU5IDgtOCA4eiIvPjwvc3ZnPg==" alt="Agentic OS v1.1.2"/>
+  <img src="https://img.shields.io/badge/Agentic OS-v1.2.0-blueviolet?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJ3aGl0ZSI+PHBhdGggZD0iTTEyIDJDNi40OCAyIDIgNi40OCAyIDEyczQuNDggMTAgMTAgMTAgMTAtNC40OCAxMC0xMFMxNy41MiAyIDEyIDJ6bTAgMThjLTQuNDEgMC04LTMuNTktOC04czMuNTktOCA4LTggOCAzLjU5IDggOC0zLjU5IDgtOCA4eiIvPjwvc3ZnPg==" alt="Agentic OS v1.2.0"/>
 </p>
 
 <h1 align="center">Agentic OS</h1>

--- a/docs/AGENT_MODEL_GUIDE.md
+++ b/docs/AGENT_MODEL_GUIDE.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.1.2 — Model Selection Guide
+# Agentic OS v1.2.0 — Model Selection Guide
 
 > For human reference only — this file is not loaded into AI context.
 

--- a/docs/AGENT_MODEL_GUIDE_zh-TW.md
+++ b/docs/AGENT_MODEL_GUIDE_zh-TW.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.1.2 — 模型選擇指南
+# Agentic OS v1.2.0 — 模型選擇指南
 
 > 人類參考用 — 此檔案不會被載入 AI context。
 

--- a/docs/README_zh-TW.md
+++ b/docs/README_zh-TW.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.1.2 (Runtime v1.1 Anti-Drift Edition)
+# Agentic OS v1.2.0 (Runtime v1.1 Anti-Drift Edition)
 
 [English Version](../README.md)
 


### PR DESCRIPTION
## Summary
Cuts **v1.2.0** and brings all version strings + doc claims into line with the implementation. Doc/version-only change (quick-win); `validate.sh` fail=0, compact index fresh.

## Version bump (1.1.2 → 1.2.0)
`deploy.sh` `ACX_VERSION`, README badge, zh-TW README, `AGENT_MODEL_GUIDE` (EN+zh), `antigravity-v5-runtime`, `TESTING_PROTOCOL` (EN+zh), migration guides (EN+zh).

## Claims ↔ implementation alignment
- **CITATION.cff**: `version 1.1.0 → 1.2.0` (was stale, out of sync with everything else); `date-released` → 2026-05-31; abstract **17 → 14 skills** (matches actual `.agents/skills/*/SKILL.md` count).
- **README counts verified accurate**: 14 professional skills (14 SKILL.md), 33 workflows (33 `.agent/workflows/*.md`).
- **CHANGELOG.md**: added a consolidated `[1.2.0]` section covering PRs #98–#122 (handoff-trigger occupancy model, doc-consistency cleanup, CI security scanning, audit-chain tamper-evidence, validator hardening, downstream/install fixes) — the changelog previously stopped at an `[Unreleased]` block for #104.

## Why minor (SemVer)
Backward-compatible new capabilities since 1.1.2 (security scanning, tamper-evidence, occupancy handoff model, cross-platform doc consistency).

## Evidence
- `validate.sh` = `pass=91 warn=14 fail=0 skip=2` / integrity check passed.
- `generate_compact_index.py --check` = fresh (rc=0).
- Branched off main (post #121+#122 merge); not stacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
