### PR TITLE
docs(readme): document validate.ps1 -NoPython in the Windows block

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,9 @@ powershell -ExecutionPolicy Bypass -File .\installers\deploy_brain.ps1 .
 powershell -ExecutionPolicy Bypass -File .\.agentcortex\bin\validate.ps1
 
 # Lightweight validation when Python is not installed
+powershell -ExecutionPolicy Bypass -File .\.agentcortex\bin\validate.ps1 -NoPython
+
+# (Git Bash equivalent)
 bash ./.agentcortex/bin/validate.sh --no-python
 ```
 


### PR DESCRIPTION
Adds the native PowerShell no-Python validation command to the README Windows `<details>` block, which previously only documented the Git Bash `validate.sh --no-python` form.

`validate.ps1` supports `-NoPython` (`param([switch]$NoPython)`), but passing `--no-python` to it is silently ignored — so Windows users had no documented native degraded-validation path.

**Verified**: `validate.ps1 -NoPython` → fail=0, skip=11 (vs skip=2 on a full run), confirming python checks are suppressed. README encoding-canary untouched (`validate.sh` README check PASS).

tiny-fix (docs-only, 3-line addition). Found via v1.4.0 downstream-simulation testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)