### PR TITLE
[codex] fix process simulation gaps

### DIFF
--- a/.agentcortex/bin/deploy.sh
+++ b/.agentcortex/bin/deploy.sh
@@ -723,6 +723,16 @@ if $DRY_RUN; then
     # Enumerate only the files that are actually deployed (mirrors real deploy logic).
     # Runtime Python tools are a whitelist — NOT all *.py in tools/.
     _runtime_tools="guard_context_write.py _yaml_loader.py check_command_sync.py check_text_integrity.py check_text_integrity.ps1 text_integrity_baseline.txt sync_skills.sh lint_governed_writes.py check_lifecycle_frontmatter.py check_lesson_chain.py check_adr_coverage.py append_chain_entry.py append_lesson.py recover_worklog_lock.py lint_spec_drift.py run_governance_eval.py scan_credentials.py credential_floor.sh credential_floor.ps1 generate_safety_nucleus.py validate_downstream_capabilities.py"
+    _dry_print_file() {
+        local src="$1"
+        local rel="$2"
+        [ -f "$src" ] || return 0
+        _dry_count=$((_dry_count + 1))
+        _get_tier_inline "$rel"
+        local status="[NEW]   "
+        [ -f "$TARGET/$rel" ] && status="[UPDATE]"
+        printf '  %s %-10s %s\n' "$status" "($_TIER)" "$rel"
+    }
     for f in "$REPO_ROOT"/AGENTS.md "$REPO_ROOT"/CLAUDE.md "$REPO_ROOT"/GEMINI.md \
              "$REPO_ROOT"/.gitattributes \
              "$REPO_ROOT"/installers/deploy_brain.sh "$REPO_ROOT"/installers/deploy_brain.ps1 "$REPO_ROOT"/installers/deploy_brain.cmd \
@@ -738,34 +748,16 @@ if $DRY_RUN; then
              "$REPO_ROOT"/.claude/agents/*.md \
              "$REPO_ROOT"/.codex/INSTALL.md \
              "$REPO_ROOT"/.github/ISSUE_TEMPLATE/*.md "$REPO_ROOT"/.github/PULL_REQUEST_TEMPLATE.md; do
-        [ -f "$f" ] || continue
-        _dry_count=$((_dry_count + 1))
-        _bname="$(basename "$f")"
-        if [ -f "$TARGET/$_bname" ] || [ -f "$TARGET/.agent/rules/$_bname" ]; then
-            echo "  [UPDATE] $_bname"
-        else
-            echo "  [NEW]    $_bname"
-        fi
+        _dry_print_file "$f" "${f#$REPO_ROOT/}"
     done
     # Runtime tools (whitelist only — not all *.py)
     for _bname in $_runtime_tools; do
         f="$REPO_ROOT/.agentcortex/tools/$_bname"
-        [ -f "$f" ] || continue
-        _dry_count=$((_dry_count + 1))
-        if [ -f "$TARGET/.agentcortex/tools/$_bname" ]; then
-            echo "  [UPDATE] $_bname"
-        else
-            echo "  [NEW]    $_bname"
-        fi
+        _dry_print_file "$f" ".agentcortex/tools/$_bname"
     done
     # ADR-008 portable safety nucleus (core tier; deployed to .agentcortex/AGENTS.safety.md)
     if [ -f "$REPO_ROOT/.agentcortex/AGENTS.safety.md" ]; then
-        _dry_count=$((_dry_count + 1))
-        if [ -f "$TARGET/.agentcortex/AGENTS.safety.md" ]; then
-            echo "  [UPDATE] AGENTS.safety.md"
-        else
-            echo "  [NEW]    AGENTS.safety.md"
-        fi
+        _dry_print_file "$REPO_ROOT/.agentcortex/AGENTS.safety.md" ".agentcortex/AGENTS.safety.md"
     fi
     # Skills (summarise counts instead of listing every file)
     _skill_count=0
@@ -775,18 +767,18 @@ if $DRY_RUN; then
             < <(find "$skill_dir" -type f -print0)
     done
     for sf in "$REPO_ROOT"/.agent/skills/*; do [ -f "$sf" ] && _skill_count=$((_skill_count + 1)); done
-    [ "$_skill_count" -gt 0 ] && echo "  [NEW]    ... $_skill_count skill files (.agent/skills/, .agents/skills/)"
+    [ "$_skill_count" -gt 0 ] && echo "  [NEW]    (mixed)    ... $_skill_count skill files under .agent/skills/ and .agents/skills/"
     # Docs (summarise)
     _doc_count=0
     for df in "$REPO_ROOT"/.agentcortex/docs/*.md "$REPO_ROOT"/.agentcortex/docs/guides/*.md \
               "$REPO_ROOT"/README.md "$REPO_ROOT"/docs/README_zh-TW.md; do
         [ -f "$df" ] && _doc_count=$((_doc_count + 1))
     done
-    [ "$_doc_count" -gt 0 ] && echo "  [NEW]    ... $_doc_count reference docs (.agentcortex/docs/)"
+    [ "$_doc_count" -gt 0 ] && echo "  [NEW]    (mixed)    ... $_doc_count reference docs under .agentcortex/docs/"
     # Claude commands
     _cmd_count=0
     for cf in "$REPO_ROOT"/.claude/commands/*; do [ -f "$cf" ] && _cmd_count=$((_cmd_count + 1)); done
-    [ "$_cmd_count" -gt 0 ] && echo "  [NEW]    ... $_cmd_count Claude slash command adapters (.claude/commands/)"
+    [ "$_cmd_count" -gt 0 ] && echo "  [NEW]    (core)     ... $_cmd_count Claude slash command adapters under .claude/commands/"
     echo ""
     echo "Total: ~$((_dry_count + _skill_count + _doc_count + _cmd_count)) files would be deployed."
     echo "Run without --dry-run to apply."

--- a/README.md
+++ b/README.md
@@ -183,7 +183,9 @@ Designed for cost-effective models (Gemini Flash, Haiku, etc.):
 
 > **No Python?** The framework deploys and works without Python. Validation runs in
 > degraded mode — Python-dependent checks report `WARN` instead of `FAIL`.
-> Pass `--no-python` to suppress warnings: `bash .agentcortex/bin/validate.sh --no-python`
+> Pass `--no-python` to suppress warnings from a Git Bash or POSIX shell:
+> `bash .agentcortex/bin/validate.sh --no-python`. On Windows PowerShell, prefer
+> `powershell -ExecutionPolicy Bypass -File .\.agentcortex\bin\validate.ps1 -NoPython`.
 
 **Install (first time):**
 
@@ -255,8 +257,8 @@ powershell -ExecutionPolicy Bypass -File .\.agentcortex\bin\validate.ps1
 # Lightweight validation when Python is not installed
 powershell -ExecutionPolicy Bypass -File .\.agentcortex\bin\validate.ps1 -NoPython
 
-# (Git Bash equivalent)
-bash ./.agentcortex/bin/validate.sh --no-python
+# Git Bash equivalent (run in a Git Bash terminal, not PowerShell)
+# bash ./.agentcortex/bin/validate.sh --no-python
 ```
 
 </details>

--- a/docs/reviews/2026-06-16-audit.md
+++ b/docs/reviews/2026-06-16-audit.md
@@ -1,0 +1,108 @@
+# Practical Development Simulation Audit - 2026-06-16
+
+## Scope
+
+This report records a read-mostly practical development simulation on branch `main` at commit `ff5c48a2fd657499c821b53d5913c9b8425c0480`.
+
+The simulation followed the `/audit` workflow: map repository structure, identify development entry points, run representative local validation, exercise a deploy dry-run, and record gaps that would affect a real contributor loop.
+
+## System Map
+
+- Tracked files: 391.
+- Files visible to `rg --files --hidden` excluding `.git`: 404.
+- Primary domains: governance runtime, workflow routing, validators, deploy/install wrappers, skill metadata, tests.
+- Top-level file concentration: `.agentcortex` 152 files, `.agent` 55, `docs` 50, `tests` 34, `.claude` 34, `.agents` 30.
+- Main contributor commands observed: `powershell -ExecutionPolicy Bypass -File .\.agentcortex\bin\validate.ps1`, `bash .agentcortex/bin/validate.sh --no-python`, `powershell -ExecutionPolicy Bypass -File .\installers\deploy_brain.ps1 -DryRun <target>`.
+
+## Evidence Summary
+
+- `bash .agentcortex/bin/validate.sh --no-python` through PATH failed before project validation because `bash` resolved to `C:\Users\wen\AppData\Local\Microsoft\WindowsApps\bash.exe`.
+- Explicit Git Bash validation: `C:\Program Files\Git\bin\bash.exe .agentcortex/bin/validate.sh --no-python` -> `pass=92 warn=6 fail=1 skip=17`.
+- PowerShell lightweight validation: `validate.ps1 -NoPython` -> `pass=92 warn=6 fail=1 skip=15`.
+- PowerShell full validation: `validate.ps1` -> `pass=104 warn=7 fail=1 skip=2`.
+- Targeted unit test: `python -m pytest tests/guard/test_worklog_lock_blocking.py -q` -> `23 passed in 0.68s`.
+- Installer dry-run: `powershell -ExecutionPolicy Bypass -File .\installers\deploy_brain.ps1 -DryRun .\temp_downstream` -> success, reported `Total: ~188 files would be deployed.`
+
+## Double-Check Calibration
+
+After a second pass, not every signal below should be treated as a governance defect. The practical simulation mixed three sources of evidence: framework behavior, local Windows/tooling behavior, and my own audit execution choices.
+
+- Reclassified as AI-flow/doc-ambiguity, not proven governance failure: the active Work Log gate-receipt failure. `/audit` requires a report file, but does not explicitly require an active Work Log; I created one manually.
+- Still likely product/tooling gaps: Windows raw `bash` misinvoke risk, deploy dry-run basename-only output, and signal-tier fixture leakage into the real workspace.
+- Local-noise only unless reproduced elsewhere: existing untracked `zz-st-*` fixture files and PowerShell mojibake.
+
+## Confirmed Findings After External Review
+
+### LOW - Optional audit Work Logs need clearer support-receipt guidance
+
+`/audit` says `NO GATE` and `REPORT ONLY`, while also requiring a report file under `docs/reviews/<date>-audit.md` (`.agent/workflows/audit.md:14`, `.agent/workflows/audit.md:28`). Active Work Logs, however, must contain a `## Gate Evidence` section with at least one receipt, or both validators emit `FAIL` (`.agentcortex/bin/validate.sh:1100`, `.agentcortex/bin/validate.sh:1108`, `.agentcortex/bin/validate.sh:1495`).
+
+Second-pass correction: this failure was triggered by my choice to create an active Work Log for the audit. `/audit` itself does not explicitly require one. The validator already treats `audit` as an out-of-band support workflow for phase progression (`.agentcortex/bin/validate.sh:1263`), so the likely intended contract is: if an audit Work Log exists, support receipts are acceptable for traceability, but they do not advance the main gate state.
+
+Recommended fix: either document that `/audit` should not create an active Work Log, or document that audit-created Work Logs must include a support-phase receipt such as `- Gate: audit | Verdict: PASS | Classification: quick-win | Timestamp: <ISO>`.
+
+### LOW - Audit report filenames can collide on same-day repeated audits
+
+Second-pass correction: the Work Log write was my execution choice, not a stated `/audit` requirement. The remaining real concern is narrow: `/audit` writes `docs/reviews/<date>-audit.md`, so two same-day audits can collide unless the report name includes scope/session detail.
+
+Recommended fix: use `docs/reviews/<date>-<scope>-audit.md` or document overwrite behavior.
+
+### MEDIUM - Windows shell validation path is easy to misinvoke
+
+README recommends the PowerShell validator on Windows, but also presents the Git Bash equivalent as `bash ./.agentcortex/bin/validate.sh --no-python` (`README.md:245`, `README.md:258`). In this environment, PowerShell resolves `bash` to the WindowsApps WSL placeholder, causing validation to fail before Agentic OS starts.
+
+The deploy PowerShell wrappers already contain the right mitigation by preferring Git Bash and skipping WindowsApps (`installers/deploy_brain.ps1:41`, `installers/deploy_brain.ps1:49`).
+
+Recommended fix: change the README wording to "from a Git Bash terminal" or provide a PowerShell-safe explicit Git Bash path example. Consider documenting `validate.ps1` as the primary Windows path and making the raw `bash` example clearly non-PowerShell.
+
+### MEDIUM - Deploy dry-run output loses target path context
+
+The dry-run file preview uses `basename` (`.agentcortex/bin/deploy.sh:743`) and prints only the leaf filename (`.agentcortex/bin/deploy.sh:745`). The observed output included repeated names such as `rules.md` and omitted important target directories such as `installers/`.
+
+This makes dry-run less useful as a blast-radius review tool: a user cannot tell which `rules.md` or `deploy_brain.sh` target will change without reading the deploy script.
+
+Recommended fix: print target-relative paths and tier in dry-run output, using the same target paths passed to `deploy_file`.
+
+### LOW - Signal-tier tests can leave formal spec fixtures in the real workspace
+
+`tests/guard/test_signal_tier_check.py` writes fixture specs directly into `docs/specs` (`tests/guard/test_signal_tier_check.py:119`, `tests/guard/test_signal_tier_check.py:127`). If a test run is interrupted, untracked `docs/specs/zz-st-*.md` files remain and pollute later validator output. This workspace currently contains those untracked fixtures.
+
+Recommended fix: run these validator tests in a temporary copied repository, or write fixtures under a temporary directory that the validator is pointed at, rather than the real `docs/specs` tree.
+
+### LOW - PowerShell validator output still has mojibake in some informational lines
+
+Full `validate.ps1` output included replacement characters in informational text such as the command-sync line and governance eval section headings. This did not affect pass/fail behavior, but it makes Windows evidence harder to review.
+
+Recommended fix: normalize PowerShell output encoding to UTF-8 for validator child processes, or avoid non-ASCII glyphs in validator-emitted status text.
+
+## Secondary Signals
+
+- Governance eval coverage reports 30 MUST-rule sections without eval cases. This is WARN-only and tier-blind, but it aligns with the project's own "MUST without enforcement" lesson.
+- Global Lessons count is exactly at cap: `20/20`.
+- Historical archived Work Log warnings remain present; they are not new regressions from this simulation.
+
+## Post-Fix Resolution
+
+- Fixed: Windows validation docs now keep `validate.ps1` as the PowerShell path and mark raw `bash` as Git Bash/POSIX-only.
+- Fixed: deploy dry-run now prints target-relative paths and tier labels.
+- Fixed: signal-tier validator tests now write fixtures in an isolated deployed temp repo instead of source `docs/specs`.
+- Calibrated: `/audit` Work Log behavior is not treated as a confirmed governance defect.
+- Local hygiene: active Work Log sentinel/Resume warnings were reduced locally; remaining WARNs are shipped-active release log, historical archives, and governance eval coverage.
+
+## routing_actions
+
+```yaml
+routing_actions:
+  - finding: "Optional audit-created Work Logs need support-phase receipt guidance."
+    target_doc: "docs/architecture/document-governance.md"
+    status: pending
+    owner: "codex-session"
+  - finding: "Audit report filenames can collide on same-day repeated audits."
+    target_doc: "docs/architecture/document-governance.md"
+    status: pending
+    owner: "codex-session"
+  - finding: "Deploy dry-run preview should print target-relative paths instead of basenames."
+    target_doc: "docs/architecture/document-governance.md"
+    status: pending
+    owner: "codex-session"
+```

--- a/tests/guard/test_signal_tier_check.py
+++ b/tests/guard/test_signal_tier_check.py
@@ -24,6 +24,7 @@ pytestmark = pytest.mark.slow
 ROOT = Path(__file__).resolve().parents[2]
 VALIDATE_SH = ROOT / ".agentcortex" / "bin" / "validate.sh"
 VALIDATE_PS1 = ROOT / ".agentcortex" / "bin" / "validate.ps1"
+DEPLOY_SH = ROOT / ".agentcortex" / "bin" / "deploy.sh"
 
 # bash discovery (mirror test_validator_false_positives.py).
 git_path = shutil.which("git")
@@ -56,7 +57,7 @@ requires_windows = pytest.mark.skipif(
 # ---------------------------------------------------------------------------
 # Fixture specs
 # ---------------------------------------------------------------------------
-# All written to docs/specs/ and removed in finally, no matter what.
+# All written to an isolated deployed temp repo, never the source docs/specs/.
 # Each is a plausible minimal spec with --- fences, title, status: draft.
 
 _FIXTURES: dict[str, str] = {
@@ -116,7 +117,6 @@ _FIXTURES: dict[str, str] = {
     ),
 }
 
-SPEC_DIR = ROOT / "docs" / "specs"
 WARN_LINE = "governance spec missing signal_tier: zz-st-missing.md"
 # Use a substring that avoids the multi-byte § character, which PowerShell may
 # emit as replacement characters depending on console encoding.
@@ -124,36 +124,52 @@ WARN_SUMMARY = "governance specs missing signal_tier frontmatter"
 SILENT_FILES = ["zz-st-tier2.md", "zz-st-none.md", "zz-st-old.md"]
 
 
-def _write_fixtures() -> None:
-    for name, content in _FIXTURES.items():
-        (SPEC_DIR / name).write_text(content, encoding="utf-8")
-
-
-def _remove_fixtures() -> None:
-    for name in _FIXTURES:
-        (SPEC_DIR / name).unlink(missing_ok=True)
-
-
-def _run_sh() -> str:
+def _make_validation_target(tmp_path: Path) -> Path:
+    target = tmp_path / "proj"
+    target.mkdir()
     proc = subprocess.run(
-        [bash, str(VALIDATE_SH)],
+        [bash, str(DEPLOY_SH), str(target)],
         capture_output=True,
         text=True,
         encoding="utf-8",
         errors="replace",
         cwd=str(ROOT),
     )
-    return proc.stdout + proc.stderr
+    assert proc.returncode == 0, f"deploy failed:\n{proc.stdout}\n{proc.stderr}"
+    return target
 
 
-def _run_ps1() -> str:
+def _write_fixtures(spec_dir: Path) -> None:
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    for name, content in _FIXTURES.items():
+        (spec_dir / name).write_text(content, encoding="utf-8")
+
+
+def _remove_fixtures(spec_dir: Path) -> None:
+    for name in _FIXTURES:
+        (spec_dir / name).unlink(missing_ok=True)
+
+
+def _run_sh(cwd: Path) -> str:
     proc = subprocess.run(
-        [powershell, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", str(VALIDATE_PS1)],
+        [bash, str(cwd / ".agentcortex" / "bin" / "validate.sh")],
         capture_output=True,
         text=True,
         encoding="utf-8",
         errors="replace",
-        cwd=str(ROOT),
+        cwd=str(cwd),
+    )
+    return proc.stdout + proc.stderr
+
+
+def _run_ps1(cwd: Path) -> str:
+    proc = subprocess.run(
+        [powershell, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", str(cwd / ".agentcortex" / "bin" / "validate.ps1")],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        cwd=str(cwd),
     )
     return proc.stdout + proc.stderr
 
@@ -164,13 +180,15 @@ def _run_ps1() -> str:
 
 
 @requires_bash
-def test_signal_tier_warn_bash() -> None:
+def test_signal_tier_warn_bash(tmp_path: Path) -> None:
     """validate.sh: WARN names zz-st-missing.md; silent for tier/none/old."""
-    _write_fixtures()
+    target = _make_validation_target(tmp_path)
+    spec_dir = target / "docs" / "specs"
+    _write_fixtures(spec_dir)
     try:
-        out = _run_sh()
+        out = _run_sh(target)
     finally:
-        _remove_fixtures()
+        _remove_fixtures(spec_dir)
 
     assert WARN_LINE in out, (
         f"Expected WARN line not found in validate.sh output.\n"
@@ -189,13 +207,15 @@ def test_signal_tier_warn_bash() -> None:
 @requires_bash
 @requires_powershell
 @requires_windows
-def test_signal_tier_warn_powershell() -> None:
+def test_signal_tier_warn_powershell(tmp_path: Path) -> None:
     """validate.ps1: same parity assertions as the bash test."""
-    _write_fixtures()
+    target = _make_validation_target(tmp_path)
+    spec_dir = target / "docs" / "specs"
+    _write_fixtures(spec_dir)
     try:
-        out = _run_ps1()
+        out = _run_ps1(target)
     finally:
-        _remove_fixtures()
+        _remove_fixtures(spec_dir)
 
     assert WARN_LINE in out, (
         f"Expected WARN line not found in validate.ps1 output.\n"


### PR DESCRIPTION
## What changed

- Clarified Windows validation docs so PowerShell users use `validate.ps1`, while raw `bash` validation is marked as Git Bash/POSIX-only.
- Updated deploy dry-run preview to show target-relative paths and tier labels instead of ambiguous basenames.
- Isolated signal-tier validator fixtures in a deployed temp repo so tests no longer write `zz-st-*` specs into the source tree.
- Added the practical simulation audit report with reviewer-calibrated findings and post-fix resolution notes.

## Why

A Codex-led practical development simulation found a few real process/tooling gaps after reviewer double-check. The `/audit` Work Log concern was narrowed as agent-flow noise, while Windows raw `bash`, dry-run path ambiguity, and source-tree fixture leakage were confirmed.

## Validation

- `python -m pytest tests/guard/test_signal_tier_check.py -q` -> 2 passed
- `powershell -ExecutionPolicy Bypass -File .\.agentcortex\bin\validate.ps1` -> pass=109 warn=4 fail=0 skip=2
- `C:\Program Files\Git\bin\bash.exe -n .agentcortex/bin/deploy.sh` -> pass
- `C:\Program Files\Git\bin\bash.exe .agentcortex/bin/validate.sh --no-python` -> pass=94 warn=5 fail=0 skip=17
- `git diff --check` -> pass

## Notes

Remaining WARNs are intentionally out of scope: one shipped active local Work Log, two historical archive warnings, and governance eval coverage debt.