### PR TITLE
chore(release): v1.5.4

### DIFF
--- a/.agentcortex/bin/deploy.sh
+++ b/.agentcortex/bin/deploy.sh
@@ -26,7 +26,7 @@ TARGET="${TARGET:-.}"
 TARGET="${TARGET%/}"
 
 MANIFEST_FILE="$TARGET/.agentcortex-manifest"
-ACX_VERSION="1.5.3"
+ACX_VERSION="1.5.4"
 
 # --- Self-deploy guard ---
 TARGET_ABS="$(cd "$TARGET" 2>/dev/null && pwd || echo "$TARGET")"

--- a/.agentcortex/docs/TESTING_PROTOCOL.md
+++ b/.agentcortex/docs/TESTING_PROTOCOL.md
@@ -1,4 +1,4 @@
-# Testing Protocol v1.5.3
+# Testing Protocol v1.5.4
 
 > **This document guides the AI Agent to produce high-quality, trustworthy, and defensive test code.**
 

--- a/.agentcortex/docs/TESTING_PROTOCOL_zh-TW.md
+++ b/.agentcortex/docs/TESTING_PROTOCOL_zh-TW.md
@@ -1,4 +1,4 @@
-# Testing Protocol (測試教戰守則) v1.5.3
+# Testing Protocol (測試教戰守則) v1.5.4
 >
 > **本文件旨在指引 AI Agent 產出高品質、可信任、且具備防禦性的測試程式碼。**
 

--- a/.agentcortex/docs/guides/antigravity-v5-runtime.md
+++ b/.agentcortex/docs/guides/antigravity-v5-runtime.md
@@ -8,7 +8,7 @@ Date: 2026-04-17
 > **Two version axes — do not conflate.** "Runtime v5" throughout this file is this
 > anti-drift *engine spec's* own generation number; the canonical Antigravity runtime
 > **contract** version is **Runtime v1** (see `AGENTS.md §Agentic OS Runtime v1`). The
-> framework release version (v1.5.3) is tracked separately in `CHANGELOG.md`.
+> framework release version (v1.5.4) is tracked separately in `CHANGELOG.md`.
 Scope: **Antigravity environments** (token-generation agents where shell exit codes don’t halt execution)
 
 ### Why v5 exists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.5.4] - 2026-06-14
+
+Patch release: downstream adaptability for heterogeneous flows/architectures (many custom skills, harness/subagent fan-out, other work-management flows), plus the cross-contributor credential CI hardening and a security-policy refresh. PRs #238 (ADR-007/008), #236 (#73/#74/#75), #237.
+
+**Governance / downstream adaptability** (#238 — ADR-007 + ADR-008)
+- **Downstream Capability Declaration Seam** (ADR-007): a present-only, opt-in, gate-capped `downstream-capabilities.yaml` (loaded at bootstrap §1b) lets a downstream register `custom-*` skills into auto-activation, declare a `subagent_policy`, and declare advisory `trackers`. Gate-relaxation is **structurally unrepresentable** — a denylist + allowlist schema validator (`validate_downstream_capabilities.py`) rejects, never clamps. Absent file = zero behavior change; the same-owner lock short-circuit was deferred as a Non-goal (`recover_worklog_lock.py` untouched).
+- **Portable Safety Floor** (ADR-008): the three always-loaded `AGENTS.md` safety invariants are fenced into a committed generated `.agentcortex/AGENTS.safety.md` nucleus (+ a validator freshness check) that any non-shim harness (Codex/Gemini/custom) can inject into every dispatched subagent. A **no-Python credential floor** (`credential_floor.sh`/`.ps1` — narrow FP-free AKIA/PEM/`ghp_` subset, redacted) is wired into the pre-commit hook so the "block secrets before object history" control works without Python; `scan_credentials.py` — previously absent from the deploy whitelist, a dead control downstream — is added as the richer python path.
+- Reviewed by 4 independent fresh-context agents (initial NOT READY → 4 fixes: dead `FAIL` arg → WARN honesty, denylist → allowlist, stale SSoT summaries, docstring → PASS). 30 new tests; full fast suite 307 passed; validators sh↔ps1 parity; ratchet 194/195. All additive + present-only.
+
+**Security / CI** (#236 — #73/#74/#75; #237)
+- **CI PR-diff credential scan** (#73): `scan_credentials.py --range base...head` in a `pull_request` job so contributors who never install the opt-in hook still get pre-merge secret protection (complements TruffleHog `--only-verified`), with a `# pragma: allowlist secret` escape + zero-sha/exit-3 fail-safe.
+- ShellCheck now lints `.githooks/*.sample` (#74); the opt-in hook's gitignored worklog-count check is WARN, not a hard FAIL that blocked every commit (#75).
+- `SECURITY.md` supported-versions refreshed to 1.5.x (#237); TruffleHog action bumped 3.95.3 → 3.95.5 (#174).
+
 ## [1.5.3] - 2026-06-13
 
 Patch release: two additive governance/security guards (zero always-loaded prompt cost) plus CI and discoverability improvements. PRs #233 (issue #157), #234 (issue #225), #230, #231.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ authors:
   - family-names: Wen
     given-names: Kb
 title: "Agentic OS: Governance-First Workflows for AI Coding Agents"
-version: 1.5.3
+version: 1.5.4
 date-released: 2026-06-11
 url: "https://github.com/KbWen/agentic-os"
 abstract: "A governance-first framework for AI coding agents. Portable workflows, delivery gates, engineering guardrails, and 14 professional skills for Claude Code, OpenAI Codex, Google Antigravity, Cursor, GitHub Copilot, and other coding agents."

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/Agentic%20OS-v1.5.3-blueviolet?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJ3aGl0ZSI+PHBhdGggZD0iTTEyIDJDNi40OCAyIDIgNi40OCAyIDEyczQuNDggMTAgMTAgMTAgMTAtNC40OCAxMC0xMFMxNy41MiAyIDEyIDJ6bTAgMThjLTQuNDEgMC04LTMuNTktOC04czMuNTktOCA4LTggOCAzLjU5IDggOC0zLjU5IDgtOCA4eiIvPjwvc3ZnPg==" alt="Agentic OS v1.5.3"/>
+  <img src="https://img.shields.io/badge/Agentic%20OS-v1.5.4-blueviolet?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJ3aGl0ZSI+PHBhdGggZD0iTTEyIDJDNi40OCAyIDIgNi40OCAyIDEyczQuNDggMTAgMTAgMTAgMTAtNC40OCAxMC0xMFMxNy41MiAyIDEyIDJ6bTAgMThjLTQuNDEgMC04LTMuNTktOC04czMuNTktOCA4LTggOCAzLjU5IDggOC0zLjU5IDgtOCA4eiIvPjwvc3ZnPg==" alt="Agentic OS v1.5.4"/>
 </p>
 
 <h1 align="center">Agentic OS</h1>

--- a/docs/AGENT_MODEL_GUIDE.md
+++ b/docs/AGENT_MODEL_GUIDE.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.5.3 — Model Selection Guide
+# Agentic OS v1.5.4 — Model Selection Guide
 
 > For human reference only — this file is not loaded into AI context.
 

--- a/docs/AGENT_MODEL_GUIDE_zh-TW.md
+++ b/docs/AGENT_MODEL_GUIDE_zh-TW.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.5.3 — 模型選擇指南
+# Agentic OS v1.5.4 — 模型選擇指南
 
 > 人類參考用 — 此檔案不會被載入 AI context。
 

--- a/docs/README_zh-TW.md
+++ b/docs/README_zh-TW.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.5.3 (Runtime v1.1 Anti-Drift Edition)
+# Agentic OS v1.5.4 (Runtime v1.1 Anti-Drift Edition)
 
 [English Version](../README.md)
 


### PR DESCRIPTION
Patch release **v1.5.4**. Banners 1.5.3->1.5.4 + CHANGELOG [1.5.4].

Covers since v1.5.3:
- #238 (ADR-007/008): downstream adaptability - capability declaration seam + portable safety floor + no-python credential floor.
- #236 (#73/#74/#75): CI PR-diff credential scan + ShellCheck .sample lint + worklog-count WARN.
- #237: SECURITY.md supported versions; #174: TruffleHog 3.95.3->3.95.5.

Tag v1.5.4 + GitHub release on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)