### PR TITLE
fix(validate): eliminate flaky SIGPIPE in cs_content index parsing

### DIFF
--- a/.agentcortex/bin/validate.sh
+++ b/.agentcortex/bin/validate.sh
@@ -1816,7 +1816,11 @@ if [[ -f "$CURRENT_STATE" ]]; then
   cs_content="$(cat "$CURRENT_STATE" 2>/dev/null)" || { record_result WARN "cannot read current_state.md — skipping state checks"; }
 
   # ADR Index completeness
-  adr_index_section="$(printf '%s' "$cs_content" | awk '/\*\*ADR Index\*\*:/{found=1; next} found && /^- \*\*/{exit} found{print}')"
+  # NOTE: feed awk via here-string, NOT `printf | awk`. awk's `exit` closes the
+  # pipe early; with set -o pipefail the upstream printf's SIGPIPE (141) would
+  # fail the whole script intermittently when $cs_content is large. <<< reads a
+  # temp file, so early exit cannot break a pipe.
+  adr_index_section="$(awk '/\*\*ADR Index\*\*:/{found=1; next} found && /^- \*\*/{exit} found{print}' <<<"$cs_content")"
   adr_missing_count=0
   adr_missing_list=""
   adr_phantom_count=0
@@ -1857,7 +1861,7 @@ if [[ -f "$CURRENT_STATE" ]]; then
   fi
 
   # Spec Index completeness
-  spec_index_section="$(printf '%s' "$cs_content" | awk '/\*\*Spec Index\*\*/{found=1; next} found && /^- \*\*/{exit} found{print}')"
+  spec_index_section="$(awk '/\*\*Spec Index\*\*/{found=1; next} found && /^- \*\*/{exit} found{print}' <<<"$cs_content")"
   spec_missing_count=0
   spec_missing_list=""
   for spec_dir in "$ROOT/docs/specs" "$ROOT/.agentcortex/specs"; do


### PR DESCRIPTION
## Problem
`Framework Validation` CI intermittently fails with:
```
validate.sh: line 1860: printf: write error: Broken pipe
##[error]Process completed with exit code 1.
```
On the same commit, `Framework Validation (Python 3.9)` and `(Windows)` **pass** — so it's timing-dependent, not a content failure. (Surfaced on PR #181; also explains earlier green-by-luck runs.)

## Root cause
Two pipelines parse `current_state.md`:
```sh
printf '%s' "$cs_content" | awk '/.../{found=1;next} found && /^- \*\*/{exit} found{print}'
```
at L1819 (ADR Index) and L1860 (Spec Index). awk's `exit` (at the section terminator) closes the pipe **while `printf` is still writing** the large content → `printf` gets SIGPIPE (exit 141). Under `set -o pipefail`, that becomes the pipeline's status and `set -e` aborts the script. Whether it fires depends on how much printf flushed before awk exited → flaky across runners.

## Fix
Feed awk via a **here-string** instead of a pipe:
```sh
awk '/.../{...} found && /^- \*\*/{exit} found{print}' <<<"$cs_content"
```
Here-strings read from a temp file, so awk's early `exit` cannot break a pipe. Identical awk program and output; deterministic.

`validate.ps1` has no shell pipe → no equivalent bug; behavior parity preserved (it already passed).

## Evidence
- `bash -n validate.sh` → syntax OK
- `validate.sh` → ADR Index + Spec Index checks PASS; `pass=103 warn=5 fail=0`, integrity passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)