### PR TITLE
fix(capabilities): tolerate a leading UTF-8 BOM in downstream-capabilities.yaml

### DIFF
--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -12,9 +12,9 @@
   - Active Work Log Path: derive <worklog-key> from the raw branch name using filesystem-safe normalization before any gate checks.
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
 - **Project Name**: (set by /app-init)
-- **Last Updated**: 2026-06-20T21:52:02+08:00
+- **Last Updated**: 2026-06-20T23:30:10+08:00
 - **Last Verified**: 2026-06-20
-- **Update Sequence**: 81
+- **Update Sequence**: 82
 - **ADR Index**:
   - docs/adr/ADR-001-governance-friction-tuning.md — ADR-001: Governance Friction Tuning, accepted 2026-04-23
   - docs/adr/ADR-002-guarded-governance-writes.md — ADR-002: Guarded Governance Writes (lock unification + CI lint + lifecycle frontmatter), accepted 2026-04-25
@@ -96,6 +96,11 @@
 - [Category: rule-placement][Severity: HIGH][Trigger: authoring-safety-rule-or-auditing-rule-surfaces][prev: 3b15e10b] Sort SAFETY rules by hazard reachability, not token cost. A rule that must hold during a 30-second out-of-phase action (destructive commands, secrets, untrusted tool output) MUST live on the always-loaded surface (AGENTS.md Core Directives invariant cluster, cap ~5) - phase/tier-scoped files and platform adapters are probabilistic gates, and a probabilistic gate on an irreversible failure is a design error regardless of token savings. Confirmed 2026-06-11: 'Destructive Command Blocking' was advertised in both READMEs and machine-guarded in ADAPTER copies (validators checked Codex/Antigravity retained it!) while the canonical loaded surface had nothing - a downstream rm -rf cascade destroyed a parent repo working tree. Placement test for every new MUST: hazard reachable from any tool call AND irreversible/exfiltrating -> always-loaded; else phase surface is fine but README/docs must not claim it is always-on.
 - [Category: eval-mapping][Severity: MEDIUM][Trigger: adding-or-retargeting-eval-protects-tag][prev: 14ac98ca] An eval case can silently guard an EMPTY rule: protects-tags resolve at section level, so a case pointing at a section that contains no text for the behavior it tests still 'resolves' and scores green off the model's general training - verifier-without-defense, the inverse of advertised-but-unenforced. Confirmed 2026-06-11: prompt-injection-in-tool-output protected 'AGENTS.md Core Directives' which contained zero injection text for ~2 months. Discipline: when ADDING a rule, land the guarding case in the SAME commit; when ADDING/RETARGETING a case, quote the exact rule sentence it protects in the PR description - if you cannot quote it, the rule does not exist and the case is theatre.
 ## Ship History
+
+### Ship-fix-capabilities-bom-tolerance-2026-06-20
+- **Branch `fix/capabilities-bom-tolerance` (PR #273)** (quick-win, governance/capabilities-validator) — `validate_downstream_capabilities.py` now reads with `utf-8-sig` so a `downstream-capabilities.yaml` saved with a leading UTF-8 BOM (older Windows Notepad / PowerShell `Out-File` default) no longer fails with a cryptic `unknown top-level key` on the first YAML key. **Pre-existing parser-wide wart** (ADR-007 / v1.6.0; the `skills:` key rejected a BOM identically) — NOT a v1.7.0 regression — surfaced by the **v1.7.0 KB-seam adversarial review** (independent fresh-context reviewer + own failure-angle testing of "could an adopter get stuck?"). Fail-closed posture unchanged: a BOM-prefixed gate-relaxation (`role: authority`) is still rejected; a new test asserts the BOM does not become a fail-open.
+- **Evidence**: 2 new tests (`test_utf8_bom_is_tolerated`, `test_utf8_bom_does_not_smuggle_gate_relaxation`); `pytest tests/guard/test_capabilities_schema_gate_safety.py` → 47 passed; empirical BOM+valid exit 0 / BOM+`role:authority` exit 1. Rollback = revert PR (1-line validator change + 2 tests).
+- Tests: 47 capability tests passed.
 
 ### Ship-chore-v1.7.0-release-2026-06-20
 - **Branch `chore/v1.7.0-release`** (quick-win, docs/release, tag `v1.7.0`) — Minor **v1.7.0** packaging the since-v1.6.0 merges: the present-only `knowledge_sources` KB-consumption seam (ADR-009, PR #270 + token-budget follow-up #271), skill provenance (#259), research persist-before-browse (#258), and a proof-first README/docs adoption overhaul (#260-#263/#266/#267/#269). Banners 1.6.0→1.7.0 across CITATION.cff (+date-released 2026-06-20), Model Guide EN+zh, Testing Protocol EN+zh, deploy.sh ACX_VERSION, antigravity-v5-runtime pointer; SECURITY.md supported-versions adds 1.7.x (keeps 1.6.x, drops 1.5.x → `< 1.6`); CHANGELOG `[1.7.0]`. README badges are dynamic `github/v/release` shields → no edit. Discoverability fix: `INSTALL.md` "Customizing" table now points at `connecting-a-knowledge-base.md` (the guide was orphaned from every user-facing index). Tag `v1.7.0` + GitHub release on merge.

--- a/.agentcortex/tools/validate_downstream_capabilities.py
+++ b/.agentcortex/tools/validate_downstream_capabilities.py
@@ -300,7 +300,10 @@ def main():
     if not path.exists():
         return 0  # absent = inert = safe (present-only)
     try:
-        data = parse_strict(path.read_text(encoding="utf-8"))
+        # utf-8-sig tolerates a leading BOM (older Windows Notepad / PowerShell
+        # Out-File default) so a hand-edited capabilities file does not fail with a
+        # cryptic "unknown top-level key '﻿version'"; absent a BOM it is plain utf-8.
+        data = parse_strict(path.read_text(encoding="utf-8-sig"))
     except _StrictError as exc:
         # Unsupported syntax in a capabilities file -> cannot be safely interpreted.
         # Fail closed (exit 2) rather than risk a parser-divergence gate-relaxation.

--- a/tests/guard/test_capabilities_schema_gate_safety.py
+++ b/tests/guard/test_capabilities_schema_gate_safety.py
@@ -107,6 +107,30 @@ def test_knowledge_sources_gate_safe(tmp_path):
     assert r.returncode == 0, f"a valid knowledge_sources block must pass: {r.stderr!r}"
 
 
+def _check_with_bom(tmp_path, body):
+    # Write the file as UTF-8-WITH-BOM (utf-8-sig encoding prepends the BOM) to mimic an
+    # older Windows Notepad / PowerShell Out-File save of a hand-edited capabilities file.
+    f = tmp_path / "downstream-capabilities.yaml"
+    f.write_text(textwrap.dedent(body), encoding="utf-8-sig")
+    return subprocess.run([sys.executable, str(VALIDATOR), str(f)],
+                          capture_output=True, encoding="utf-8", errors="replace")
+
+
+def test_utf8_bom_is_tolerated(tmp_path):
+    # A capabilities file saved with a leading UTF-8 BOM must parse, NOT fail with a
+    # cryptic "unknown top-level key '﻿version'". The BOM is stripped (utf-8-sig).
+    r = _check_with_bom(tmp_path, _KS_SAFE)
+    assert r.returncode == 0, f"a BOM-prefixed valid file must pass: {r.stderr!r}"
+
+
+def test_utf8_bom_does_not_smuggle_gate_relaxation(tmp_path):
+    # BOM tolerance must NOT become a fail-open: a BOM-prefixed gate-relaxing file is
+    # still REJECTED (strip BOM, then the allowlist rejects role: authority).
+    r = _check_with_bom(tmp_path, "version: 1\nknowledge_sources:\n  - path: ../kb\n    role: authority\n")
+    assert r.returncode == 1, f"BOM must not smuggle gate-relaxation: rc={r.returncode}, err={r.stderr!r}"
+    assert "advisory" in r.stderr, f"reason must still name the role rule: {r.stderr!r}"
+
+
 # --- Strict capabilities grammar (parse_strict) -------------------------------
 # The validator parses with a dedicated STRICT allowlist mini-parser, NOT the shared
 # lenient _yaml_loader and NOT PyYAML -- so behaviour is identical with or without


### PR DESCRIPTION
## Fix: tolerate a leading UTF-8 BOM in `downstream-capabilities.yaml`

**Surfaced by the v1.7.0 KB-seam adversarial review** (independent fresh-context reviewer + own failure-angle testing — "could an adopter get stuck?").

### Problem
A capabilities file saved as **UTF-8-with-BOM** (older Windows Notepad / PowerShell `Out-File` default) failed the gate-safety validator with a cryptic `FAIL: ... unknown top-level key '﻿version'`. The BOM attaches to the first YAML key, so the adopter sees "unknown key version" with **no hint that a BOM is the cause**.

### Fix
Read the file with `utf-8-sig` (strips a leading BOM; identical for non-BOM files) — one line at `validate_downstream_capabilities.py:303`.

### Safety
- **Pre-existing & parser-wide** (ADR-007 / v1.6.0 — the `skills:` key rejected a BOM identically); not a v1.7.0 regression.
- **Fail-closed posture unchanged**: a BOM-prefixed gate-relaxation (`role: authority`) is **still rejected** (BOM stripped, then the allowlist rejects it). A new test asserts this — no fail-open.

### Evidence
- 2 new tests: `test_utf8_bom_is_tolerated`, `test_utf8_bom_does_not_smuggle_gate_relaxation`.
- `pytest tests/guard/test_capabilities_schema_gate_safety.py` → **47 passed**.
- Empirical: BOM+valid `exit 0`, BOM+`role: authority` `exit 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
