### PR TITLE
chore(archive): fix archived gate receipt schema

### DIFF
--- a/.agentcortex/context/archive/main-20260615.md
+++ b/.agentcortex/context/archive/main-20260615.md
@@ -207,7 +207,7 @@ none
 - Local validator note: local `validate.ps1` on the working tree failed only on gitignored active Work Log compaction (`arch-safety-floor-credential-hardening.md` 142 lines / 30KB), not on tracked release content.
 - Downstream update simulation: temp v1.5.3 source deployed, then v1.5.4 source re-deployed; manifest upgraded 1.5.3 -> 1.5.4; `AGENTS.safety.md`, `scan_credentials.py`, `credential_floor.sh`, `credential_floor.ps1`, `validate_downstream_capabilities.py` present; customized scaffold skill preserved via `.acx-incoming`; private `downstream-capabilities.yaml` not shipped.
 - Fresh downstream no-python simulation: deployed v1.5.4 to temp repo; downstream `validate.sh --no-python` -> pass=75 warn=2 fail=0 skip=11; downstream `validate.ps1 -NoPython` -> pass=75 warn=2 fail=0 skip=11.
-- Gate: review | Verdict: NOT READY | Transition: REVIEWED→IMPLEMENTING | Timestamp: 2026-06-14T00:00:00+08:00
+- Gate: review | Verdict: NOT READY | Classification: quick-win | Transition: REVIEWED→IMPLEMENTING | Timestamp: 2026-06-14T00:00:00+08:00
 
 ## Implement/Test 2026-06-14 Capability Ceiling Fix
 


### PR DESCRIPTION
## Summary
- Add missing Classification field to the archived NOT READY gate receipt in main-20260615.md

## Verification
- git diff --check
- python .agentcortex/tools/scan_credentials.py --range HEAD~0..HEAD --staged
- powershell -ExecutionPolicy Bypass -File .agentcortex/bin/validate.ps1
- bash .agentcortex/bin/validate.sh