### PR TITLE
fix(deploy): back up + warn on locally-modified core overwrite; harden sha256 for backslash paths (#173)

### DIFF
--- a/.agentcortex/bin/deploy.sh
+++ b/.agentcortex/bin/deploy.sh
@@ -183,6 +183,12 @@ deploy_file() {
                 [ "$dst_hash" != "$src_hash" ] && locally_modified=true
             fi
             if $locally_modified && [ "$dst_hash" != "$src_hash" ]; then
+                # A backup MUST always overwrite a stale .acx-local. Unlike
+                # .acx-incoming (cleaned each run by clean_acx_incoming), the
+                # .acx-local backup persists, so a pre-existing one + a user-set
+                # CP_FLAG=-n/-i would make `cp` silently skip — losing the newest
+                # local edits. Remove first so the backup always lands.
+                rm -f "$dst.acx-local"
                 cp ${CP_FLAG:+"$CP_FLAG"} "$dst" "$dst.acx-local"
                 echo "  [OVERWRITE] $rel (core force-updated; your local edits backed up to $rel.acx-local)"
                 COUNT_CORE_OVERWRITTEN=$((COUNT_CORE_OVERWRITTEN + 1))
@@ -749,6 +755,7 @@ write_downstream_ignore_block() {
 # Deploy Artifacts
 .agentcortex-src/
 *.acx-incoming
+*.acx-local
 
 # Third-party AI Tool Local State
 .openrouter/
@@ -776,6 +783,7 @@ strip_managed_ignore_blocks() {
         managed[".agent/private/"] = 1
         managed[".agentcortex-src/"] = 1
         managed["*.acx-incoming"] = 1
+        managed["*.acx-local"] = 1
         managed[".openrouter/"] = 1
         managed[".claude-chat/"] = 1
         managed[".cursor/"] = 1

--- a/.agentcortex/bin/deploy.sh
+++ b/.agentcortex/bin/deploy.sh
@@ -44,14 +44,21 @@ COUNT_UPDATED=0
 COUNT_SKIPPED=0
 COUNT_NEW=0
 COUNT_REMOVED=0
+COUNT_CORE_OVERWRITTEN=0
 
 # --- SHA256 utility (cross-platform) ---
 compute_sha256() {
     local file="$1"
+    # NOTE: GNU sha256sum / BSD shasum escape filenames containing a backslash
+    # or newline by prefixing the output line with a literal '\' (and escaping
+    # the name). On Windows/Git Bash a backslash TARGET path (e.g. C:\proj)
+    # therefore yields "\<hash>", which silently breaks every dst-hash
+    # comparison (a clean repo path hashes without the prefix). Strip a leading
+    # backslash so the hash is comparable regardless of path style.
     if command -v sha256sum >/dev/null 2>&1; then
-        sha256sum "$file" | cut -d' ' -f1
+        sha256sum "$file" | cut -d' ' -f1 | sed 's/^\\//'
     elif command -v shasum >/dev/null 2>&1; then
-        shasum -a 256 "$file" | cut -d' ' -f1
+        shasum -a 256 "$file" | cut -d' ' -f1 | sed 's/^\\//'
     elif command -v openssl >/dev/null 2>&1; then
         openssl dgst -sha256 "$file" | awk '{print $NF}'
     else
@@ -159,7 +166,27 @@ deploy_file() {
         old_manifest_hash="$(manifest_lookup_hash "$rel")"
 
         if [ "$tier" = "core" ]; then
-            # Core: always overwrite
+            # Core: force-update (ADR-005 — governance/security fixes always land,
+            # no drift). But if the downstream locally modified this core file,
+            # back up their version to a .acx-local sidecar + warn before
+            # overwriting, so edits are recoverable instead of silently lost
+            # (#173). The force-update invariant is preserved — the new framework
+            # version still lands; only the silent-data-loss footgun is closed.
+            local dst_hash
+            dst_hash="$(compute_sha256 "$dst")"
+            local locally_modified=false
+            if [ -n "$old_manifest_hash" ]; then
+                [ "$dst_hash" != "$old_manifest_hash" ] && locally_modified=true
+            else
+                # Pre-manifest/legacy: no baseline to compare against; treat
+                # content that differs from the framework version as user content.
+                [ "$dst_hash" != "$src_hash" ] && locally_modified=true
+            fi
+            if $locally_modified && [ "$dst_hash" != "$src_hash" ]; then
+                cp ${CP_FLAG:+"$CP_FLAG"} "$dst" "$dst.acx-local"
+                echo "  [OVERWRITE] $rel (core force-updated; your local edits backed up to $rel.acx-local)"
+                COUNT_CORE_OVERWRITTEN=$((COUNT_CORE_OVERWRITTEN + 1))
+            fi
             cp ${CP_FLAG:+"$CP_FLAG"} "$src" "$dst"
             [ -n "$do_chmod" ] && chmod +x "$dst"
             COUNT_UPDATED=$((COUNT_UPDATED + 1))
@@ -919,7 +946,11 @@ echo ""
 echo "Agentic OS v${ACX_VERSION} (${SOURCE_COMMIT}) deployed successfully!"
 echo ""
 if $IS_UPDATE; then
-    echo "Summary: ${COUNT_UPDATED} updated / ${COUNT_SKIPPED} skipped / ${COUNT_NEW} new / ${COUNT_REMOVED} removed"
+    if [ "$COUNT_CORE_OVERWRITTEN" -gt 0 ]; then
+        echo "Summary: ${COUNT_UPDATED} updated (${COUNT_CORE_OVERWRITTEN} locally-modified core force-updated) / ${COUNT_SKIPPED} skipped / ${COUNT_NEW} new / ${COUNT_REMOVED} removed"
+    else
+        echo "Summary: ${COUNT_UPDATED} updated / ${COUNT_SKIPPED} skipped / ${COUNT_NEW} new / ${COUNT_REMOVED} removed"
+    fi
 else
     echo "Installed ${TOTAL_DEPLOYED} files."
 fi
@@ -930,6 +961,13 @@ if [ "$COUNT_SKIPPED" -gt 0 ]; then
     echo ""
     echo "  → Manual merge:  diff each pair, keep your content + adopt framework updates, then re-run deploy."
     echo "  → AI-assisted:   ask your AI agent — \"merge each *.acx-incoming into its target, preserving project-specific content and adopting framework updates, then delete the sidecars\""
+fi
+if [ "$COUNT_CORE_OVERWRITTEN" -gt 0 ]; then
+    echo ""
+    echo "⚠ ${COUNT_CORE_OVERWRITTEN} locally-modified core file(s) were force-updated (ADR-005)."
+    echo "  Your previous versions were backed up as *.acx-local sidecars."
+    echo "  Core files are framework-authoritative — re-apply needed tweaks via"
+    echo "  AGENTS.override.md (governance) or custom-* skills, not by editing core in place."
 fi
 echo ""
 echo "Platform Entry Points Ready:"

--- a/tests/ci/test_deploy_tiering.py
+++ b/tests/ci/test_deploy_tiering.py
@@ -124,6 +124,49 @@ def test_skill_edit_sidecars_and_core_rule_force_updates() -> None:
             "core rule edit must be overwritten by the framework version"
 
 
+@requires_bash
+def test_modified_core_rule_backs_up_to_acx_local_and_is_not_silent() -> None:
+    """#173: a locally-modified core file is force-updated (ADR-005 invariant),
+    but its previous version is backed up to a .acx-local sidecar and the
+    overwrite is surfaced in deploy output — never silently lost."""
+    with tempfile.TemporaryDirectory() as td:
+        target = Path(td) / "proj"
+        target.mkdir()
+
+        assert _deploy(target).returncode == 0
+        rule = target / ".agent" / "rules" / "engineering_guardrails.md"
+        assert rule.exists()
+
+        marker = "<!-- downstream core tweak 173 -->"
+        rule.write_text(rule.read_text(encoding="utf-8") + f"\n{marker}\n", encoding="utf-8")
+
+        second = _deploy(target)
+        assert second.returncode == 0, f"update failed:\n{second.stderr}"
+
+        backup = rule.with_name("engineering_guardrails.md.acx-local")
+        # The user's edit is recoverable from the .acx-local backup ...
+        assert backup.exists(), "modified core file must back up to .acx-local"
+        assert marker in backup.read_text(encoding="utf-8"), \
+            "the .acx-local backup must contain the user's edit"
+        # ... while the live file is force-updated (ADR-005 invariant preserved) ...
+        assert marker not in rule.read_text(encoding="utf-8"), \
+            "core rule must still be force-updated to the framework version"
+        # ... using .acx-local, NOT .acx-incoming (parity with the AC-5 contract).
+        assert not rule.with_name("engineering_guardrails.md.acx-incoming").exists()
+        # ... and the overwrite is NOT silent.
+        assert "acx-local" in second.stdout, \
+            "deploy must surface the core overwrite (non-silent)"
+
+        # Idempotency: a second update (file now matches framework) must NOT
+        # re-flag or create another backup.
+        backup.unlink()
+        third = _deploy(target)
+        assert third.returncode == 0
+        assert not backup.exists(), \
+            "unmodified core file must not be flagged as locally-modified"
+        assert "acx-local" not in third.stdout
+
+
 @requires_powershell
 def test_deploy_ps1_entrypoint_resolves_real_bash() -> None:
     with tempfile.TemporaryDirectory() as td:

--- a/tests/ci/test_deploy_tiering.py
+++ b/tests/ci/test_deploy_tiering.py
@@ -13,6 +13,7 @@ Structural tests guard the wiring/parity against silent deletion.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import tempfile
@@ -53,11 +54,12 @@ powershell = shutil.which("powershell") or shutil.which("pwsh")
 requires_powershell = pytest.mark.skipif(powershell is None, reason="PowerShell not available")
 
 
-def _deploy(target: Path) -> subprocess.CompletedProcess:
+def _deploy(target: Path, env: dict | None = None) -> subprocess.CompletedProcess:
+    run_env = {**os.environ, **env} if env else None
     return subprocess.run(
         [bash, str(DEPLOY_SH), str(target)],
         capture_output=True, text=True, encoding="utf-8", errors="replace",
-        cwd=str(ROOT),
+        cwd=str(ROOT), env=run_env,
     )
 
 
@@ -165,6 +167,42 @@ def test_modified_core_rule_backs_up_to_acx_local_and_is_not_silent() -> None:
         assert not backup.exists(), \
             "unmodified core file must not be flagged as locally-modified"
         assert "acx-local" not in third.stdout
+
+
+@requires_bash
+def test_core_backup_not_skipped_under_cp_flag_n() -> None:
+    """#173 regression: the .acx-local backup must ALWAYS land, even with
+    CP_FLAG=-n. .acx-local is never auto-cleaned, so a stale one + `cp -n`
+    would silently skip the backup and lose the newest local edits — exactly
+    the data loss this fix closes."""
+    with tempfile.TemporaryDirectory() as td:
+        target = Path(td) / "proj"
+        target.mkdir()
+        assert _deploy(target).returncode == 0
+        rule = target / ".agent" / "rules" / "engineering_guardrails.md"
+        backup = rule.with_name("engineering_guardrails.md.acx-local")
+        base = rule.read_text(encoding="utf-8")
+
+        # First local edit, then a no-clobber (CP_FLAG=-n) update creates .acx-local(A).
+        rule.write_text(base + "\n<!-- edit A -->\n", encoding="utf-8")
+        assert _deploy(target, env={"CP_FLAG": "-n"}).returncode == 0
+        assert backup.exists() and "edit A" in backup.read_text(encoding="utf-8")
+
+        # Second local edit, then another -n update. The stale backup must be
+        # replaced with edit B — NOT skipped by `cp -n`.
+        rule.write_text(base + "\n<!-- edit B -->\n", encoding="utf-8")
+        assert _deploy(target, env={"CP_FLAG": "-n"}).returncode == 0
+        bk = backup.read_text(encoding="utf-8")
+        assert "edit B" in bk, "newest local edits must be backed up, not skipped under CP_FLAG=-n"
+        assert "edit A" not in bk, "stale backup must be replaced, not retained"
+
+
+def test_deploy_gitignores_acx_local_sidecar() -> None:
+    """#173: the .acx-local backup is deploy-generated; it must be in the
+    managed downstream .gitignore block (parity with *.acx-incoming) so it
+    does not pollute the downstream working tree."""
+    s = DEPLOY_SH.read_text(encoding="utf-8")
+    assert "*.acx-local" in s, "deploy.sh must add *.acx-local to the managed .gitignore block"
 
 
 @requires_powershell


### PR DESCRIPTION
## Summary
Closes #173. On the deploy **UPDATE** path a downstream-locally-modified **core** file was silently overwritten — no warning, no backup, counted inside "N updated" — unlike scaffold-tier files which sidecar via `.acx-incoming`. Reproduced empirically.

Fix preserves the **ADR-005 force-update invariant** (the new framework version still lands) but, when the destination differs from the manifest baseline, backs up the user's prior version to a `.acx-local` sidecar, prints `[OVERWRITE]`, counts it, and surfaces a post-deploy notice — so edits are recoverable instead of silently lost.

## Root cause of a second (pre-existing) defect, found while testing
`compute_sha256` used `sha256sum "$file"`. GNU `sha256sum` / BSD `shasum` **escape filenames containing a backslash** by prefixing the output line with a literal `\`. A Windows/Git Bash backslash `TARGET` path (as `deploy.ps1` and subprocess callers pass, e.g. `C:\proj`) made every `dst` hash come back as `\<hash>` while repo-side `src` (`$REPO_ROOT`, forward-slash) hashed clean — silently mis-flagging **unmodified core AND scaffold** files as locally-modified on backslash-path deploys. Fixed by stripping a leading `\`. (My new idempotency test went 124 spurious overwrites → 0.)

## Scope
- `deploy.sh` only. `deploy.ps1` is a thin bash launcher (delegates to `deploy.sh`), so there is a single logic file — not "both" as the issue assumed.
- No ADR-005 amendment: the force-update decision boundary is unchanged (implementation hardening, not a reversal).

## Evidence
- Behavioral repro: core edit backed up to `.acx-local`, live file force-updated, scaffold preserved, **0 false positives over 180+ core files**, idempotent on re-update.
- New test `test_modified_core_rule_backs_up_to_acx_local_and_is_not_silent` + existing AC-5/AC-6 green — **deploy tiering suite 10 passed**.
- `pytest tests/ci tests/guard` → **199 passed**; `validate.sh` integrity check **passed**; `bash -n` OK.

## Rollback
Revert this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)