### PR TITLE
chore(release): cut v1.8.0 - ADR-009 KB-seam hardening wave

### DIFF
--- a/.agentcortex/bin/deploy.sh
+++ b/.agentcortex/bin/deploy.sh
@@ -26,7 +26,7 @@ TARGET="${TARGET:-.}"
 TARGET="${TARGET%/}"
 
 MANIFEST_FILE="$TARGET/.agentcortex-manifest"
-ACX_VERSION="1.7.0"
+ACX_VERSION="1.8.0"
 
 # --- Self-deploy guard ---
 TARGET_ABS="$(cd "$TARGET" 2>/dev/null && pwd || echo "$TARGET")"

--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -12,9 +12,9 @@
   - Active Work Log Path: derive <worklog-key> from the raw branch name using filesystem-safe normalization before any gate checks.
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
 - **Project Name**: (set by /app-init)
-- **Last Updated**: 2026-06-21T11:30:00+08:00
+- **Last Updated**: 2026-06-21T12:00:00+08:00
 - **Last Verified**: 2026-06-21
-- **Update Sequence**: 85
+- **Update Sequence**: 86
 - **ADR Index**:
   - docs/adr/ADR-001-governance-friction-tuning.md — ADR-001: Governance Friction Tuning, accepted 2026-04-23
   - docs/adr/ADR-002-guarded-governance-writes.md — ADR-002: Guarded Governance Writes (lock unification + CI lint + lifecycle frontmatter), accepted 2026-04-25
@@ -97,6 +97,19 @@
 - [Category: rule-placement][Severity: HIGH][Trigger: authoring-safety-rule-or-auditing-rule-surfaces][prev: 3b15e10b] Sort SAFETY rules by hazard reachability, not token cost. A rule that must hold during a 30-second out-of-phase action (destructive commands, secrets, untrusted tool output) MUST live on the always-loaded surface (AGENTS.md Core Directives invariant cluster, cap ~5) - phase/tier-scoped files and platform adapters are probabilistic gates, and a probabilistic gate on an irreversible failure is a design error regardless of token savings. Confirmed 2026-06-11: 'Destructive Command Blocking' was advertised in both READMEs and machine-guarded in ADAPTER copies (validators checked Codex/Antigravity retained it!) while the canonical loaded surface had nothing - a downstream rm -rf cascade destroyed a parent repo working tree. Placement test for every new MUST: hazard reachable from any tool call AND irreversible/exfiltrating -> always-loaded; else phase surface is fine but README/docs must not claim it is always-on.
 - [Category: eval-mapping][Severity: MEDIUM][Trigger: adding-or-retargeting-eval-protects-tag][prev: 14ac98ca] An eval case can silently guard an EMPTY rule: protects-tags resolve at section level, so a case pointing at a section that contains no text for the behavior it tests still 'resolves' and scores green off the model's general training - verifier-without-defense, the inverse of advertised-but-unenforced. Confirmed 2026-06-11: prompt-injection-in-tool-output protected 'AGENTS.md Core Directives' which contained zero injection text for ~2 months. Discipline: when ADDING a rule, land the guarding case in the SAME commit; when ADDING/RETARGETING a case, quote the exact rule sentence it protects in the PR description - if you cannot quote it, the rule does not exist and the case is theatre.
 ## Ship History
+
+### Ship-chore-v1.8.0-release-2026-06-21
+- **Branch `chore/v1.8.0-release`** (quick-win, docs/release; tag `v1.8.0`) — Minor **v1.8.0**
+  packaging the KB-seam hardening wave landed since v1.7.0: `${ACX_KB_PATH}` env resolution +
+  path trust-model + injection-decline eval + committed `.example` (PR #275), surgical-read
+  discipline at `bootstrap.md §3.6` + per-entry KB health + no-Python one-liner (PR #276), README
+  `## Docs` discoverability EN+繁中 (PR #274). Version banners 1.7.0→1.8.0: `deploy.sh` ACX_VERSION,
+  `CITATION.cff` (+`date-released` 2026-06-21), Model Guide EN+zh, Testing Protocol EN+zh,
+  `antigravity-v5-runtime.md`; `SECURITY.md` supported adds 1.8.x (keeps 1.7.x, drops 1.6.x →
+  `< 1.7`); `CHANGELOG.md` `[1.8.0]`. README badges are dynamic shields → no edit. Tag `v1.8.0`
+  + GitHub release cut on merge.
+- **Evidence**: validators fail=0 (CI-equiv `Framework Validation` green on the wave PRs); release
+  is version/doc-only — no engine/test/logic change; ADR-009 decisions unchanged.
 
 ### Ship-feat-kb-consult-surgical-discipline-2026-06-21
 - **Branch `feat/kb-consult-surgical-discipline`** (quick-win, ADR-009 follow-up; **stacked on PR #275**)

--- a/.agentcortex/docs/TESTING_PROTOCOL.md
+++ b/.agentcortex/docs/TESTING_PROTOCOL.md
@@ -1,4 +1,4 @@
-# Testing Protocol v1.7.0
+# Testing Protocol v1.8.0
 
 > **This document guides the AI Agent to produce high-quality, trustworthy, and defensive test code.**
 

--- a/.agentcortex/docs/TESTING_PROTOCOL_zh-TW.md
+++ b/.agentcortex/docs/TESTING_PROTOCOL_zh-TW.md
@@ -1,4 +1,4 @@
-# Testing Protocol (測試教戰守則) v1.7.0
+# Testing Protocol (測試教戰守則) v1.8.0
 >
 > **本文件旨在指引 AI Agent 產出高品質、可信任、且具備防禦性的測試程式碼。**
 

--- a/.agentcortex/docs/guides/antigravity-v5-runtime.md
+++ b/.agentcortex/docs/guides/antigravity-v5-runtime.md
@@ -8,7 +8,7 @@ Date: 2026-04-17
 > **Two version axes — do not conflate.** "Runtime v5" throughout this file is this
 > anti-drift *engine spec's* own generation number; the canonical Antigravity runtime
 > **contract** version is **Runtime v1** (see `AGENTS.md §Agentic OS Runtime v1`). The
-> framework release version (v1.7.0) is tracked separately in `CHANGELOG.md`.
+> framework release version (v1.8.0) is tracked separately in `CHANGELOG.md`.
 Scope: **Antigravity environments** (token-generation agents where shell exit codes don’t halt execution)
 
 ### Why v5 exists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.8.0] - 2026-06-21
+
+Minor release: a hardening + dogfood wave for the v1.7.0 ADR-009 knowledge-base seam. Packages #274–#276. **Adopters with no KB are unaffected** — still byte-identical, zero-cost-when-absent.
+
+**Governance / downstream adaptability** (#275/#276 — ADR-009 follow-up, `docs/specs/kb-seam-hardening.md`)
+- **`${ACX_KB_PATH}` env resolution** (#275): a `knowledge_sources[].path` containing `${ACX_KB_PATH}` resolves against the env var (clone root; `entrypoint` relative) so one machine relocates a shared KB clone without per-project edits. Present-only (read only when a block is present), literal paths unchanged, cross-platform, no-Python safe. A committed `.agentcortex/templates/downstream-capabilities.example.yaml` demonstrates it (the strict validator accepts only full-line comments + quoted `:`/`${}` paths — now documented, closing a pre-existing copy-paste footgun).
+- **Path trust model, no guard** (#275): the KB path is documented as self-authored / out-of-repo / OFF the trust boundary, consumed fail-closed as DATA; **no `..`/containment guard is added** — it would only ever fire on the legitimate out-of-repo KB, and the path is not attacker-influenced. `validate_downstream_capabilities.py` stays schema-gate-safety-only (never resolves the path; CI-deterministic).
+- **Surgical-read discipline at the line-of-action** (#276): the `bootstrap.md §3.6 kb-consult` row now carries the mechanic the agent acts on — query `task_routing` (never Read the whole ~25–53K-tok manifest), read the routed page's checklist *section* not the whole page, ≤3 pages/phase. A real **dogfood** proved the gap (the agent over-routed 4 pages = 36K tok vs a 495-tok surgical consult = ~17× cheaper). **Per-entry KB health**: `§1b` records `knowledge_sources: <id>→OK|UNREADABLE` so a moved/dead KB is visible each bootstrap; a no-Python one-liner verifies wiring on demand.
+- **Injection-decline eval** (#275): one LLM-in-loop governance-eval case asserts a directive embedded in a KB page is named-and-declined (the `§Untrusted Tool Output` floor on KB-surfaced data). Consult-quality stays honor-system — labeled, raised-probability-not-enforced.
+
+**Docs / adoption** (#274)
+- **README discoverability**: the `knowledge_sources` KB seam now surfaces in the README `## Docs` table (EN + 繁中), linking the adopter guide — previously reachable only via `INSTALL.md`.
+
+**Housekeeping**
+- Lifecycle token budget bumped 352k→353k for the matured seam (the §3.6 rule is net-token-saving — it prevents 36K-tok over-routes) and re-baselined. A roundtable + Tenth-Man pass deliberately **deferred** a `kb_doctor` tool and **cut** a resolver / fixture-pytest / path-guard (vacuous-green or security-theater given consumption is agent-prose-driven).
+
 ## [1.7.0] - 2026-06-20
 
 Minor release: a present-only knowledge-base consumption seam (ADR-009) plus skill-provenance, a research-persistence convention, and a proof-first README/docs overhaul aimed at adoption. Packages the since-v1.6.0 merges (#258–#271, #86).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ authors:
   - family-names: Wen
     given-names: Kb
 title: "Agentic OS: Governance-First Workflows for AI Coding Agents"
-version: 1.7.0
-date-released: 2026-06-20
+version: 1.8.0
+date-released: 2026-06-21
 url: "https://github.com/KbWen/agentic-os"
 abstract: "A governance-first framework for AI coding agents. Portable workflows, delivery gates, engineering guardrails, and 14 professional skills for Claude Code, OpenAI Codex, Google Antigravity, Cursor, GitHub Copilot, and other coding agents."
 keywords:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,6 +34,6 @@ Security issues in Agentic OS may include:
 
 | Version | Supported |
 |---------|-----------|
+| 1.8.x   | Yes       |
 | 1.7.x   | Yes       |
-| 1.6.x   | Yes       |
-| < 1.6   | No        |
+| < 1.7   | No        |

--- a/docs/AGENT_MODEL_GUIDE.md
+++ b/docs/AGENT_MODEL_GUIDE.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.7.0 — Model Selection Guide
+# Agentic OS v1.8.0 — Model Selection Guide
 
 > For human reference only — this file is not loaded into AI context.
 

--- a/docs/AGENT_MODEL_GUIDE_zh-TW.md
+++ b/docs/AGENT_MODEL_GUIDE_zh-TW.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.7.0 — 模型選擇指南
+# Agentic OS v1.8.0 — 模型選擇指南
 
 > 人類參考用 — 此檔案不會被載入 AI context。
 


### PR DESCRIPTION
## Release v1.8.0 — ADR-009 KB-seam hardening wave

Minor release packaging the three merged PRs that hardened + dogfooded the v1.7.0 `knowledge_sources` KB-consumption seam. **Adopters with no KB are unaffected** — still byte-identical, zero-cost-when-absent.

### What's in it
| PR | Change |
|----|--------|
| #275 | `${ACX_KB_PATH}` env resolution + path **trust model** (no guard, with rationale) + LLM-in-loop injection-decline eval + committed `.example` |
| #276 | Surgical-read discipline at `bootstrap.md §3.6` (query `task_routing`, read the checklist *section* not the page, ≤3pg/phase) + per-entry KB health + no-Python verify one-liner |
| #274 | README `## Docs` discoverability (EN + 繁中) |

### Why minor (not patch)
The wave adds a new opt-in adopter capability — `${ACX_KB_PATH}` env resolution — so it is a backward-compatible feature → **minor**. Smallest minor bump, matching the v1.6.0 / v1.7.0 feature-wave convention.

### Version banners (1.7.0 → 1.8.0)
- `.agentcortex/bin/deploy.sh` `ACX_VERSION`
- `CITATION.cff` `version` + `date-released` 2026-06-21
- `docs/AGENT_MODEL_GUIDE.md` + `_zh-TW`
- `.agentcortex/docs/TESTING_PROTOCOL.md` + `_zh-TW`
- `.agentcortex/docs/guides/antigravity-v5-runtime.md`
- `SECURITY.md` supported → `1.8.x` / `1.7.x` / `< 1.7`
- `CHANGELOG.md` `[1.8.0]`
- `current_state.md` Ship History + seq 85→86

README badges are dynamic shields → no edit needed.

### Evidence
- Version/doc-only — **no engine/test/logic change**; ADR-009 decisions unchanged.
- `validate.sh` CI-equivalent fail=0.
- Tag `v1.8.0` + GitHub release cut on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
