### PR TITLE
docs: refine root document descriptions

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,11 +3,11 @@ message: "If you use this software, please cite it as below."
 authors:
   - family-names: Wen
     given-names: Kb
-title: "Agentic OS: Governance-First OS for AI Coding Agents"
+title: "Agentic OS: Governance-First Workflows for AI Coding Agents"
 version: 1.2.0
 date-released: 2026-05-31
 url: "https://github.com/KbWen/agentic-os"
-abstract: "A governance-first framework for AI coding agents. Structured workflows, delivery gates, engineering guardrails, and 14 professional skills for Claude Code, Cursor, Copilot, Antigravity, and Codex."
+abstract: "A governance-first framework for AI coding agents. Portable workflows, delivery gates, engineering guardrails, and 14 professional skills for Claude Code, OpenAI Codex, Google Antigravity, Cursor, GitHub Copilot, and other coding agents."
 keywords:
   - ai-agent
   - agent-framework

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## Our Pledge
 
-We are committed to providing a friendly, safe, and welcoming environment for all contributors — whether biological or silicon-based.
+We are committed to providing a friendly, safe, and welcoming environment for human contributors and AI-assisted workflows.
 
 ## Our Standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Agentic OS
 
-Thank you for your interest in **Agentic OS**! This project is designed as an "Agentic-First" ecosystem. Whether you are a human developer or an AI Agent, please follow these guidelines to maintain project integrity and token efficiency.
+Thank you for your interest in **Agentic OS**. This repository is designed for human maintainers working alongside AI coding agents. These guidelines keep changes reviewable, evidence-backed, and consistent across supported agent platforms.
 
 ## 🤖 For AI Agents & Subagents
 
@@ -18,6 +18,16 @@ If you are an AI assisting in this repository:
 2. **Feature Branches**: Use descriptive `codex/<task-name>` branch names for framework work in this repo.
 3. **PR Standards**: Every Pull Request should include a clear "Problem/Solution" summary and verification evidence.
 4. **Language**: All internal documentation, rules, and commit messages must be in **English** for maximum cross-model compatibility.
+
+## 📚 Root Document Roles
+
+| File | Role |
+|:---|:---|
+| `README.md` | Public overview, install path, platform compatibility, and documentation map |
+| `CONTRIBUTING.md` | Contributor workflow, validation expectations, and PR standards |
+| `SECURITY.md` | Vulnerability reporting scope, private disclosure path, and support policy |
+| `CODE_OF_CONDUCT.md` | Conduct expectations for human contributors and AI-assisted workflows |
+| `CITATION.cff` | Citation metadata for papers, talks, and downstream references |
 
 ## 🔧 Local Development
 
@@ -86,7 +96,7 @@ Quick reference:
 
 ## ⚖️ Code of Conduct
 
-We are committed to providing a friendly, safe, and welcoming environment for all contributors, regardless of whether they are biological or silicon-based.
+We are committed to a respectful environment for human contributors and AI-assisted workflows. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
 ---
 *Questions? Open an issue or refer to [README.md](README.md).*

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 <p align="center">
   <strong>The governance-first operating system for AI coding agents.</strong><br/>
-  Structured workflows, delivery gates, engineering guardrails, and 14 professional skills<br/>
-  that work across Claude Code, Cursor, GitHub Copilot, Google Antigravity, and Codex.
+  Portable workflows, delivery gates, engineering guardrails, and 14 professional skills<br/>
+  for Claude Code, OpenAI Codex, Google Antigravity, Cursor, GitHub Copilot, and other coding agents.
 </p>
 
 <p align="center">
@@ -30,7 +30,7 @@
 
 ## The Problem
 
-AI coding agents are powerful but undisciplined. Without structure, they:
+AI coding agents are powerful, but they need shared operating rules. Without structure, they can:
 
 - **Skip steps** — jump straight to code without planning or reviewing
 - **Hallucinate completion** — claim "done" without verifiable evidence
@@ -40,7 +40,7 @@ AI coding agents are powerful but undisciplined. Without structure, they:
 
 ## The Solution
 
-**Agentic OS** is a drop-in governance framework that makes any AI agent follow professional engineering workflows. Install it into your project, and your AI agents gain:
+**Agentic OS** is a portable governance framework that gives AI agents a repeatable engineering workflow. Install it into your project, and your AI agents gain:
 
 ```
    Intent          Gate           Workflow         Evidence        Ship
@@ -368,12 +368,12 @@ your-project/
 
 | Platform | Status | Integration |
 |:---|:---|:---|
-| **Claude Code** | Full support | `CLAUDE.md` auto-loads governance |
-| **Google Antigravity** | Full support | Intent router + Antigravity runtime |
-| **OpenAI Codex** | Full support | Platform guide + CLI delegation |
-| **Cursor** | Compatible | Reads `AGENTS.md` as project rules |
-| **GitHub Copilot** | Compatible | Follows guardrails via `AGENTS.md` |
-| **Any LLM Agent** | Compatible | Model-agnostic governance language |
+| **Claude Code** | Native support | `CLAUDE.md` entrypoint + Claude platform guide |
+| **OpenAI Codex** | Native support | `AGENTS.md`, Codex platform guide, and CLI delegation workflow |
+| **Google Antigravity** | Native support | Intent router + Antigravity runtime guidance |
+| **Cursor** | Compatible | Uses `AGENTS.md` / project-rule style guidance |
+| **GitHub Copilot** | Compatible | Uses repository instructions and guardrail docs |
+| **Any LLM Agent** | Compatible | Model-agnostic Markdown workflows and evidence rules |
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ If you discover a security vulnerability in Agentic OS, **please do not open a p
 
 Instead, report it privately:
 
-1. **Email**: Send details to the maintainer via GitHub's private vulnerability reporting (Settings > Security > Advisories > New draft advisory)
+1. **Private advisory**: Use GitHub's private vulnerability reporting flow (Settings > Security > Advisories > New draft advisory).
 2. **Include**: Description of the vulnerability, steps to reproduce, affected files/workflows, and potential impact
 
 ## Response Timeline
@@ -34,5 +34,5 @@ Security issues in Agentic OS may include:
 
 | Version | Supported |
 |---------|-----------|
-| 1.0.x   | Yes       |
-| < 1.0   | No        |
+| 1.2.x   | Yes       |
+| < 1.2   | No        |


### PR DESCRIPTION
## Summary
- refine README intro and platform compatibility wording for clearer platform claims
- add root document role guidance to CONTRIBUTING.md
- update SECURITY.md supported version policy to the current 1.2.x line
- align CODE_OF_CONDUCT.md and CONTRIBUTING.md language for human contributors and AI-assisted workflows
- refresh CITATION.cff title and abstract to match the current public positioning

## Contributor attribution
- Commit ea82279 is authored as Codex <267193182+codex@users.noreply.github.com>

## Verification
- PASS: git diff --check -- README.md CONTRIBUTING.md SECURITY.md CODE_OF_CONDUCT.md CITATION.cff
- PASS: stale phrase scan found no remaining root-doc matches for biological, silicon-based, 17 professional, 1.0.x, drop-in governance, undisciplined, or Full support
- ATTEMPTED: powershell -ExecutionPolicy Bypass -File .\.agentcortex\bin\validate.ps1 -NoPython (local validation ran; local working tree still reports the unrelated INDEX.jsonl append-only witness failure)