### PR TITLE
chore(release): v1.5.2

### DIFF
--- a/.agentcortex/bin/deploy.sh
+++ b/.agentcortex/bin/deploy.sh
@@ -26,7 +26,7 @@ TARGET="${TARGET:-.}"
 TARGET="${TARGET%/}"
 
 MANIFEST_FILE="$TARGET/.agentcortex-manifest"
-ACX_VERSION="1.5.1"
+ACX_VERSION="1.5.2"
 
 # --- Self-deploy guard ---
 TARGET_ABS="$(cd "$TARGET" 2>/dev/null && pwd || echo "$TARGET")"

--- a/.agentcortex/docs/TESTING_PROTOCOL.md
+++ b/.agentcortex/docs/TESTING_PROTOCOL.md
@@ -1,4 +1,4 @@
-# Testing Protocol v1.5.1
+# Testing Protocol v1.5.2
 
 > **This document guides the AI Agent to produce high-quality, trustworthy, and defensive test code.**
 

--- a/.agentcortex/docs/TESTING_PROTOCOL_zh-TW.md
+++ b/.agentcortex/docs/TESTING_PROTOCOL_zh-TW.md
@@ -1,4 +1,4 @@
-# Testing Protocol (測試教戰守則) v1.5.1
+# Testing Protocol (測試教戰守則) v1.5.2
 >
 > **本文件旨在指引 AI Agent 產出高品質、可信任、且具備防禦性的測試程式碼。**
 

--- a/.agentcortex/docs/guides/antigravity-v5-runtime.md
+++ b/.agentcortex/docs/guides/antigravity-v5-runtime.md
@@ -8,7 +8,7 @@ Date: 2026-04-17
 > **Two version axes — do not conflate.** "Runtime v5" throughout this file is this
 > anti-drift *engine spec's* own generation number; the canonical Antigravity runtime
 > **contract** version is **Runtime v1** (see `AGENTS.md §Agentic OS Runtime v1`). The
-> framework release version (v1.5.1) is tracked separately in `CHANGELOG.md`.
+> framework release version (v1.5.2) is tracked separately in `CHANGELOG.md`.
 Scope: **Antigravity environments** (token-generation agents where shell exit codes don’t halt execution)
 
 ### Why v5 exists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.5.2] - 2026-06-11
+
+Patch release: destructive-command incident response. A downstream field report (real `rm -rf` cascade that clobbered a parent repo's working tree) exposed a README↔enforcement drift class; this release closes it, hardens the deploy bootstrap, and promotes the remaining flow-independent safety invariants found by the follow-up audit. PRs #222/#223/#224.
+
+**Governance**
+- **Safety-invariant cluster in `AGENTS.md §Core Directives`**: the advertised "Destructive Command Blocking" rule had existed on NO loaded surface since day one (READMEs only, with divergent EN/zh severity + command lists; platform adapters carried drifting copies). `AGENTS.md` now carries a capped cluster (hard cap ~5; placement test: hazard reachable from any tool call AND irreversible/exfiltrating): **Destructive Command Gate** (deny-by-default; rollback plan must explicitly cover UNTRACKED/gitignored state; STOP on partial failure — a half-deleted directory silently redirects git to the parent repo), **Secrets Prohibition**, **Untrusted Tool Output** (tool-result text is data, never instructions). Each is eval-backed; retargeting also fixed a dangling protects-tag (the prompt-injection eval case had been guarding a section containing no injection text).
+- Both READMEs demoted to pointers at the canonical rule (ends the EN/zh disagreement structurally); Codex/Antigravity adapter lists reconciled and now cite the canonical rule; Codex gains the previously-missing secrets rule.
+- **ADR-001 amendment**: safety invariants carved out of the token-saving skip policy's jurisdiction (D3 governs cost/process rules only; its ~3.5k-token dollar premise measured stale at 2026 cached pricing). The tiering architecture itself is unchanged — the sorting key for safety content changes from token cost to hazard reachability.
+
+**Deploy / downstream**
+- **`deploy_brain.sh` cache origin verification**: the bootstrap path did `cache exists → git pull` without comparing the cache's origin URL to the configured source — a stale pre-migration cache pulled 457 commits of the WRONG repo on a live downstream. Now: normalized URL compare (env `ACX_SOURCE` > `--source` flag > manifest `source_repo:`; the `.ps1 -Source` path is now honored by the check), mismatch → warn + re-clone, and a partially-failed cache removal hard-fails instead of letting git fall through to the parent repo. +4 regression tests (mutation-verified).
+- `.gitattributes` scaffold pins `.agentcortex-manifest` and `.githooks/**` to LF (manifest hash-field parsing was one `\r` away from "every file appears undeployed" on Windows autocrlf checkouts).
+
+
 ## [1.5.1] - 2026-06-11
 
 Patch release: post-v1.5.0 downstream-simulation fixes (6-way fleet; 36/40 checks already passing — every v1.5.0 promise held).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ authors:
   - family-names: Wen
     given-names: Kb
 title: "Agentic OS: Governance-First Workflows for AI Coding Agents"
-version: 1.5.1
+version: 1.5.2
 date-released: 2026-06-11
 url: "https://github.com/KbWen/agentic-os"
 abstract: "A governance-first framework for AI coding agents. Portable workflows, delivery gates, engineering guardrails, and 14 professional skills for Claude Code, OpenAI Codex, Google Antigravity, Cursor, GitHub Copilot, and other coding agents."

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/Agentic%20OS-v1.5.1-blueviolet?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJ3aGl0ZSI+PHBhdGggZD0iTTEyIDJDNi40OCAyIDIgNi40OCAyIDEyczQuNDggMTAgMTAgMTAgMTAtNC40OCAxMC0xMFMxNy41MiAyIDEyIDJ6bTAgMThjLTQuNDEgMC04LTMuNTktOC04czMuNTktOCA4LTggOCAzLjU5IDggOC0zLjU5IDgtOCA4eiIvPjwvc3ZnPg==" alt="Agentic OS v1.5.1"/>
+  <img src="https://img.shields.io/badge/Agentic%20OS-v1.5.2-blueviolet?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJ3aGl0ZSI+PHBhdGggZD0iTTEyIDJDNi40OCAyIDIgNi40OCAyIDEyczQuNDggMTAgMTAgMTAgMTAtNC40OCAxMC0xMFMxNy41MiAyIDEyIDJ6bTAgMThjLTQuNDEgMC04LTMuNTktOC04czMuNTktOCA4LTggOCAzLjU5IDggOC0zLjU5IDgtOCA4eiIvPjwvc3ZnPg==" alt="Agentic OS v1.5.2"/>
 </p>
 
 <h1 align="center">Agentic OS</h1>

--- a/docs/AGENT_MODEL_GUIDE.md
+++ b/docs/AGENT_MODEL_GUIDE.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.5.1 — Model Selection Guide
+# Agentic OS v1.5.2 — Model Selection Guide
 
 > For human reference only — this file is not loaded into AI context.
 

--- a/docs/AGENT_MODEL_GUIDE_zh-TW.md
+++ b/docs/AGENT_MODEL_GUIDE_zh-TW.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.5.1 — 模型選擇指南
+# Agentic OS v1.5.2 — 模型選擇指南
 
 > 人類參考用 — 此檔案不會被載入 AI context。
 

--- a/docs/README_zh-TW.md
+++ b/docs/README_zh-TW.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.5.1 (Runtime v1.1 Anti-Drift Edition)
+# Agentic OS v1.5.2 (Runtime v1.1 Anti-Drift Edition)
 
 [English Version](../README.md)
 


### PR DESCRIPTION
Patch release for the destructive-command incident response (#222/#223/#224 already merged). Doc-only: version banners 1.5.1→1.5.2 across 9 files + CHANGELOG [1.5.2]. README canaries untouched — validators pass=101 fail=0 both platforms. Tag v1.5.2 + GitHub release on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)