### PR TITLE
docs: add documentation navigation map

### DIFF
--- a/.agentcortex/docs/CODEX_PLATFORM_GUIDE.md
+++ b/.agentcortex/docs/CODEX_PLATFORM_GUIDE.md
@@ -35,6 +35,18 @@ Use the canonical state machine:
 3. Run `/review` and `/test` after every implementation.
 4. Run `./.agentcortex/bin/validate.sh` before submission.
 
+## GitHub Contributor Attribution
+
+GitHub repository `Contributors` are derived from commit attribution on the default branch, not from repository collaborator invitations. If a project wants Codex-authored work to appear as `codex` in the Contributors panel, keep at least one merged commit authored or co-authored with the GitHub-linked no-reply address for the `codex` account.
+
+Recommended author identity for Codex App/Web-authored commits:
+
+```text
+Codex <267193182+codex@users.noreply.github.com>
+```
+
+When merging a Codex-authored PR, prefer a merge or rebase merge that preserves individual commit authors. If using squash merge, preserve a `Co-authored-by: Codex <267193182+codex@users.noreply.github.com>` trailer in the final squash commit.
+
 ## Handoff Hard Gate (Non-tiny-fix)
 
 Before `/ship`, you must have a `/handoff`. Minimum reference requirements:

--- a/.agentcortex/docs/CODEX_PLATFORM_GUIDE_zh-TW.md
+++ b/.agentcortex/docs/CODEX_PLATFORM_GUIDE_zh-TW.md
@@ -35,6 +35,18 @@
 3. 每次實作後跑 `/review` 與 `/test`。
 4. 提交前跑 `./.agentcortex/bin/validate.sh`。
 
+## GitHub Contributors 歸屬
+
+GitHub repo 右側的 `Contributors` 來自預設分支上的 commit attribution，不是 repository collaborator invitation。若專案希望 Codex 執行的工作在 Contributors 面板顯示為 `codex`，至少要有一個合併到預設分支的 commit 使用 GitHub `codex` 帳號可識別的作者或共同作者 email。
+
+Codex App/Web authored commit 建議使用：
+
+```text
+Codex <267193182+codex@users.noreply.github.com>
+```
+
+合併 Codex-authored PR 時，優先使用會保留 individual commit authors 的 merge 或 rebase merge。若使用 squash merge，請在最終 squash commit 保留 `Co-authored-by: Codex <267193182+codex@users.noreply.github.com>` trailer。
+
 ## Handoff Hard Gate（非 tiny-fix）
 
 在 `/ship` 之前，必須先有 `/handoff`，且 References 最低要求：

--- a/README.md
+++ b/README.md
@@ -398,6 +398,17 @@ Agentic OS is built on [10 non-negotiable principles](.agentcortex/docs/AGENT_PH
 
 ## Documentation
 
+Start with the document that matches what you are trying to do:
+
+| Goal | Start Here | Why |
+|:---|:---|:---|
+| Install or upgrade Agentic OS | [Quick Start](#quick-start), [Migration Guide](.agentcortex/docs/guides/migration.md) | Deployment commands, update flow, and existing-project guidance |
+| Choose the right AI model | [Model Selection Guide](docs/AGENT_MODEL_GUIDE.md), [Lifecycle Benchmark](docs/LIFECYCLE_BENCHMARK.md) | Practical model tradeoffs and measured token costs |
+| Run disciplined agent workflows | [Agent Philosophy](.agentcortex/docs/AGENT_PHILOSOPHY.md), [Testing Protocol](.agentcortex/docs/TESTING_PROTOCOL.md) | Core rules, evidence expectations, and verification standards |
+| Use a specific platform | [Codex Platform Guide](.agentcortex/docs/CODEX_PLATFORM_GUIDE.md), [Claude Platform Guide](.agentcortex/docs/CLAUDE_PLATFORM_GUIDE.md) | Platform-specific loading, handoff, and compatibility notes |
+| Understand governance internals | [Document Governance](.agentcortex/docs/guides/doc-governance.md), [Nonlinear Scenarios](.agentcortex/docs/NONLINEAR_SCENARIOS.md) | State, handoff, recovery, and documentation lifecycle rules |
+| Extend skills safely | [Skill Ecosystem](docs/architecture/skill-ecosystem.md), [Token Governance](.agentcortex/docs/guides/token-governance.md) | Skill packaging, trigger policy, and context budget control |
+
 | Document | Description |
 |:---|:---|
 | [Agent Philosophy](.agentcortex/docs/AGENT_PHILOSOPHY.md) | 10 core principles |

--- a/docs/README_zh-TW.md
+++ b/docs/README_zh-TW.md
@@ -250,6 +250,17 @@ flowchart LR
 - 先用 `/plan` 收斂檔案範圍，再進入 `/implement`，降低來回修正。
 - 小型任務沿用 Fast Lane；若變更開始影響狀態/策略，立即升級流程，避免返工。
 
+## 🗺️ 文件導覽
+
+| 目標 | 先讀這裡 | 用途 |
+|:---|:---|:---|
+| 安裝或升級 Agentic OS | [快速開始](#-快速開始)、[遷移與整合指南](../.agentcortex/docs/guides/migration_zh-TW.md) | 部署指令、更新流程、既有專案導入 |
+| 選擇合適模型 | [模型選擇指南](AGENT_MODEL_GUIDE_zh-TW.md)、[生命週期基準測試](LIFECYCLE_BENCHMARK_zh-TW.md) | 模型取捨與實測 token 成本 |
+| 跑穩定的 agent 工作流 | [設計哲學](../.agentcortex/docs/AGENT_PHILOSOPHY_zh-TW.md)、[測試協議](../.agentcortex/docs/TESTING_PROTOCOL_zh-TW.md) | 核心規則、證據要求、驗證標準 |
+| 使用特定平台 | [Codex 平台指南](../.agentcortex/docs/CODEX_PLATFORM_GUIDE_zh-TW.md)、[Antigravity v5 Runtime](../.agentcortex/docs/guides/antigravity-v5-runtime.md) | 平台載入、交接、相容性注意事項 |
+| 理解治理內部機制 | [文件治理](../.agentcortex/docs/guides/doc-governance.md)、[非線性情境](../.agentcortex/docs/NONLINEAR_SCENARIOS_zh-TW.md) | 狀態、交接、復原與文件生命週期 |
+| 安全擴充技能 | [Skill Ecosystem](architecture/skill-ecosystem.md)、[Token 治理指南](../.agentcortex/docs/guides/token-governance_zh-TW.md) | skill 封裝、觸發策略、context 預算控制 |
+
 ## ✅ 自我驗證
 
 ```bash


### PR DESCRIPTION
## Summary
- add a goal-oriented documentation map to the English README
- add the matching Traditional Chinese document navigation table
- document how Codex-authored commits can be attributed to GitHub user \codex\ for Contributors visibility

## Contributor attribution
- PR includes commit \415eb21\ authored as \Codex <267193182+codex@users.noreply.github.com>\
- GitHub resolves that commit author to login \codex\
- To make \codex\ appear in the repository Contributors panel, merge this PR with merge commit or rebase merge so the Codex-authored commit reaches \main\. If squash merging, preserve \Co-authored-by: Codex <267193182+codex@users.noreply.github.com>\ in the squash commit.

## Verification
- PASS: git diff --check -- README.md docs/README_zh-TW.md
- PASS: manual link target check for newly added local documentation links
- PASS: git diff --check HEAD~1..HEAD
- PASS: GitHub PR commit metadata resolves \415eb21\ author to \login: codex\
- ATTEMPTED: powershell -ExecutionPolicy Bypass -File .\\.agentcortex\\bin\\validate.ps1 -NoPython (local repo validation ran; local working tree still reports an unrelated INDEX.jsonl append-only witness failure)