### PR TITLE
fix(citation): CITATION.cff v1.2.0 + skill count 17→14

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,10 +4,10 @@ authors:
   - family-names: Wen
     given-names: Kb
 title: "Agentic OS: Governance-First OS for AI Coding Agents"
-version: 1.1.0
-date-released: 2026-04-16
+version: 1.2.0
+date-released: 2026-05-31
 url: "https://github.com/KbWen/agentic-os"
-abstract: "A governance-first framework for AI coding agents. Structured workflows, delivery gates, engineering guardrails, and 17 professional skills for Claude Code, Cursor, Copilot, Antigravity, and Codex."
+abstract: "A governance-first framework for AI coding agents. Structured workflows, delivery gates, engineering guardrails, and 14 professional skills for Claude Code, Cursor, Copilot, Antigravity, and Codex."
 keywords:
   - ai-agent
   - agent-framework


### PR DESCRIPTION
## Summary
Follow-up to the v1.2.0 release (#123), which missed `CITATION.cff`:
- `version: 1.1.0` → `1.2.0` (was stale even pre-release, out of sync with every other version string)
- `date-released` → 2026-05-31
- abstract: **17 → 14** professional skills (matches actual `.agents/skills/*/SKILL.md` count)

Metadata-only; no code/behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
