### PR TITLE
ci: pin test deps + pip cache + UTF-8 + branch-scoped concurrency (#163)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+  # Pinned CI test deps (#163) — keep .github/requirements-ci.txt fresh.
+  - package-ecosystem: "pip"
+    directory: "/.github"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/requirements-ci.txt
+++ b/.github/requirements-ci.txt
@@ -1,0 +1,5 @@
+# Pinned CI test dependencies for reproducible runs (#163).
+# Bumped by Dependabot (pip ecosystem, see .github/dependabot.yml).
+# Must stay compatible with the CI Python matrix (3.9 and 3.12).
+pytest==8.4.1
+PyYAML==6.0.2

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,8 +9,15 @@ on:
 permissions:
   contents: read
 
+env:
+  # Force UTF-8 for all Python I/O across the matrix. Windows runners default to
+  # cp1252, which has previously broken this repo's cross-platform tooling. (#163)
+  PYTHONUTF8: "1"
+
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Group by branch (head_ref on PRs, ref_name on push) so a new push cancels the
+  # prior in-flight run for the same branch rather than across all refs. (#163)
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -153,9 +160,11 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: .github/requirements-ci.txt
 
       - name: Install test dependencies
-        run: pip install pyyaml pytest
+        run: pip install -r .github/requirements-ci.txt
 
       - name: Run CI structural + guard tests
         run: python -m pytest tests/ci/ tests/guard/ -v

--- a/tests/ci/test_ci_hardening.py
+++ b/tests/ci/test_ci_hardening.py
@@ -1,0 +1,54 @@
+"""Structural regression tests for CI hardening (#163).
+
+Locks the reproducibility/hygiene wiring so a careless edit can't silently
+un-pin the CI deps, drop pip caching, lose the UTF-8 default, or revert to the
+old ad-hoc `pip install pyyaml pytest`. Mirrors the structural style of
+test_security_workflow.py. Pure-Python (CI-safe on Linux).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+REQS = ROOT / ".github" / "requirements-ci.txt"
+WORKFLOW = ROOT / ".github" / "workflows" / "validate.yml"
+DEPENDABOT = ROOT / ".github" / "dependabot.yml"
+
+
+def test_requirements_file_pins_test_deps() -> None:
+    assert REQS.exists(), ".github/requirements-ci.txt must exist (#163)"
+    lines = [ln.strip() for ln in REQS.read_text(encoding="utf-8").splitlines()
+             if ln.strip() and not ln.strip().startswith("#")]
+    pkgs = {re.split(r"[=<>!~]", ln, maxsplit=1)[0].lower(): ln for ln in lines}
+    for required in ("pytest", "pyyaml"):
+        assert required in pkgs, f"requirements-ci.txt must list {required}"
+        assert "==" in pkgs[required], f"{required} must be pinned with '==' (got: {pkgs[required]})"
+
+
+def test_workflow_installs_from_pinned_requirements() -> None:
+    txt = WORKFLOW.read_text(encoding="utf-8")
+    assert "pip install -r .github/requirements-ci.txt" in txt, \
+        "CI must install from the pinned requirements file (#163)"
+    assert "pip install pyyaml pytest" not in txt, \
+        "CI must not reintroduce the ad-hoc unpinned install (#163)"
+
+
+def test_workflow_enables_pip_cache() -> None:
+    txt = WORKFLOW.read_text(encoding="utf-8")
+    assert "cache: 'pip'" in txt, "CI must enable pip caching (#163)"
+    assert "cache-dependency-path: .github/requirements-ci.txt" in txt, \
+        "pip cache must key on the requirements file (#163)"
+
+
+def test_workflow_forces_utf8() -> None:
+    txt = WORKFLOW.read_text(encoding="utf-8")
+    assert re.search(r"PYTHONUTF8:\s*[\"']?1", txt), \
+        "CI must export PYTHONUTF8=1 for cross-platform encoding safety (#163)"
+
+
+def test_dependabot_tracks_pip_requirements() -> None:
+    txt = DEPENDABOT.read_text(encoding="utf-8")
+    assert re.search(r'package-ecosystem:\s*"pip"', txt), \
+        "dependabot must track the pip ecosystem so the CI pins stay fresh (#163)"


### PR DESCRIPTION
Core CI-hardening slice of #163 (reproducibility/hygiene, low risk). PR-first because it modifies the CI workflow itself — the PR run validates the new pinned-install + pip-cache + PYTHONUTF8 path end-to-end before it reaches main.

## Changes
- `.github/requirements-ci.txt` (new): pin `pytest==8.4.1` + `PyYAML==6.0.2` (3.9/3.12-compatible). `test-ci-structural` installs `-r` it (was ad-hoc `pip install pyyaml pytest`); `setup-python` caches pip keyed on the file.
- `validate.yml`: workflow-level `PYTHONUTF8: "1"` (Windows cp1252 has bitten cross-platform tooling here); concurrency keyed on branch (`head_ref || ref_name`).
- `dependabot.yml`: add pip ecosystem so pins stay fresh.
- `tests/ci/test_ci_hardening.py`: structural regression guard.

## Deferred (noted on #163, not this slice)
Running `.agentcortex/tests` in CI cross-platform + `verify_agent_evidence.py` on PRs — both need separate verification (those legacy tests aren't currently CI-gated; Windows behavior unproven). pytest-on-PR is already satisfied.

## Evidence
Local: validate.sh pass=103/0/0; YAML parses; new structural tests 5 passed; no test asserted the old unpinned line. CI on this PR is the end-to-end verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)