### PR TITLE
docs: fix README arch tree + refresh stale test-suite info

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,6 @@ your-project/
 │   ├── docs/                    # Philosophy, platform guides, examples
 │   ├── metadata/                # Skill registry & cache index
 │   ├── templates/               # Reusable ADR/spec/README templates
-│   ├── tests/                   # Framework validation tests
 │   └── tools/                   # Runtime tools (Python)
 │
 ├── docs/                        # Project-level documentation
@@ -408,7 +407,7 @@ Agentic OS is built on [10 non-negotiable principles](.agentcortex/docs/AGENT_PH
 | [Token Governance](.agentcortex/docs/guides/token-governance.md) | Token optimization strategies |
 | [Token Optimization Quickstart](https://github.com/KbWen/agentic-os/blob/main/docs/guides/token-optimization-quickstart.md) | Reduce token costs immediately ([繁體中文](https://github.com/KbWen/agentic-os/blob/main/docs/guides/token-optimization-quickstart_zh-TW.md)) |
 | [Context Budget](.agentcortex/docs/guides/context-budget.md) | Context window management |
-| [Migration Guide](.agentcortex/docs/guides/migration.md) | Upgrade to v1.1+ |
+| [Migration Guide](.agentcortex/docs/guides/migration.md) | Upgrade an existing install |
 | [Codex Platform Guide](.agentcortex/docs/CODEX_PLATFORM_GUIDE.md) | Codex Web/App adaptation |
 | [Claude Platform Guide](.agentcortex/docs/CLAUDE_PLATFORM_GUIDE.md) | Claude Code integration |
 | [Nonlinear Scenarios](.agentcortex/docs/NONLINEAR_SCENARIOS.md) | Recovery from interrupted sessions |


### PR DESCRIPTION
## Summary
Corrects two diagram/test-info accuracy issues the user flagged.

### 1. README architecture tree — wrong tests location
The tree (labeled `your-project/`, i.e. the **deployed** layout) listed `.agentcortex/tests/` — but:
- that directory **does not exist**, and
- the framework's validation tests live at **repo-root `tests/`** (`tests/ci/` + `tests/guard/`), which are **dev-only and not deployed** into downstream projects.

So the entry was doubly wrong. Removed it from the deployed-layout tree.

### 2. LIFECYCLE_BENCHMARK.md (+zh-TW) — stale test info
Header + category table claimed **"v1.1 | 170 passed / 178 total"** with a breakdown that no longer maps to the suite. Refreshed to the **verified current state**:
- **126 passing** via `python -m pytest tests/ci/ tests/guard/` (the exact CI command)
- accurate per-file category table (ci = 32, guard = 94)
- framework version v1.1 → **v1.2.0**
- token figures kept as the dated **illustrative** measurements they are (2026-04-12), now clearly labeled as not re-run per release

### 3. Minor
README "Upgrade to v1.1+" → "Upgrade an existing install".

## Evidence
- `python -m pytest tests/ci/ tests/guard/` = **126 passed**
- `validate.sh` = `fail=0`
- No stale `170/178` strings remain; README bogus tests line removed; mermaid diagram untouched + intact.

Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
