### PR TITLE
docs(governance): reconcile ADR-002 AC-24/25 with realized doc-governance.md

### DIFF
--- a/.agentcortex/docs/guides/doc-governance.md
+++ b/.agentcortex/docs/guides/doc-governance.md
@@ -7,6 +7,13 @@ authority: extracted from AGENTS.md (2026-05-07) to keep AGENTS.md within token 
 
 # Document Lifecycle Governance
 
+> **Realizes** ADR-002 / `docs/specs/lock-unification.md` AC-24 & AC-25. This guide is the
+> canonical "Document Lifecycle Governance" home — extracted from `AGENTS.md` on 2026-05-07
+> (token-budget consolidation). The **Document Taxonomy** below is the doc-ownership matrix
+> that AC-25 planned under the filename `governance-doc-lifecycle-matrix.md`; that file was
+> never created — this guide superseded it. AC-25's "3 ownership gaps marked as Spec Seeds"
+> were superseded by the doc-lifecycle backlog (#1, #3, #7, #11, #13, #67).
+
 ## Document Taxonomy
 
 | Type | Path | Status | Owner Workflow |

--- a/docs/adr/ADR-002-guarded-governance-writes.md
+++ b/docs/adr/ADR-002-guarded-governance-writes.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-04-25
 classification: architecture-change
 primary_domain: document-governance
@@ -184,7 +184,7 @@ Skeptic Amendment #3: "Closes Part B & D in one stroke; ~15 LOC, no friction add
 | `.agentcortex/bin/validate.ps1` | mirror (~10 LOC) |
 | `docs/audit/governance-lifecycle-2026-04-25.md` | retroactively add `lifecycle:` (this is THE audit doc; lead by example) |
 | `docs/adr/ADR-002-guarded-governance-writes.md` | this file's frontmatter ALREADY includes `lifecycle:` fields (see top) |
-| `AGENTS.md §Document Lifecycle Governance` | +1 paragraph pointer to `docs/guides/governance-doc-lifecycle-matrix.md` |
+| `AGENTS.md §Document Lifecycle Governance` | +1 paragraph pointer to the ownership matrix. **As-built (post-ship):** the section was extracted from `AGENTS.md` into `.agentcortex/docs/guides/doc-governance.md` (2026-05-07); the planned `governance-doc-lifecycle-matrix.md` was never created and is superseded by that guide's Document Taxonomy. |
 
 ---
 


### PR DESCRIPTION
Resolves item 1 of #180.

## Finding (severity downgraded after investigation)
The audit flagged ADR-002 / `lock-unification.md` AC-24 & AC-25 as referencing nonexistent artifacts (`governance-doc-lifecycle-matrix.md`, an `AGENTS.md §Document Lifecycle Governance` section). Deeper reading shows the deliverables were **realized under a different name, not skipped**:

- `lock-unification.md` is `status: shipped` (2026-04-25); D1/D2/D3 tooling (`guard_context_write.py`, `lint_governed_writes.py`, `check_lifecycle_frontmatter.py`) all exist.
- The doc-lifecycle "section" + "ownership matrix" were **consolidated into `.agentcortex/docs/guides/doc-governance.md`** when AGENTS.md was trimmed on 2026-05-07 (per that guide's `authority:` field). Its **Document Taxonomy** table IS the planned matrix.

So this is **traceability drift**, not a false-ship of missing governance.

## Changes (reconciliation only)
- `doc-governance.md`: added a "Realizes ADR-002 AC-24/25" note — anchors it as the canonical realization, explains the rename, and notes the "3 Spec Seeds" were superseded by the doc-lifecycle backlog.
- `ADR-002`: `status: proposed` → `accepted` (it shipped); as-built note on the stale matrix-doc reference.
- **Frozen shipped spec `lock-unification.md` left untouched** (historical record — reconciliation is anchored in the living guide + ADR instead).

## Residual (tracked, not blocking)
AC-25's "3 ownership gaps as Spec Seeds" were never written to a doc (lived in the roundtable transcript) — effectively superseded by doc-lifecycle backlog #1/#3/#7/#11/#13/#67.

## Evidence
`validate.sh` → `pass=103 warn=5 fail=0`, integrity passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)