### PR TITLE
docs(security): refresh SECURITY.md supported versions to 1.5.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,5 +34,5 @@ Security issues in Agentic OS may include:
 
 | Version | Supported |
 |---------|-----------|
-| 1.2.x   | Yes       |
-| < 1.2   | No        |
+| 1.5.x   | Yes       |
+| < 1.5   | No        |


### PR DESCRIPTION
## Summary
Update the `SECURITY.md` **Supported Versions** table from the stale `1.2.x` to the current `1.5.x` line — the repo ships **v1.5.3** (`CHANGELOG.md`).

## Why
A vulnerability reporter on a current build would read the policy as their version being unsupported / out-of-scope, discouraging disclosure — the opposite of the file's intent. Keeps the existing single-supported-minor policy shape (`1.5.x` = Yes, `< 1.5` = No).

## Classification & evidence
- **tiny-fix** — docs-only, no semantic change, 1 file / 2 lines.
- `SECURITY.md` is **not** in the deploy manifest and **not** checked by `validate.sh` / `validate.ps1`.
- Verified no test / validator / cross-platform coupling — zero canary references to the version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)