### PR TITLE
fix(security): close ADR-007 capability-gate fail-open via strict mini-parser

### DIFF
--- a/.agentcortex/tools/validate_downstream_capabilities.py
+++ b/.agentcortex/tools/validate_downstream_capabilities.py
@@ -8,25 +8,206 @@ declares anything that could relax/escalate a gate (gate / ship-edge / block_if_
 / trigger_priority / concurrent-writer / blocking tracker).
 
   exit 0 = gate-safe (or absent / empty -> inert)
-  exit 1 = NOT gate-safe (reason on stderr)
-  exit 2 = malformed / unreadable
+  exit 1 = NOT gate-safe (a forbidden/over-cap field, reason on stderr)
+  exit 2 = MALFORMED / unsupported syntax -> fail-closed
 
-Parsed via the repo's `_yaml_loader` (PyYAML when installed, else a dependency-free
-subset). Cap-evasion via YAML anchors/aliases/merge-keys is caught regardless of parser:
-the recursive denylist + the top-level/skill-key ALLOWLIST reject the *resolved* keys,
-so the guarantee is structural, not a property of the parser. When Python is absent the
-validator is SKIPped by validate.* (run_python_check); the file is inert at runtime
-until an agent reads it, so this source/CI-side check is the machine guarantee.
+The file is parsed by a dedicated STRICT, dependency-free mini-parser (`parse_strict`),
+NOT the lenient shared `_yaml_loader`. The capabilities schema needs only a tiny block
+subset (block mappings/sequences, plain or simple-quoted scalars, and `[a, b]` flow
+sequences of plain scalars); `parse_strict` accepts ONLY that and RAISES on EVERYTHING
+else - flow mappings `{}`, anchors `&`, aliases `*`, tags `!`, merge keys `<<`, explicit
+keys `?`, backslash escapes, block scalars `>`/`|`, inline comments, tabs, multi-doc
+markers, and ANY misaligned indentation. This flips the security argument from a denylist
+of dangerous syntax (whack-a-mole, the source of repeated fail-opens) to an ALLOWLIST of
+permitted syntax: any construct that could make the parser's resolved keys diverge from a
+spec parser is a hard syntax error, so a forbidden key cannot hide behind parser leniency.
+The shared `_yaml_loader` (which legitimately serves trigger-registry.yaml, where tokens
+like `trigger_priority` are valid data) is intentionally NOT used or modified here -> zero
+blast radius on its ~20 other consumers.
 """
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-try:
-    import _yaml_loader
-except Exception as exc:  # pragma: no cover - deployed alongside in runtime_tools
-    sys.stderr.write("ERROR: _yaml_loader unavailable (%s)\n" % exc)
-    sys.exit(2)
+
+# ---------------------------------------------------------------------------
+# Strict capabilities-grammar parser (dependency-free, fail-closed by default)
+# ---------------------------------------------------------------------------
+
+class _StrictError(ValueError):
+    """Raised on any syntax outside the minimal capabilities grammar (fail-closed)."""
+
+
+def _coerce(scalar):
+    if scalar in ("true", "false"):
+        return scalar == "true"
+    if scalar in ("null", "~"):
+        return None
+    try:
+        return int(scalar)
+    except ValueError:
+        return scalar
+
+
+# characters that introduce YAML features the strict grammar refuses to interpret
+_DISALLOWED = ("{", "}", "&", "*", "!", "\\", "#", "<", ">", "|", "?")
+
+
+def _strict_quoted(tok, lineno):
+    q = tok[0]
+    if len(tok) < 2 or tok[-1] != q:
+        raise _StrictError("unterminated/mismatched quote (line %d): %r" % (lineno, tok))
+    inner = tok[1:-1]
+    if "\\" in inner or q in inner:
+        raise _StrictError("escapes / embedded quotes not allowed (line %d): %r" % (lineno, tok))
+    return inner
+
+
+def _strict_plain(tok, lineno):
+    if not tok:
+        raise _StrictError("empty scalar (line %d)" % lineno)
+    if any(c in tok for c in _DISALLOWED) or "[" in tok or "]" in tok or ":" in tok:
+        raise _StrictError("unsupported plain scalar (line %d): %r" % (lineno, tok))
+    return _coerce(tok)
+
+
+def _strict_atom(tok, lineno):
+    """A flow-sequence element or a simple scalar: plain or simple-quoted only."""
+    tok = tok.strip()
+    if tok[:1] in ("'", '"'):
+        return _strict_quoted(tok, lineno)
+    return _strict_plain(tok, lineno)
+
+
+def _strict_value(tok, lineno):
+    tok = tok.strip()
+    if tok in (">", "|"):
+        raise _StrictError("block scalars not allowed (line %d)" % lineno)
+    if tok[:1] in ("'", '"'):
+        return _strict_quoted(tok, lineno)
+    if tok[:1] == "[":
+        if not tok.endswith("]"):
+            raise _StrictError("malformed flow sequence (line %d): %r" % (lineno, tok))
+        inner = tok[1:-1].strip()
+        if not inner:
+            return []
+        return [_strict_atom(p, lineno) for p in inner.split(",")]
+    return _strict_plain(tok, lineno)
+
+
+def _strict_key(tok, lineno):
+    tok = tok.strip()
+    if tok[:1] in ("'", '"'):
+        return _strict_quoted(tok, lineno)
+    if tok == "<<":
+        raise _StrictError("merge keys not allowed (line %d)" % lineno)
+    if any(c in tok for c in _DISALLOWED) or "[" in tok or "]" in tok or ":" in tok or "," in tok:
+        raise _StrictError("unsupported key (line %d): %r" % (lineno, tok))
+    return tok
+
+
+def _colon_index(s):
+    """Index of the key/value-separating ':' (followed by space or EOL), ignoring
+    colons inside quotes. -1 if none."""
+    q = None
+    for i, c in enumerate(s):
+        if q is not None:
+            if c == q:
+                q = None
+        elif c in ("'", '"'):
+            q = c
+        elif c == ":" and (i + 1 >= len(s) or s[i + 1] == " "):
+            return i
+    return -1
+
+
+def parse_strict(text):
+    """Parse the minimal capabilities grammar. Raise _StrictError on anything else."""
+    toks = []  # (indent, content, lineno)
+    for lineno, raw in enumerate(text.splitlines(), 1):
+        if "\t" in raw:
+            raise _StrictError("tab character not allowed (line %d)" % lineno)
+        s = raw.strip()
+        if not s or s.startswith("#"):
+            continue
+        if s in ("---", "..."):
+            raise _StrictError("document markers / multi-doc not allowed (line %d)" % lineno)
+        indent = len(raw) - len(raw.lstrip(" "))
+        toks.append((indent, s, lineno))
+    if not toks:
+        return {}
+    idx = [0]
+    result = _parse_block(toks, idx, toks[0][0])
+    if idx[0] != len(toks):
+        raise _StrictError("misaligned indentation (line %d)" % toks[idx[0]][2])
+    return result
+
+
+def _parse_block(toks, idx, base):
+    return _parse_seq(toks, idx, base) if toks[idx[0]][1].startswith("- ") else _parse_map(toks, idx, base)
+
+
+def _parse_map(toks, idx, base):
+    out = {}
+    while idx[0] < len(toks):
+        ind, s, lineno = toks[idx[0]]
+        if ind < base:
+            break
+        if ind > base:
+            raise _StrictError("misaligned indentation (line %d)" % lineno)
+        if s.startswith("- "):
+            raise _StrictError("sequence item in mapping context (line %d)" % lineno)
+        ci = _colon_index(s)
+        if ci < 0:
+            raise _StrictError("expected 'key: value' (line %d): %r" % (lineno, s))
+        key = _strict_key(s[:ci], lineno)
+        if key in out:
+            raise _StrictError("duplicate key %r (line %d)" % (key, lineno))
+        rest = s[ci + 1:].strip()
+        idx[0] += 1
+        if rest == "":
+            if idx[0] < len(toks) and toks[idx[0]][0] > base:
+                out[key] = _parse_block(toks, idx, toks[idx[0]][0])
+            else:
+                out[key] = {}
+        else:
+            out[key] = _strict_value(rest, lineno)
+    return out
+
+
+def _parse_seq(toks, idx, base):
+    out = []
+    while idx[0] < len(toks):
+        ind, s, lineno = toks[idx[0]]
+        if ind < base:
+            break
+        if ind > base:
+            raise _StrictError("misaligned indentation (line %d)" % lineno)
+        if not s.startswith("- "):
+            raise _StrictError("expected '- item' (line %d): %r" % (lineno, s))
+        content = s[2:].strip()
+        item_indent = base + 2
+        sub = [(item_indent, content, lineno)]
+        idx[0] += 1
+        while idx[0] < len(toks) and toks[idx[0]][0] > base:
+            ti, ts, tl = toks[idx[0]]
+            if ti < item_indent:
+                raise _StrictError("misaligned indentation (line %d)" % tl)
+            sub.append((ti, ts, tl))
+            idx[0] += 1
+        if _colon_index(content) >= 0 or len(sub) > 1:
+            si = [0]
+            item = _parse_map(sub, si, item_indent)
+            if si[0] != len(sub):
+                raise _StrictError("misaligned indentation (line %d)" % sub[si[0]][2])
+            out.append(item)
+        else:
+            out.append(_strict_value(content, lineno))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Schema gate-safety checks (run on the strictly-parsed structure)
+# ---------------------------------------------------------------------------
 
 ALLOWED_LOAD_POLICY = {"on-match"}
 ALLOWED_SUBAGENT_POLICY = {"read-only", "governed"}
@@ -98,8 +279,13 @@ def main():
     if not path.exists():
         return 0  # absent = inert = safe (present-only)
     try:
-        data = _yaml_loader.load_data(path)
-    except Exception as exc:
+        data = parse_strict(path.read_text(encoding="utf-8"))
+    except _StrictError as exc:
+        # Unsupported syntax in a capabilities file -> cannot be safely interpreted.
+        # Fail closed (exit 2) rather than risk a parser-divergence gate-relaxation.
+        sys.stderr.write("MALFORMED: downstream-capabilities.yaml uses unsupported syntax - %s\n" % exc)
+        return 2
+    except Exception as exc:  # pragma: no cover - defensive
         sys.stderr.write("MALFORMED: cannot parse %s (%s)\n" % (path, exc))
         return 2
     reason = validate(data)

--- a/tests/guard/test_capabilities_schema_gate_safety.py
+++ b/tests/guard/test_capabilities_schema_gate_safety.py
@@ -77,3 +77,87 @@ def test_unsafe_file_is_rejected_not_clamped(tmp_path, body, needle):
     r = _check(tmp_path, body)
     assert r.returncode == 1, f"must REJECT (not clamp) {body!r} -> rc={r.returncode}, err={r.stderr!r}"
     assert needle in r.stderr, f"reason must name {needle!r}: {r.stderr!r}"
+
+
+# --- Strict capabilities grammar (parse_strict) -------------------------------
+# The validator parses with a dedicated STRICT allowlist mini-parser, NOT the shared
+# lenient _yaml_loader and NOT PyYAML -- so behaviour is identical with or without
+# PyYAML installed (no shadow harness needed). The security argument is an ALLOWLIST of
+# syntax: a forbidden key in plain/simple-quoted form is RESOLVED and caught by the
+# denylist (rc 1); a forbidden key hidden behind ANY exotic syntax the grammar refuses
+# to interpret is a hard syntax error (rc 2, fail-closed) and can never reach a gate-safe
+# verdict. Three review rounds found flow-map / quoted-key / flow-seq-k:v / mismatched-
+# quote / double-quoted-escape / silent-drop-misindent fail-opens; the strict grammar
+# closes all of them by construction.
+
+_RICH_SAFE = """\
+version: 1
+skills:
+  - id: custom-tf
+    load_policy: on-match
+    phase_scope: [implement, review]
+    detect_by:
+      classification: [feature]
+    description: "validates, formats: and lints"
+subagent_policy: governed
+trackers:
+  - id: custom-jira
+    skill: custom-jira-sync
+"""
+
+
+def test_strict_parser_accepts_rich_safe_file(tmp_path):
+    # Nested detect_by mapping, a flow-sequence, and a quoted value CONTAINING ':' and
+    # ',' must all parse and be gate-safe (no false positive).
+    r = _check(tmp_path, _RICH_SAFE)
+    assert r.returncode == 0, f"rich safe file must pass: {r.stderr!r}"
+
+
+@pytest.mark.parametrize("body,needle", [
+    ("trackers:\n  - id: custom-j\n    blocking: true\n", "blocking"),                  # plain block
+    ("version: 1\ntrackers:\n  - 'blocking': true\n", "blocking"),                      # simple single-quote key
+    ('version: 1\ntrackers:\n  - "gate": ship\n', "gate"),                              # simple double-quote key
+    ("skills:\n  - id: custom-x\n    detect_by:\n      ship_edge: x\n", "ship_edge"),   # nested key
+    ("trigger_priority: hard\n", "trigger_priority"),                                   # top-level
+])
+def test_forbidden_key_in_clean_syntax_rejected(tmp_path, body, needle):
+    # Cleanly-parseable forbidden key -> RESOLVED -> denylist -> rc 1 naming the key.
+    r = _check(tmp_path, body)
+    assert r.returncode == 1, f"forbidden key must reject: rc={r.returncode}, err={r.stderr!r}"
+    assert needle in r.stderr, f"reason must name {needle!r}: {r.stderr!r}"
+
+
+@pytest.mark.parametrize("body", [
+    "version: 1\ntrackers:\n  - {id: x, blocking: true}\n",                             # flow mapping
+    "version: 1\ntrackers:\n  - {worklog_writers: all}\n",                              # flow mapping
+    'version: 1\ntrackers:\n  - "\\x62\\x6c\\x6f\\x63\\x6b\\x69\\x6e\\x67": true\n',     # \\x escape -> blocking
+    'version: 1\ntrackers:\n  - "\\u0067ate": ship\n',                                  # \\u escape -> gate
+    "version: 1\ntrackers:\n  - phase_scope: [blocking: true]\n",                       # flow-seq k:v
+    "version: 1\ntrackers:\n  - 'blocking: true\n",                                     # unterminated quote
+    "version: 1\ntrackers:\n  - id: custom-x\n     blocking: true\n",                   # silent-drop misindent (5sp)
+    "version: 1\ntrackers:\n  - id: &a custom-x\n",                                     # anchor
+    "version: 1\ntrackers:\n  - !!str gate: ship\n",                                    # tag
+    "version: 1\ntrackers:\n  - <<: x\n",                                               # merge key
+    "version: 1\ntrackers:\n  - ? blocking\n    : true\n",                              # explicit key
+    "version: 1\nskills:\n  - id: custom-x\n    description: >\n      blocking: true\n", # block scalar
+    "version: 1\ntrackers:\n\t- blocking: true\n",                                      # tab indentation
+])
+def test_unsupported_syntax_fails_closed(tmp_path, body):
+    # Any syntax outside the minimal grammar -> hard syntax error (rc 2). A forbidden key
+    # can never reach a gate-safe verdict by hiding behind exotic syntax.
+    r = _check(tmp_path, body)
+    assert r.returncode == 2, (
+        f"unsupported syntax must fail-closed (rc 2): rc={r.returncode}, "
+        f"out={r.stdout!r}, err={r.stderr!r}")
+
+
+@pytest.mark.parametrize("body", [
+    'skills:\n  - id: custom-x\n    description: "first, gate: second"\n',
+    'skills:\n  - id: custom-x\n    description: "a hard: limit, gates: ok"\n',
+    'trackers:\n  - id: custom-x\n    note: "blocking: only in prose"\n',
+])
+def test_forbidden_token_inside_value_is_not_false_positive(tmp_path, body):
+    # A forbidden WORD inside a quoted VALUE (not a key) is gate-safe. The old raw-text
+    # scan false-rejected these; the strict parser resolves them correctly -> no FP.
+    r = _check(tmp_path, body)
+    assert r.returncode == 0, f"forbidden token in a value must NOT false-reject: {r.stderr!r}"


### PR DESCRIPTION
## Security fix — ADR-007 capability-gate fail-open

### What it guards
`downstream-capabilities.yaml` lets a downstream repo opt-in to declare its own `custom-*` skills, `subagent_policy`, and advisory `trackers` — extending the framework without forking. `validate_downstream_capabilities.py` is the **gate that makes governance-relaxation UNREPRESENTABLE**: a downstream cannot use that file to smuggle in gate-relaxing directives (`blocking`, `gate`, `ship_edge`, `worklog_writers`, `block_if_missed`, `trigger_priority: hard`, …) that would weaken the framework's review/ship gates.

### The bug
Under the **no-PyYAML CI env** (the branch-protection-required *Framework Validation* jobs run `setup-python` + `validate.sh` with no `pip install`), the validator parsed with the **lenient shared `_yaml_loader` subset parser**, which structures input differently than a spec parser. Four independent fresh-context review rounds found **six distinct fail-open vectors** where a forbidden key slipped past the denylist (validator → exit 0 gate-safe, while real PyYAML rejects):

1. flow mapping `{id: x, blocking: true}`
2. quoted key `'blocking': true`
3. flow-sequence `[blocking: true]`
4. mismatched/unterminated quote `'blocking: true`
5. double-quoted backslash-escape `"\x62locking": true` (PyYAML decodes → `blocking`)
6. silent-drop misindentation (the parser drops lines it can't place; PyYAML errors)

### The fix (design-panel-chosen)
A 3-expert design panel diagnosed the root cause — the shared `_yaml_loader` serves two opposite masters (`trigger-registry.yaml`, where tokens like `trigger_priority` are *legal data*, vs capabilities, where they're *forbidden*) — and recommended decoupling.

Replace the lenient-parser dependence with a **dedicated STRICT allowlist mini-parser** (`parse_strict`) scoped to the capabilities file. It accepts ONLY the minimal block subset the schema needs (block mappings/sequences, plain + simple-quoted scalars, `[a, b]` plain flow-sequences) and **raises on EVERYTHING else** (flow maps, anchors, aliases, tags, merge keys, explicit keys, escapes, block scalars, inline comments, tabs, multi-doc markers, duplicate keys, and any misaligned indentation). **Allowlist, not denylist → fail-closed on any unforeseen syntax by construction** (the six vectors close at once; no whack-a-mole).

- **Decoupled** from the shared `_yaml_loader` (reverted to `main` — **zero blast radius** on its ~20 other consumers) and from **PyYAML** (dependency-free, preserving the ADR-008 no-python doctrine).
- No new file → no deploy-whitelist change.

### Evidence
- **38** capability-gate tests (schema + reject-not-clamp + 5 clean-forbidden→rc1 + **13 exotic-syntax→rc2 fail-closed** + 3 value-not-FP→rc0).
- Full fast suite **503 passed, 0 regressions**.
- 4th-round **differential fuzz: 1,143,072 cases vs PyYAML + 4,536 subprocess cases → 0 fail-open leaks, 0 crashes, 0 hangs.**
- Independent confirm: `parse_strict ≡ PyYAML` structure on accepted docs (so `validate()` runs on real data, not accidentally-empty).
- `validate.sh`: `[PASS] downstream-capabilities gate-safety`; CI-equiv `fail=0` (local FAILs are gitignored work-log hygiene, CI-invisible).

### Impact / scope
- **Source repo & framework runtime: none** — the file is present-only (absent here → exit 0 inert).
- **Downstream: bounded runtime risk today** (ADR-007 trackers are advisory; no shipped consumer honors a smuggled key) → this restores a **source/CI-side defense-in-depth guarantee** the framework advertises, and forecloses the vector if a future runtime consumer starts honoring these keys.
- **Authoring change**: a capabilities file must use simple YAML (quote values containing special chars; no inline comments) — fail-closed with a line+reason message. (Optional follow-up: a one-line author note in ADR-007.)

Rollback: revert PR (single validator file + test; `_yaml_loader` already at `main`).
