### PR TITLE
docs(readme): de-slop EN/zh-TW README tone; release v1.2.1

### DIFF
--- a/.agentcortex/bin/deploy.sh
+++ b/.agentcortex/bin/deploy.sh
@@ -26,7 +26,7 @@ TARGET="${TARGET:-.}"
 TARGET="${TARGET%/}"
 
 MANIFEST_FILE="$TARGET/.agentcortex-manifest"
-ACX_VERSION="1.2.0"
+ACX_VERSION="1.2.1"
 
 # --- Self-deploy guard ---
 TARGET_ABS="$(cd "$TARGET" 2>/dev/null && pwd || echo "$TARGET")"

--- a/.agentcortex/bin/validate.ps1
+++ b/.agentcortex/bin/validate.ps1
@@ -871,13 +871,13 @@ else {
 if ($isSourceRepo) {
     $readmeZhTw = Join-NormalPath $root 'docs/README_zh-TW.md'
     if (Test-Path -Path $readmeZhTw -PathType Leaf) {
-        Test-ContainsLiteral -Path $readmeZhTw -Pattern '從「流程驅動」進化到「自我管理」的專業級 AI Agent 核心架構。' -SuccessMessage 'README_zh-TW.md encoding looks healthy' -FailureMessage 'README_zh-TW.md appears mojibaked or re-encoded'
+        Test-ContainsLiteral -Path $readmeZhTw -Pattern '用工作流程、交付閘門與工程護欄' -SuccessMessage 'README_zh-TW.md encoding looks healthy' -FailureMessage 'README_zh-TW.md appears mojibaked or re-encoded'
     }
     $readmeEn = Join-NormalPath $root 'README.md'
     if (Test-Path -Path $readmeEn -PathType Leaf) {
         $params = @{
             Path = $readmeEn
-            Pattern = 'governance-first operating system for AI coding agents'
+            Pattern = 'governance-first layer for AI coding agents'
             SuccessMessage = 'README.md encoding looks healthy'
             FailureMessage = 'README.md appears mojibaked or re-encoded'
         }

--- a/.agentcortex/bin/validate.sh
+++ b/.agentcortex/bin/validate.sh
@@ -935,14 +935,14 @@ if [[ "$IS_SOURCE_REPO" -eq 1 ]]; then
   if [[ -f "$ROOT/docs/README_zh-TW.md" ]]; then
     check_contains_literal \
       "$ROOT/docs/README_zh-TW.md" \
-      '從「流程驅動」進化到「自我管理」的專業級 AI Agent 核心架構。' \
+      '用工作流程、交付閘門與工程護欄' \
       "README_zh-TW.md encoding looks healthy" \
       "README_zh-TW.md appears mojibaked or re-encoded"
   fi
   if [[ -f "$ROOT/README.md" ]]; then
     check_contains_literal \
       "$ROOT/README.md" \
-      'governance-first operating system for AI coding agents' \
+      'governance-first layer for AI coding agents' \
       "README.md encoding looks healthy" \
       "README.md appears mojibaked or re-encoded"
   fi

--- a/.agentcortex/docs/TESTING_PROTOCOL.md
+++ b/.agentcortex/docs/TESTING_PROTOCOL.md
@@ -1,4 +1,4 @@
-# Testing Protocol v1.2.0
+# Testing Protocol v1.2.1
 
 > **This document guides the AI Agent to produce high-quality, trustworthy, and defensive test code.**
 

--- a/.agentcortex/docs/TESTING_PROTOCOL_zh-TW.md
+++ b/.agentcortex/docs/TESTING_PROTOCOL_zh-TW.md
@@ -1,4 +1,4 @@
-# Testing Protocol (測試教戰守則) v1.2.0
+# Testing Protocol (測試教戰守則) v1.2.1
 >
 > **本文件旨在指引 AI Agent 產出高品質、可信任、且具備防禦性的測試程式碼。**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.2.1] - 2026-06-03
+
+Documentation polish release — no functional, governance, or runtime behavior changes.
+
+**Docs**
+- **README de-slop (EN + zh-TW)**: removed AI-generated tonal artifacts to make the project face read as a genuine, professional share rather than a product launch page. Dropped the triple-slogan line, per-section header emoji, and the "demand discipline" footer in `README.md`; softened the buzzword-heavy opening ("頂尖開發者 / 高效能 / 結構化認知框架") and removed section-header emoji in `docs/README_zh-TW.md`. Aligned the top tagline ("operating system" → "layer") with the humbler open-source footer, and brought the zh-TW anti-drift bullets back to plain register for EN/zh parity. Trimmed the redundant "Ready/Compatible" marketing badges (platform support already documented in the Platform Compatibility table). No content, tables, diagrams, or install steps were removed.
+- Version banners bumped to v1.2.1 across `README.md`, `docs/README_zh-TW.md`, `CITATION.cff`, the Model Selection Guide, and the Testing Protocol (EN + zh-TW). Measurement-tied banners (`LIFECYCLE_BENCHMARK`, dated to the v1.2.0 snapshot) were intentionally left unchanged.
+
 ## [1.2.0] - 2026-05-31
 
 Consolidated release covering PRs #98–#122 since v1.1.2. Highlights:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ authors:
   - family-names: Wen
     given-names: Kb
 title: "Agentic OS: Governance-First Workflows for AI Coding Agents"
-version: 1.2.0
-date-released: 2026-05-31
+version: 1.2.1
+date-released: 2026-06-03
 url: "https://github.com/KbWen/agentic-os"
 abstract: "A governance-first framework for AI coding agents. Portable workflows, delivery gates, engineering guardrails, and 14 professional skills for Claude Code, OpenAI Codex, Google Antigravity, Cursor, GitHub Copilot, and other coding agents."
 keywords:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/Agentic OS-v1.2.0-blueviolet?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJ3aGl0ZSI+PHBhdGggZD0iTTEyIDJDNi40OCAyIDIgNi40OCAyIDEyczQuNDggMTAgMTAgMTAgMTAtNC40OCAxMC0xMFMxNy41MiAyIDEyIDJ6bTAgMThjLTQuNDEgMC04LTMuNTktOC04czMuNTktOCA4LTggOCAzLjU5IDggOC0zLjU5IDgtOCA4eiIvPjwvc3ZnPg==" alt="Agentic OS v1.2.0"/>
+  <img src="https://img.shields.io/badge/Agentic OS-v1.2.1-blueviolet?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJ3aGl0ZSI+PHBhdGggZD0iTTEyIDJDNi40OCAyIDIgNi40OCAyIDEyczQuNDggMTAgMTAgMTAgMTAtNC40OCAxMC0xMFMxNy41MiAyIDEyIDJ6bTAgMThjLTQuNDEgMC04LTMuNTktOC04czMuNTktOCA4LTggOCAzLjU5IDggOC0zLjU5IDgtOCA4eiIvPjwvc3ZnPg==" alt="Agentic OS v1.2.1"/>
 </p>
 
 <h1 align="center">Agentic OS</h1>
 
 <p align="center">
-  <strong>The governance-first operating system for AI coding agents.</strong><br/>
+  <strong>A governance-first layer for AI coding agents.</strong><br/>
   Portable workflows, delivery gates, engineering guardrails, and 14 professional skills<br/>
   for Claude Code, OpenAI Codex, Google Antigravity, Cursor, GitHub Copilot, and other coding agents.
 </p>
@@ -14,10 +14,6 @@
   <a href="https://github.com/KbWen/agentic-os/actions/workflows/validate.yml"><img src="https://img.shields.io/github/actions/workflow/status/KbWen/agentic-os/validate.yml?branch=main&style=flat-square&label=CI" alt="CI Status"/></a>
   <a href="https://github.com/KbWen/agentic-os/actions/workflows/security.yml"><img src="https://img.shields.io/github/actions/workflow/status/KbWen/agentic-os/security.yml?branch=main&style=flat-square&label=Security" alt="Security Scan"/></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-22c55e?style=flat-square" alt="MIT License"/></a>
-  <img src="https://img.shields.io/badge/Claude_Code-Ready-8b5cf6?style=flat-square" alt="Claude Code"/>
-  <img src="https://img.shields.io/badge/Antigravity-Compatible-3b82f6?style=flat-square" alt="Antigravity"/>
-  <img src="https://img.shields.io/badge/Codex-Ready-f59e0b?style=flat-square" alt="Codex"/>
-  <img src="https://img.shields.io/badge/Cursor-Compatible-ec4899?style=flat-square" alt="Cursor"/>
 </p>
 
 <p align="center">
@@ -53,13 +49,13 @@ AI coding agents are powerful, but they need shared operating rules. Without str
                ⛔ STOP                          ⛔ STOP
 ```
 
-**No evidence = no completion. No gate = no progression. No exceptions.**
+The idea behind every phase is the same: if there's no verifiable evidence, the task isn't done — and the gates enforce that, instead of trusting the agent to self-report honestly.
 
 ---
 
 ## Features
 
-### 🔒 Gate Engine & Phase System
+### Gate Engine & Phase System
 
 Every task flows through mandatory phases. The AI cannot skip ahead.
 
@@ -87,7 +83,7 @@ flowchart LR
 | **hotfix** | Bootstrap → Research → Plan → Implement → Review → Test → Ship |
 | **architecture-change** | Bootstrap → ADR → Spec → Plan → Implement → Review → Test → Handoff → Ship |
 
-### 🛡️ Engineering Guardrails
+### Engineering Guardrails
 
 A constitution for AI behavior — loaded automatically, enforced at every phase:
 
@@ -97,7 +93,7 @@ A constitution for AI behavior — loaded automatically, enforced at every phase
 - **OWASP Top 10 Auto-Scan** — security checks run during `/implement` and `/review`
 - **Confidence Gate** — AI must declare confidence level; low confidence triggers escalation
 
-### ⚡ 14 Professional Skills
+### 14 Professional Skills
 
 Skills auto-activate based on task classification and workflow phase:
 
@@ -118,7 +114,7 @@ Skills auto-activate based on task classification and workflow phase:
 | Git Worktrees | parallel branches | Worktree isolation workflows |
 | Doc Lookup | documentation needed | Documentation retrieval strategy |
 
-### 🧠 Single Source of Truth (SSoT)
+### Single Source of Truth (SSoT)
 
 Every project has one canonical state file. AI agents read it first, write to it last.
 
@@ -133,7 +129,7 @@ Every project has one canonical state file. AI agents read it first, write to it
 - **SSoT** tracks global decisions, lessons, and ship history
 - **Handoff** enables seamless AI-to-AI continuity across conversations
 
-### 👥 Multi-Agent Collaboration
+### Multi-Agent Collaboration
 
 Built for teams where multiple AI sessions work on the same codebase:
 
@@ -142,7 +138,7 @@ Built for teams where multiple AI sessions work on the same codebase:
 - **Ship Guard** — checks for SSoT conflicts before merging
 - **Session Identity** — every AI session writes its model name and timestamp
 
-### 🚀 Three Entry Paths
+### Three Entry Paths
 
 Pick the one that matches your starting point (full opener templates in **Quick Start §2**):
 
@@ -154,7 +150,7 @@ Pick the one that matches your starting point (full opener templates in **Quick 
 
 See the [Lifecycle Benchmark](https://github.com/KbWen/agentic-os/blob/main/docs/LIFECYCLE_BENCHMARK.md) ([繁體中文](https://github.com/KbWen/agentic-os/blob/main/docs/LIFECYCLE_BENCHMARK_zh-TW.md)) for real token consumption data across 6 development scenarios.
 
-### 📉 Token Efficiency
+### Token Efficiency
 
 Designed for cost-effective models (Gemini Flash, Haiku, etc.):
 
@@ -451,5 +447,5 @@ MIT License. See [LICENSE](LICENSE) for details.
 ---
 
 <p align="center">
-  <sub>Built for developers who demand discipline from their AI agents.</sub>
+  <sub>An open-source governance layer for AI coding agents. Contributions and feedback are welcome.</sub>
 </p>

--- a/docs/AGENT_MODEL_GUIDE.md
+++ b/docs/AGENT_MODEL_GUIDE.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.2.0 — Model Selection Guide
+# Agentic OS v1.2.1 — Model Selection Guide
 
 > For human reference only — this file is not loaded into AI context.
 

--- a/docs/AGENT_MODEL_GUIDE_zh-TW.md
+++ b/docs/AGENT_MODEL_GUIDE_zh-TW.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.2.0 — 模型選擇指南
+# Agentic OS v1.2.1 — 模型選擇指南
 
 > 人類參考用 — 此檔案不會被載入 AI context。
 

--- a/docs/README_zh-TW.md
+++ b/docs/README_zh-TW.md
@@ -1,25 +1,25 @@
-# Agentic OS v1.2.0 (Runtime v1.1 Anti-Drift Edition)
+# Agentic OS v1.2.1 (Runtime v1.1 Anti-Drift Edition)
 
 [English Version](../README.md)
 
-> **從「流程驅動」進化到「自我管理」的專業級 AI Agent 核心架構。**
+> 一套給 AI coding agent 的治理框架：用工作流程、交付閘門與工程護欄，讓 agent 的行為可預期、可驗證。
 
-## 🎯 專案定位
+## 專案定位
 
-**Agentic OS** 是一個專為頂尖開發者（使用 Gemini、Claude、或 GPT 等主流模型）設計的高效能**結構化認知框架**。它能幫助 AI Agent 深度理解代碼庫、嚴格遵守工程護欄，並以極高的 Token 效率執行複雜任務。
+**Agentic OS** 是一套可攜的治理框架，適用於 Gemini、Claude、GPT 等主流模型。它讓 AI agent 在理解代碼庫、遵守工程護欄的同時，以較低的 token 成本穩定執行複雜任務。
 
 我們對齊並優化了 Google Antigravity / Codex Web / Codex App 的使用情境：
 
 - **Self-Managed**：AI 自行分類任務並套用對應的治理閘門。
-- **Anti-Drift Engine**：具備強制防跳步驟的 `Gate Engine` 與 `Handshake` 交握機制，封鎖幻覺越權。
-- **Concurrency & Migration Safe**：內建衝突感知的 optimistic multi-session 保護、多人協作 Metadata 防撞車，以及舊專案無痛導入的 `/audit` 工作流。
+- **Anti-Drift Engine**：強制防跳步驟的 `Gate` 與交握機制，防止 AI 略過流程或宣稱未經驗證的完成。
+- **Concurrency & Migration Safe**：衝突感知的多 session 保護、多人協作的 metadata 防衝突，以及既有專案無痛導入的 `/audit` 工作流。
 - **Token Optimized**：針對不同風險等級自動調整治理強度，`tiny-fix` 走 fast-path 以節省成本。
 - **Command-first**：用標準化指令觸發 Agent 能力，確保行為一致性。
 - **10 不可違反原則**：[設計哲學](../.agentcortex/docs/AGENT_PHILOSOPHY_zh-TW.md)定義 P1-P10 核心信條 — AI 主導、不跳步驟、憲法高於任務、無證據不完成、跨模型合規。
 - **命名空間隔離**：下游專案可自由添加自定義 skill 和 workflow，框架用 `.agentcortex-manifest` 區分管理範圍，用戶指令永遠優先。
 - **14 項專業技能**：每個 skill metadata 都宣告在哪個 phase 自動啟用，AI 不需要人類提示就知道何時使用。
 
-## 🚀 三條起點路徑
+## 三條起點路徑
 
 依你的專案狀態挑一條（詳細開場提示見「快速開始 §3」）：
 
@@ -31,7 +31,7 @@
 
 詳見 [生命週期基準測試](LIFECYCLE_BENCHMARK_zh-TW.md)（[English](LIFECYCLE_BENCHMARK.md)）— 6 個真實場景的 token 消耗數據。
 
-## 🔗 參考來源
+## 參考來源
 
 - Superpowers 專案（理念參考）：<https://github.com/obra/superpowers>
 - 專案導入範例：`.agentcortex/docs/PROJECT_EXAMPLES_zh-TW.md`
@@ -40,7 +40,7 @@
 - Token 優化快速指南：[token-optimization-quickstart_zh-TW.md](guides/token-optimization-quickstart_zh-TW.md)（[English](guides/token-optimization-quickstart.md)）
 - 生命週期基準測試：[LIFECYCLE_BENCHMARK_zh-TW.md](LIFECYCLE_BENCHMARK_zh-TW.md)
 
-## 📦 目錄總覽
+## 目錄總覽
 
 - `.agent/rules/engineering_guardrails.md`：工程憲法（含分類規則與 Gate 標準）
 - `.agent/workflows/*.md`：單檔工作流程（bootstrap, plan, implement, handoff, ship 等）
@@ -51,7 +51,7 @@
 - `.agentcortex/docs/CODEX_PLATFORM_GUIDE_zh-TW.md`：Codex 平台指南
 - `AGENTS.md`：跨平台長期指令入口
 
-## 🧩 系列功能對照 (Superpowers Based)
+## 系列功能對照 (Superpowers Based)
 
 | 功能 | 指令 | 對應檔案 | 目的 |
 | :--- | :--- | :--- | :--- |
@@ -72,13 +72,13 @@
 | 外部委派 (自然語言) | `ask-openrouter` | `.agent/workflows/ask-openrouter.md` | [可選] 將任務委派給 OpenRouter 模型 |
 | Codex CLI 執行 | `codex-cli` | `.agent/workflows/codex-cli.md` | [可選] 透過 Codex CLI 安全執行任務 |
 
-## 🔀 Antigravity / Codex 路徑差異
+## Antigravity / Codex 路徑差異
 
 - Antigravity 主要讀取：`.agent/skills` (Native Agent 核心能力)
 - Codex 主要掃描：`.agents/skills` (Codex App 專屬能力)
 - **注意**：兩者目錄獨立存在以適應不同平台配置。若需共用，請根據需求手動鏡像或建立軟連結。
 
-## 🛡️ 規則檔與安全邊界
+## 規則檔與安全邊界
 
 - `.antigravity/rules.md`：Antigravity 優先讀取的規則總表。
 - `codex/rules/default.rules`：Codex 規則擴充入口。
@@ -115,7 +115,7 @@ flowchart LR
 - `rm -rf`、`git reset --hard`、`git clean -fdx`
 - `docker system prune -a`、`chown -R`、`curl ... | bash`、`chmod -R 777`
 
-## 🚀 快速開始
+## 快速開始
 
 ### 1) 部署到專案
 
@@ -237,7 +237,7 @@ Fetch and follow instructions from <your-raw-url>/.codex/INSTALL.md
 6. `/handoff`：跨回合交接（非 tiny-fix 必須）
 7. `/ship`：整理 commit / 變更摘要 / 測試結果
 
-## ⚙️ 建議節奏
+## 建議節奏
 
 ```mermaid
 flowchart LR
@@ -255,25 +255,25 @@ flowchart LR
 - **架構調整（architecture-change）**：`/bootstrap → /adr → /spec → /plan → /implement → /review → /test → /handoff → /ship`
 - **緊急修復（hotfix）**：`/bootstrap → /research → /plan → /implement → /review → /test → /ship`
 
-## 🧠 Token Hygiene（避免小任務放大成本）
+## Token Hygiene（避免小任務放大成本）
 
 - 任務啟動只讀：`.agentcortex/context/current_state.md` 與 `.agentcortex/context/work/<worklog-key>.md`（worklog-key = branch name 的 filesystem-safe 正規化，例如 `/` 換 `-`）。
 - 優先精準檢索（`rg <keyword> <path>`），避免全樹掃描。
 - 先用 `/plan` 收斂檔案範圍，再進入 `/implement`，降低來回修正。
 - 小型任務沿用 Fast Lane；若變更開始影響狀態/策略，立即升級流程，避免返工。
 
-## 🗺️ 文件導覽
+## 文件導覽
 
 | 目標 | 先讀這裡 | 用途 |
 |:---|:---|:---|
-| 安裝或升級 Agentic OS | [快速開始](#-快速開始)、[遷移與整合指南](../.agentcortex/docs/guides/migration_zh-TW.md) | 部署指令、更新流程、既有專案導入 |
+| 安裝或升級 Agentic OS | [快速開始](#快速開始)、[遷移與整合指南](../.agentcortex/docs/guides/migration_zh-TW.md) | 部署指令、更新流程、既有專案導入 |
 | 選擇合適模型 | [模型選擇指南](AGENT_MODEL_GUIDE_zh-TW.md)、[生命週期基準測試](LIFECYCLE_BENCHMARK_zh-TW.md) | 模型取捨與實測 token 成本 |
 | 跑穩定的 agent 工作流 | [設計哲學](../.agentcortex/docs/AGENT_PHILOSOPHY_zh-TW.md)、[測試協議](../.agentcortex/docs/TESTING_PROTOCOL_zh-TW.md) | 核心規則、證據要求、驗證標準 |
 | 使用特定平台 | [Codex 平台指南](../.agentcortex/docs/CODEX_PLATFORM_GUIDE_zh-TW.md)、[Antigravity v5 Runtime](../.agentcortex/docs/guides/antigravity-v5-runtime.md) | 平台載入、交接、相容性注意事項 |
 | 理解治理內部機制 | [文件治理](../.agentcortex/docs/guides/doc-governance.md)、[非線性情境](../.agentcortex/docs/NONLINEAR_SCENARIOS_zh-TW.md) | 狀態、交接、復原與文件生命週期 |
 | 安全擴充技能 | [Skill Ecosystem](architecture/skill-ecosystem.md)、[Token 治理指南](../.agentcortex/docs/guides/token-governance_zh-TW.md) | skill 封裝、觸發策略、context 預算控制 |
 
-## ✅ 自我驗證
+## 自我驗證
 
 ```bash
 .agentcortex/bin/validate.sh


### PR DESCRIPTION
## What

Documentation-only patch release. **No functional, governance, or runtime behavior changes.**

### README de-slop (EN + zh-TW)
Removed AI-generated tonal artifacts so the project's public face reads as a genuine, professional share rather than a product launch page.

- **EN (`README.md`)**: dropped the triple-slogan line (`No evidence = no completion…`), per-section header emoji, and the `Built for developers who demand discipline…` footer; aligned the top tagline (`operating system` → `layer`) with the humbler open-source footer; trimmed the redundant `Ready/Compatible` marketing badges (platform support already lives in the Platform Compatibility table).
- **zh-TW (`docs/README_zh-TW.md`)**: softened the buzzword-heavy opening (`頂尖開發者 / 高效能 / 結構化認知框架`), removed section-header emoji, and brought the anti-drift bullets back to plain register for EN/zh voice parity.
- **No content, tables, diagrams, or install steps were removed.**

A senior-technical-writer review pass (`SHIP-WITH-MINOR-FIXES`) drove the tagline alignment and zh-TW parity fixes above.

### Validator canary repoint (`validate.sh` + `validate.ps1`, parity)
The "encoding-health" check pins literal README phrases as mojibake canaries. The de-slop removed those exact phrases, so both canaries were repointed to stable phrases that survive the edit. Both validators green: `pass=103 warn=5 fail=0` (the 5 WARNs are pre-existing work-log/archive state, untouched here).

### Release v1.2.1
Version banners bumped across `README.md`, `docs/README_zh-TW.md`, `CITATION.cff` (+`date-released` → 2026-06-03), `deploy.sh` `ACX_VERSION`, the Model Selection Guide, and the Testing Protocol (EN + zh-TW). Measurement-tied banners (`LIFECYCLE_BENCHMARK`, dated to the v1.2.0 snapshot) and illustrative example text were intentionally left unchanged.

## Evidence
- `bash .agentcortex/bin/validate.sh` → `pass=103 warn=5 fail=0`, integrity check **passed**
- `validate.ps1` → identical `pass=103 warn=5 fail=0` (cross-platform parity)
- 11 files changed, +48 / -44

🤖 Generated with [Claude Code](https://claude.com/claude-code)