### PR TITLE
docs(governance): intent-first startup pointer for Claude/Gemini

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 ## Startup (every conversation)
 
-1. Governance rules from `AGENTS.md` are loaded — follow them exactly.
+1. **At the start of a task, enter the governed flow in `AGENTS.md` before any file edit or completion claim — decide up front, not at the edit moment. No silent direct edits.**
 2. Classify task scope from the user's message:
    - `tiny-fix` (< 3 files, no semantic change) → skip to Step 5.
    - `quick-win` (1–2 modules, clear scope) → read SSoT (Step 3), skip Step 4.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -6,7 +6,7 @@
 
 ## Startup
 
-1. Load the shared instructions from `AGENTS.md`.
+1. **At the start of a task, enter the governed flow in `AGENTS.md` before any file edit or completion claim — decide up front, not at the edit moment. No silent direct edits.**
 2. Use `/memory show` when you need to inspect the active Gemini context.
 3. Use `/memory refresh` after this file or `AGENTS.md` changes during an active session.
 


### PR DESCRIPTION
## What
Reframe `CLAUDE.md` + `GEMINI.md` Startup step 1 from a passive statement to an **intent-first imperative pointer**.

```diff
-1. Governance rules from `AGENTS.md` are loaded — follow them exactly.   (CLAUDE.md)
-1. Load the shared instructions from `AGENTS.md`.                         (GEMINI.md)
+1. **At the start of a task, enter the governed flow in `AGENTS.md` before any file edit or completion claim — decide up front, not at the edit moment. No silent direct edits.**
```

## Why
A downstream Claude session shipped two PRs via silent direct edits — 0 classification, 0 gate block, no Work Log — while the framework was loaded (it still printed `⚡ ACX`). So AGENTS.md was *received* but the bootstrap→classify→gate flow was *selectively skipped*. The old line was passive ("rules are loaded") and edit-late; this makes step 1 an **intent-first, up-front** trigger aligned with `AGENTS.md` Runtime #1 (Intent-Driven Routing: map intent to phase **before any action**).

## Design constraints honored
- **Pure pointer** — no gate-block format (`gate:`/`classification:`/`verdict:`) or classification taxonomy embedded → top-layer adapters stay decoupled from mutable lower-layer detail (`Do NOT duplicate rules from AGENTS.md`).
- **No read-only carve-out** — avoids handing a skipper a self-justification; `/audit` (NO GATE), `/research`, `/brainstorm` are exempted by their own workflow routing, not by this line.
- **Cross-platform parity** — mirrored in both adapters; Codex (`prefix_rule`) and Antigravity (`rules.md`) already carry the equivalent imperative.
- Wording converged via a 3-lens expert review (instruction-following / governance-architecture / adversarial red-team).

## Honest scope
Soft / semantic reinforcement → raises adherence probability, **not** a guarantee. A claim-triggered Stop hook (independent hard layer) remains the deferred option if the silent-edit pattern recurs.

## Evidence
`validate.ps1`: **pass=102 warn=6 fail=0** (exit 0). The 6 WARNs are pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)