### PR TITLE
fix(validate): close PowerShell validator parity gaps

### DIFF
--- a/.agentcortex/bin/validate.ps1
+++ b/.agentcortex/bin/validate.ps1
@@ -1979,7 +1979,7 @@ if (Test-Path -Path $githubWorkflowsDir -PathType Container) {
 # Document lifecycle bloat checks
 $globalLessonsMax = if ($env:GLOBAL_LESSONS_MAX) { [int]$env:GLOBAL_LESSONS_MAX } else { 20 }
 if (Test-Path -Path $currentStatePath -PathType Leaf) {
-    $lessonsCount = @([regex]::Matches($csContent, '(?m)^- \[Category:') | Measure-Object).Count
+    $lessonsCount = ([regex]::Matches($csContent, '(?m)^- \[Category:')).Count
     if ($lessonsCount -gt $globalLessonsMax) {
         Add-Result -Level 'WARN' -Message "Global Lessons exceeds cap ($lessonsCount > $globalLessonsMax); run /retro to archive LOW-severity entries"
     }

--- a/.agentcortex/tools/check_lifecycle_frontmatter.py
+++ b/.agentcortex/tools/check_lifecycle_frontmatter.py
@@ -19,9 +19,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
+import tempfile
 from datetime import date
 from pathlib import Path
 from typing import Iterable, NamedTuple
@@ -72,8 +74,12 @@ def parse_frontmatter(path: Path) -> tuple[str | None, dict | None]:
     if not m:
         return None, None
     raw = m.group(1)
-    # Build a temporary file-like for the YAML loader (.yaml extension required)
-    tmp = Path(str(path) + ".__fm_probe__.yaml")
+    # Build a unique temp file for the YAML loader (.yaml extension required).
+    # Keep it outside the repo so parallel validators cannot race on a fixed
+    # sidecar path next to the source document.
+    fd, tmp_name = tempfile.mkstemp(suffix=".yaml")
+    os.close(fd)
+    tmp = Path(tmp_name)
     try:
         # Write the frontmatter as a standalone YAML doc and parse via loader.
         # We avoid touching the source file; this just reuses the parser.

--- a/tests/ci/test_validator_false_positives.py
+++ b/tests/ci/test_validator_false_positives.py
@@ -216,6 +216,14 @@ def test_f4_deprecated_files_pass_branch_parity() -> None:
     assert msg in VALIDATE_PS1.read_text(encoding="utf-8")
 
 
+def test_global_lessons_count_uses_match_count_in_ps1() -> None:
+    """PowerShell must count regex matches, not the single Measure-Object result."""
+    ps1 = VALIDATE_PS1.read_text(encoding="utf-8")
+
+    assert "Measure-Object).Count" not in ps1
+    assert "([regex]::Matches($csContent, '(?m)^- \\[Category:')).Count" in ps1
+
+
 requires_windows = pytest.mark.skipif(
     sys.platform != "win32",
     reason="validate.ps1 is the native Windows validator; running it under Linux "

--- a/tests/guard/test_d2_3_lifecycle.py
+++ b/tests/guard/test_d2_3_lifecycle.py
@@ -5,6 +5,7 @@ Spec: docs/specs/lock-unification.md (AC-15..AC-20)
 
 from __future__ import annotations
 
+import concurrent.futures
 import sys
 import tempfile
 import unittest
@@ -91,6 +92,26 @@ class TestFrontmatterParsing(unittest.TestCase):
             f.write_text(VALID_FM)
             finding = lc.check_file(f, "docs/audit/doc.md")
             self.assertEqual(finding.severity, "PASS")
+
+    def test_parser_uses_unique_tempfile_not_source_sidecar(self) -> None:
+        source = (ROOT / ".agentcortex" / "tools" / "check_lifecycle_frontmatter.py").read_text(encoding="utf-8")
+
+        self.assertIn("mkstemp", source)
+        self.assertNotIn(".__fm_probe__", source)
+
+    def test_parallel_frontmatter_parse_does_not_race_on_sidecar(self) -> None:
+        with tempfile.TemporaryDirectory() as base_dir:
+            f = Path(base_dir) / "doc.md"
+            f.write_text(VALID_FM)
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+                results = list(executor.map(lambda _i: lc.parse_frontmatter(f), range(24)))
+
+            for raw, parsed in results:
+                self.assertIsNotNone(raw)
+                self.assertIsInstance(parsed, dict)
+                self.assertIn("lifecycle", parsed)
+            self.assertFalse(list(Path(base_dir).glob("*.__fm_probe__.yaml")))
 
     def test_missing_lifecycle_fails_when_recent(self) -> None:
         with tempfile.TemporaryDirectory() as base_dir:


### PR DESCRIPTION
## Summary
- Fix PowerShell Global Lessons count to use the regex match count instead of counting the single `Measure-Object` result.
- Fix lifecycle frontmatter parsing to use a unique temp `.yaml` file outside the repo, avoiding parallel validator races on a fixed `.__fm_probe__.yaml` sidecar.
- Add focused regression guards, including an actual parallel frontmatter-parse test.

## Evidence
- `python -m pytest tests/guard/test_d2_3_lifecycle.py -q` -> 16 passed
- `python -m pytest tests/guard/test_d2_3_lifecycle.py tests/ci/test_validator_false_positives.py::test_global_lessons_count_uses_match_count_in_ps1 -q` -> 17 passed
- `C:\Program Files\Git\bin\bash.exe .agentcortex/bin/validate.sh` -> `pass=102 warn=6 fail=0 skip=2`
- `powershell -ExecutionPolicy Bypass -File .agentcortex/bin/validate.ps1` -> `pass=102 warn=6 fail=0 skip=2`

## Notes
Generated with Codex.