### PR TITLE
chore(release): v1.5.3

### DIFF
--- a/.agentcortex/bin/deploy.sh
+++ b/.agentcortex/bin/deploy.sh
@@ -26,7 +26,7 @@ TARGET="${TARGET:-.}"
 TARGET="${TARGET%/}"
 
 MANIFEST_FILE="$TARGET/.agentcortex-manifest"
-ACX_VERSION="1.5.2"
+ACX_VERSION="1.5.3"
 
 # --- Self-deploy guard ---
 TARGET_ABS="$(cd "$TARGET" 2>/dev/null && pwd || echo "$TARGET")"

--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -12,9 +12,9 @@
   - Active Work Log Path: derive <worklog-key> from the raw branch name using filesystem-safe normalization before any gate checks.
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
 - **Project Name**: (set by /app-init)
-- **Last Updated**: 2026-06-13T12:58:15+08:00
+- **Last Updated**: 2026-06-13T13:20:00+08:00
 - **Last Verified**: 2026-06-13
-- **Update Sequence**: 63
+- **Update Sequence**: 64
 - **ADR Index**:
   - docs/adr/ADR-001-governance-friction-tuning.md — ADR-001: Governance Friction Tuning, accepted 2026-04-23
   - docs/adr/ADR-002-guarded-governance-writes.md — ADR-002: Guarded Governance Writes (lock unification + CI lint + lifecycle frontmatter), accepted 2026-04-25
@@ -91,6 +91,10 @@
 - [Category: rule-placement][Severity: HIGH][Trigger: authoring-safety-rule-or-auditing-rule-surfaces][prev: 3b15e10b] Sort SAFETY rules by hazard reachability, not token cost. A rule that must hold during a 30-second out-of-phase action (destructive commands, secrets, untrusted tool output) MUST live on the always-loaded surface (AGENTS.md Core Directives invariant cluster, cap ~5) - phase/tier-scoped files and platform adapters are probabilistic gates, and a probabilistic gate on an irreversible failure is a design error regardless of token savings. Confirmed 2026-06-11: 'Destructive Command Blocking' was advertised in both READMEs and machine-guarded in ADAPTER copies (validators checked Codex/Antigravity retained it!) while the canonical loaded surface had nothing - a downstream rm -rf cascade destroyed a parent repo working tree. Placement test for every new MUST: hazard reachable from any tool call AND irreversible/exfiltrating -> always-loaded; else phase surface is fine but README/docs must not claim it is always-on.
 - [Category: eval-mapping][Severity: MEDIUM][Trigger: adding-or-retargeting-eval-protects-tag][prev: 14ac98ca] An eval case can silently guard an EMPTY rule: protects-tags resolve at section level, so a case pointing at a section that contains no text for the behavior it tests still 'resolves' and scores green off the model's general training - verifier-without-defense, the inverse of advertised-but-unenforced. Confirmed 2026-06-11: prompt-injection-in-tool-output protected 'AGENTS.md Core Directives' which contained zero injection text for ~2 months. Discipline: when ADDING a rule, land the guarding case in the SAME commit; when ADDING/RETARGETING a case, quote the exact rule sentence it protects in the PR description - if you cannot quote it, the rule does not exist and the case is theatre.
 ## Ship History
+
+### Ship-chore-v1.5.3-release-2026-06-13
+- **Branch `chore/v1.5.3-release`** (quick-win, docs/release) — Patch **v1.5.3** covering since v1.5.2: token-lifecycle baseline + drift detector (issue #157, PR #233), pre-commit credential scanner (issue #225, PR #234), repo discoverability pass (#230), CI skip-heavy-on-docs (#231). Banners 1.5.2→1.5.3 across README badge, README_zh-TW, CITATION.cff, Model Guide EN+zh, Testing Protocol EN+zh, deploy.sh ACX_VERSION, antigravity-v5-runtime pointer; CHANGELOG `[1.5.3]`. README canaries untouched (line 8 verified). Tag `v1.5.3` + GitHub release on merge.
+- Tests: validators fail=0 CI-equiv; release is doc-only.
 
 ### Ship-feat-precommit-credential-scan-2026-06-13
 - **Branch `feat/precommit-credential-scan`** (quick-win, security/governance, issue #225 / backlog #71, commits `5445efc`→`a6f0f1c`→`b460c2f`) — High-confidence pre-commit credential scanner: a developer-convenience LOCAL catch for the AGENTS.md Secrets Prohibition invariant (CI TruffleHog remains the ENFORCED post-commit control). `.agentcortex/tools/scan_credentials.py` flags distinctive-prefix shapes (AWS AKIA, PEM key headers, GitHub ghp_/github_pat_, OpenAI sk-proj-/legacy-48, Slack xox, Google AIza) on the staged diff with REDACTED output (path:line + pattern name, never the value); wired into the opt-in `.githooks/pre-commit.guard-ssot.sample` (blocks on match, warns+continues on git error, skips when python absent). Honest framing: opt-in + `--no-verify`-bypassable → NOT a standalone machine gate (no "T1" overclaim).

--- a/.agentcortex/docs/TESTING_PROTOCOL.md
+++ b/.agentcortex/docs/TESTING_PROTOCOL.md
@@ -1,4 +1,4 @@
-# Testing Protocol v1.5.2
+# Testing Protocol v1.5.3
 
 > **This document guides the AI Agent to produce high-quality, trustworthy, and defensive test code.**
 

--- a/.agentcortex/docs/TESTING_PROTOCOL_zh-TW.md
+++ b/.agentcortex/docs/TESTING_PROTOCOL_zh-TW.md
@@ -1,4 +1,4 @@
-# Testing Protocol (測試教戰守則) v1.5.2
+# Testing Protocol (測試教戰守則) v1.5.3
 >
 > **本文件旨在指引 AI Agent 產出高品質、可信任、且具備防禦性的測試程式碼。**
 

--- a/.agentcortex/docs/guides/antigravity-v5-runtime.md
+++ b/.agentcortex/docs/guides/antigravity-v5-runtime.md
@@ -8,7 +8,7 @@ Date: 2026-04-17
 > **Two version axes — do not conflate.** "Runtime v5" throughout this file is this
 > anti-drift *engine spec's* own generation number; the canonical Antigravity runtime
 > **contract** version is **Runtime v1** (see `AGENTS.md §Agentic OS Runtime v1`). The
-> framework release version (v1.5.2) is tracked separately in `CHANGELOG.md`.
+> framework release version (v1.5.3) is tracked separately in `CHANGELOG.md`.
 Scope: **Antigravity environments** (token-generation agents where shell exit codes don’t halt execution)
 
 ### Why v5 exists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.5.3] - 2026-06-13
+
+Patch release: two additive governance/security guards (zero always-loaded prompt cost) plus CI and discoverability improvements. PRs #233 (issue #157), #234 (issue #225), #230, #231.
+
+**Governance / CI**
+- **Token-lifecycle baseline + drift detector** (#157): `update_lifecycle_baseline.py` stores a per-scenario governance token-cost baseline around the existing `analyze_token_lifecycle.py`, with a `--dry-run` drift check — growth beyond a 10% slack is flagged (advisory WARN in `validate.sh`/`.ps1`, hard teeth in a pytest ratchet); shrink is never punished. Catches slow per-PR governance-token creep that no existing test covered. ADR-006 native-baseline bumped with justification.
+- **Pre-commit credential scanner** (#225): `scan_credentials.py` flags distinctive-prefix credential shapes (AWS AKIA, PEM key headers, GitHub `ghp_`/`github_pat_`, OpenAI `sk-`, Slack `xox`, Google `AIza`) on the staged diff with redacted output, wired into the opt-in `.githooks` pre-commit hook (blocks on match, warns+continues on a git error). Honest framing: opt-in + `--no-verify`-bypassable, so CI TruffleHog remains the enforced control. A 4-expert review + dev-flow simulation hardened it — precise-only patterns (zero false positives on real code) and a hunk-context diff parser that closed a secret-dropping false negative.
+
+**Docs / discoverability**
+- Repo discoverability pass (#230): README `## FAQ`, root `llms.txt` (llmstxt.org convention), friendlier GitHub description + topics.
+- CI wall-clock (#231): docs-only PRs skip the heavy job matrix via a dependency-free scope detector; required checks and branch protection unchanged.
+
 ## [1.5.2] - 2026-06-11
 
 Patch release: destructive-command incident response. A downstream field report (real `rm -rf` cascade that clobbered a parent repo's working tree) exposed a README↔enforcement drift class; this release closes it, hardens the deploy bootstrap, and promotes the remaining flow-independent safety invariants found by the follow-up audit. PRs #222/#223/#224.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ authors:
   - family-names: Wen
     given-names: Kb
 title: "Agentic OS: Governance-First Workflows for AI Coding Agents"
-version: 1.5.2
+version: 1.5.3
 date-released: 2026-06-11
 url: "https://github.com/KbWen/agentic-os"
 abstract: "A governance-first framework for AI coding agents. Portable workflows, delivery gates, engineering guardrails, and 14 professional skills for Claude Code, OpenAI Codex, Google Antigravity, Cursor, GitHub Copilot, and other coding agents."

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/Agentic%20OS-v1.5.2-blueviolet?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJ3aGl0ZSI+PHBhdGggZD0iTTEyIDJDNi40OCAyIDIgNi40OCAyIDEyczQuNDggMTAgMTAgMTAgMTAtNC40OCAxMC0xMFMxNy41MiAyIDEyIDJ6bTAgMThjLTQuNDEgMC04LTMuNTktOC04czMuNTktOCA4LTggOCAzLjU5IDggOC0zLjU5IDgtOCA4eiIvPjwvc3ZnPg==" alt="Agentic OS v1.5.2"/>
+  <img src="https://img.shields.io/badge/Agentic%20OS-v1.5.3-blueviolet?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJ3aGl0ZSI+PHBhdGggZD0iTTEyIDJDNi40OCAyIDIgNi40OCAyIDEyczQuNDggMTAgMTAgMTAgMTAtNC40OCAxMC0xMFMxNy41MiAyIDEyIDJ6bTAgMThjLTQuNDEgMC04LTMuNTktOC04czMuNTktOCA4LTggOCAzLjU5IDggOC0zLjU5IDgtOCA4eiIvPjwvc3ZnPg==" alt="Agentic OS v1.5.3"/>
 </p>
 
 <h1 align="center">Agentic OS</h1>

--- a/docs/AGENT_MODEL_GUIDE.md
+++ b/docs/AGENT_MODEL_GUIDE.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.5.2 — Model Selection Guide
+# Agentic OS v1.5.3 — Model Selection Guide
 
 > For human reference only — this file is not loaded into AI context.
 

--- a/docs/AGENT_MODEL_GUIDE_zh-TW.md
+++ b/docs/AGENT_MODEL_GUIDE_zh-TW.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.5.2 — 模型選擇指南
+# Agentic OS v1.5.3 — 模型選擇指南
 
 > 人類參考用 — 此檔案不會被載入 AI context。
 

--- a/docs/README_zh-TW.md
+++ b/docs/README_zh-TW.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.5.2 (Runtime v1.1 Anti-Drift Edition)
+# Agentic OS v1.5.3 (Runtime v1.1 Anti-Drift Edition)
 
 [English Version](../README.md)
 


### PR DESCRIPTION
Patch release **v1.5.3** — covers everything merged since v1.5.2: #157 token-lifecycle drift detector (PR #233), #225 pre-commit credential scanner (PR #234), #230 discoverability, #231 CI skip-heavy.

Banners 1.5.2 → 1.5.3 across 9 files + CHANGELOG `[1.5.3]` + SSoT Ship History. README canaries untouched (text-integrity + encoding PASS); validators fail=0 CI-equivalent. Doc-only. Tag `v1.5.3` + GitHub release on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)