### PR TITLE
chore(backlog): archive 6 shipped rows to _product-backlog-archive.md

### DIFF
--- a/docs/specs/_product-backlog-archive.md
+++ b/docs/specs/_product-backlog-archive.md
@@ -3,7 +3,7 @@ status: archive
 title: Product Backlog — Completed Archive
 source: split out of _product-backlog.md (backlog item #8)
 created: 2026-06-02
-last_updated: 2026-06-09
+last_updated: 2026-06-15
 ---
 
 # Product Backlog — Completed Archive
@@ -59,3 +59,9 @@ living backlog still resolve here. Ship details: see Ship History in
 | 65 | Deletion-First Norm + ADD-gate signal tiering | framework | governance | P1 | docs/specs/deletion-first-add-gate.md | feature | Shipped | [#166](https://github.com/KbWen/agentic-os/issues/166) | #45 |
 | 48 | ~~Skill discovery linter + skill-cards.json index~~ — Cancelled (verified already-implemented: trigger-registry.yaml + trigger-compact-index.json + validate_trigger_metadata.py; issue #154 closure 2026-06-02; row desynced until 2026-06-10) | framework | skills | P2 | — | quick-win | Cancelled | [#154](https://github.com/KbWen/agentic-os/issues/154) | — |
 | 58 | ~~Downstream local_guardrails.md extension point~~ — Cancelled (redundant: ADR-004 override layer already provides the surface; issue #164 closed 2026-06-10 after expert verification; zero downstream demand signal) | framework | governance | P2 | — | quick-win | Cancelled | [#164](https://github.com/KbWen/agentic-os/issues/164) | — |
+| 14 | External Skill Research & Integration (Phase A: 3 core skills) | framework | skills | P2 | docs/specs/skill-research-integration.md | feature | Shipped | [#145](https://github.com/KbWen/agentic-os/issues/145) | — |
+| 51 | Token lifecycle baseline + drift detector | framework | ci | P2 | — | quick-win | Shipped | [#157](https://github.com/KbWen/agentic-os/issues/157) | — |
+| 71 | T1 pre-commit credential regex (secrets L2 machine layer; CI TruffleHog is post-commit backstop) | framework | governance | P2 | — | quick-win | Shipped | [#225](https://github.com/KbWen/agentic-os/issues/225) | — |
+| 73 | CI PR-diff credential scan (extend scan_credentials.py --staged to a --range base..head mode in a pull_request job → contributors who never install the opt-in hook still get pre-merge protection; the real cross-contributor T1) | review-finding | governance | P2 | — | quick-win | Shipped | — | #71 |
+| 74 | ShellCheck CI lints only `**/*.sh` so `.githooks/*.sample` is never linted; fix the glob to cover the hook samples | review-finding | ci | P2 | — | quick-win | Shipped | — | #71 |
+| 75 | Pre-commit hook dev-friendliness — the #192 hook gates every commit on the full validator; a gitignored, CI-invisible worklog-count FAIL blocked all commits. Shipped: worklog-count FAIL→WARN. Future dev-UX option: changed-files-scoped / advisory validator step in the hook (keep the #225 credential block hard) | review-finding | dx | P2 | — | quick-win | Shipped | — | #71 |

--- a/docs/specs/_product-backlog.md
+++ b/docs/specs/_product-backlog.md
@@ -36,26 +36,20 @@ Governance file bloat review (2026-04-12) identified 10 findings across P0–P2:
 | 7 | Domain Doc L2 superseded entry archival | framework | lifecycle | P2 | — | quick-win | Pending | [#142](https://github.com/KbWen/agentic-os/issues/142) | — |
 | 11 | Shipped specs accumulation — status-driven filtering | framework | lifecycle | P2 | — | quick-win | Pending | [#143](https://github.com/KbWen/agentic-os/issues/143) | #1 |
 | 13 | Warm→Cold LLM summarization pass in /ship | framework | lifecycle | P2 | — | feature | Pending | [#144](https://github.com/KbWen/agentic-os/issues/144) | #1, #3 |
-| 14 | External Skill Research & Integration (Phase A: 3 core skills) | framework | skills | P2 | docs/specs/skill-research-integration.md | feature | Shipped | [#145](https://github.com/KbWen/agentic-os/issues/145) | — |
 | 16 | Skill Validation Pipeline (meta-governance) | framework | skills | P2 | docs/specs/skill-research-integration.md | feature | Pending | [#146](https://github.com/KbWen/agentic-os/issues/146) | #14 |
 | 18 | Lightweight routing heuristics (decision tree in config.yaml, not a DSL) | framework | routing | P2 | — | quick-win | Pending | [#148](https://github.com/KbWen/agentic-os/issues/148) | — |
 | 21 | Skill cache timestamp + staleness invalidation | framework | skills | P2 | — | quick-win | Pending | [#149](https://github.com/KbWen/agentic-os/issues/149) | — |
 | 33 | Claude Code plugin packaging (.claude-plugin/plugin.json + bin/ + commands/agents/hooks bundling, no monitors) | dx | packaging | P2 | — | feature | Pending | [#150](https://github.com/KbWen/agentic-os/issues/150) | #30, #31 |
-| 51 | Token lifecycle baseline + drift detector | framework | ci | P2 | — | quick-win | Shipped | [#157](https://github.com/KbWen/agentic-os/issues/157) | — |
 | 70 | Export structured JSON Drift Log on ship for CI/CD audit trails | framework | governance | P2 | — | feature | Pending | [#193](https://github.com/KbWen/agentic-os/issues/193) | — |
-| 71 | T1 pre-commit credential regex (secrets L2 machine layer; CI TruffleHog is post-commit backstop) | framework | governance | P2 | — | quick-win | Shipped | [#225](https://github.com/KbWen/agentic-os/issues/225) | — |
 | 66 | Recommended-workflows advisory layer | framework | routing | P2 | — | feature | Pending | [#167](https://github.com/KbWen/agentic-os/issues/167) | — |
 | 67 | Canonical-doc-path gate + research-wiki sidecar | framework | governance | P2 | — | quick-win | Pending | [#168](https://github.com/KbWen/agentic-os/issues/168) | — |
 | 68 | Authority-map metadata (read-this-not-that resolver) | framework | governance | P2 | — | quick-win | Pending | [#169](https://github.com/KbWen/agentic-os/issues/169) | — |
 | 69 | RPI→QRSPI flow-adaptation study (alignment-side Q/D/S decomposition before Plan; strands A–E incl. governance load) | framework | governance | P1 | docs/specs/_research-rpi-qrspi-corroboration.md | feature | Pending | [#176](https://github.com/KbWen/agentic-os/issues/176) | #45, #65 |
 | 72 | zh-TW README FAQ mirror (parity with EN discoverability FAQ added in PR #230) | docs | i18n | P3 | — | quick-win | Pending | — | — |
-| 73 | CI PR-diff credential scan (extend scan_credentials.py --staged to a --range base..head mode in a pull_request job → contributors who never install the opt-in hook still get pre-merge protection; the real cross-contributor T1) | review-finding | governance | P2 | — | quick-win | Shipped | — | #71 |
-| 74 | ShellCheck CI lints only `**/*.sh` so `.githooks/*.sample` is never linted; fix the glob to cover the hook samples | review-finding | ci | P2 | — | quick-win | Shipped | — | #71 |
-| 75 | Pre-commit hook dev-friendliness — the #192 hook gates every commit on the full validator; a gitignored, CI-invisible worklog-count FAIL blocked all commits. Shipped: worklog-count FAIL→WARN. Future dev-UX option: changed-files-scoped / advisory validator step in the hook (keep the #225 credential block hard) | review-finding | dx | P2 | — | quick-win | Shipped | — | #71 |
 
 > Rows whose GH issue is CLOSED-premature (#7, #13, #18, #21, #33) are kept deliberately as
 > future directions — reopen the issue when a concrete signal appears (2026-06-02 curation).
-> Completed entries (#2, 4–6, 8–10, 12, 15, 19–20, 22–32, 34–44) are in [`_product-backlog-archive.md`](./_product-backlog-archive.md).
+> Completed entries (#2, 4–6, 8–10, 12, 14, 15, 19–20, 22–32, 34–44, 51, 71, 73–75) are in [`_product-backlog-archive.md`](./_product-backlog-archive.md).
 
 ## Status Key
 


### PR DESCRIPTION
## What

Backlog hygiene: move the 6 rows currently marked `Shipped` — **#14, #51, #71, #73, #74, #75** — out of the active `docs/specs/_product-backlog.md` into `docs/specs/_product-backlog-archive.md`.

## Why

The active file's own header is a contract: *"this index tracks only active (Pending / In Progress) work"* — Shipped/Cancelled entries belong in the archive. These 6 had accumulated in the active index (the validator also WARNs about shipped artifacts lingering). Pure relocation; entry numbers preserved so `#N` dependency refs still resolve in either file.

## Vetted

A 3-expert fresh-context panel (this session) independently ranked this the #1 clean **DELETE**-aligned action — no honor-system, no new surface, no parity obligations (no validator pins backlog rows; not a registry `detail_ref` → no compact-index regen; both files already tracked, not deploy-managed).

## Evidence (2 files, +8/−8)

- Active: `Shipped` rows now **0**; inventory 21 → 15; the 6 numbers absent.
- Archive: 6 rows present (10-col form matching recent precedent rows #56–61); footer enumeration + both `last_updated` updated.
- `validate.sh`: all backlog checks PASS (SSoT Active-Backlog consistency, structure, Status enum, spec links); CI-equiv `fail=0` (sole local FAIL = pre-existing gitignored work-log compaction).
- Rollback: revert PR (pure row relocation).
