### PR TITLE
chore: track Codex agent definitions + ignore local experiment artifacts

### DIFF
--- a/.codex/agents/acx-handoff.toml
+++ b/.codex/agents/acx-handoff.toml
@@ -1,0 +1,6 @@
+name = "acx-handoff"
+description = "AgentCortex /handoff phase executor. Use when delegating handoff work that must produce a resumable state summary with full Work Log archival per agentic-os governance."
+developer_instructions = """
+Execute `.agent/workflows/handoff.md` verbatim. All gates, evidence, output format, and compression receipts are defined there.\r
+\r
+This agent exists solely to leverage Codex's native skill frontmatter injection — DO NOT add logic here."""

--- a/.codex/agents/acx-implementer.toml
+++ b/.codex/agents/acx-implementer.toml
@@ -1,0 +1,6 @@
+name = "acx-implementer"
+description = "AgentCortex /implement phase executor. Use when delegating implementation work that must follow agentic-os gates, evidence requirements, and skill injection."
+developer_instructions = """
+Execute `.agent/workflows/implement.md` verbatim. All gates, evidence, output format, and compression receipts are defined there.\r
+\r
+This agent exists solely to leverage Codex's native skill frontmatter injection — DO NOT add logic here."""

--- a/.codex/agents/acx-reviewer.toml
+++ b/.codex/agents/acx-reviewer.toml
@@ -1,0 +1,6 @@
+name = "acx-reviewer"
+description = "AgentCortex /review phase executor. Use when delegating code review that must apply adversarial checks, AC alignment, and scope enforcement per agentic-os governance."
+developer_instructions = """
+Execute `.agent/workflows/review.md` verbatim. All gates, evidence, output format, and compression receipts are defined there.\r
+\r
+This agent exists solely to leverage Codex's native skill frontmatter injection — DO NOT add logic here."""

--- a/.codex/agents/acx-shipper.toml
+++ b/.codex/agents/acx-shipper.toml
@@ -1,0 +1,6 @@
+name = "acx-shipper"
+description = "AgentCortex /ship phase executor. Use when delegating final ship work that must consolidate evidence, update SSoT, and archive the Work Log per agentic-os governance."
+developer_instructions = """
+Execute `.agent/workflows/ship.md` verbatim. All gates, evidence, output format, and compression receipts are defined there.\r
+\r
+This agent exists solely to leverage Codex's native skill frontmatter injection — DO NOT add logic here."""

--- a/.codex/agents/acx-tester.toml
+++ b/.codex/agents/acx-tester.toml
@@ -1,0 +1,6 @@
+name = "acx-tester"
+description = "AgentCortex /test phase executor. Use when delegating test verification that must follow the test skeleton, coverage delta, and evidence requirements per agentic-os governance."
+developer_instructions = """
+Execute `.agent/workflows/test.md` verbatim. All gates, evidence, output format, and compression receipts are defined there.\r
+\r
+This agent exists solely to leverage Codex's native skill frontmatter injection — DO NOT add logic here."""

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@
 # Deploy artifacts
 .agentcortex-src/
 *.acx-incoming
+temp_downstream/
+
+# Local dev experiments (not part of the framework)
+scratch/
+cache_test.py
 
 # Third-party AI tool local state
 .openrouter/


### PR DESCRIPTION
## What
- **Track `.codex/agents/*.toml`** — the `acx-*` Codex subagent definitions (handoff / implementer / reviewer / shipper / tester). They delegate to `.agent/workflows/*` and exist to leverage Codex's native skill-frontmatter injection. Cross-platform framework content that belongs in the repo so Codex users get it.
- **`.gitignore`** — exclude local-only experiment artifacts (`temp_downstream/`, `scratch/`, `cache_test.py`) that are not part of the framework.

## Why
Working tree had untracked content in two categories: framework files that *should* be tracked (the Codex agent defs) and local experiments that should *not*. This sorts both.

## Evidence
- `git diff --stat`: 6 files changed, 35 insertions(+), 0 deletions(-)
- No existing files modified except `.gitignore` (additive only).
- No semantic/logic change to framework behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)