### PR TITLE
docs: clarify Windows Git Bash requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ powershell -ExecutionPolicy Bypass -File .\agentic-os\installers\deploy_brain.ps
 ```
 
 Use the PowerShell entrypoint when possible. It resolves Git Bash directly and does not require a WSL distro.
+Git Bash is still required on Windows for shell-based deploy and validation scripts; the PowerShell entrypoint simply locates and invokes it for you.
 
 ```powershell
 # Already installed? Run from your project root to update:


### PR DESCRIPTION
## Summary
- clarify that Git Bash is still required for shell-based deploy and validation scripts on Windows
- note that the PowerShell entrypoint locates and invokes Git Bash automatically

## Verification
- PASS: git diff --check -- README.md
- ATTEMPTED: bash .agentcortex/bin/validate.sh --no-python (blocked by local WSL/Git Bash startup issue)
- ATTEMPTED: powershell -ExecutionPolicy Bypass -File .\.agentcortex\bin\validate.ps1 -NoPython (repo validation ran; existing INDEX.jsonl append-only witness failure remains unrelated to README change)