### PR TITLE
chore(release): v1.8.6 — dev-flow hardening (13 ACs, #299-#304)

### DIFF
--- a/.agentcortex/bin/deploy.sh
+++ b/.agentcortex/bin/deploy.sh
@@ -26,7 +26,7 @@ TARGET="${TARGET:-.}"
 TARGET="${TARGET%/}"
 
 MANIFEST_FILE="$TARGET/.agentcortex-manifest"
-ACX_VERSION="1.8.4"
+ACX_VERSION="1.8.6"
 
 # --- Self-deploy guard ---
 TARGET_ABS="$(cd "$TARGET" 2>/dev/null && pwd || echo "$TARGET")"

--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -12,9 +12,9 @@
   - Active Work Log Path: derive <worklog-key> from the raw branch name using filesystem-safe normalization before any gate checks.
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
 - **Project Name**: (set by /app-init)
-- **Last Updated**: 2026-06-30T21:00:00Z
+- **Last Updated**: 2026-06-30T23:00:00Z
 - **Last Verified**: 2026-06-30
-- **Update Sequence**: 101
+- **Update Sequence**: 102
 - **ADR Index**:
   - docs/adr/ADR-001-governance-friction-tuning.md — ADR-001: Governance Friction Tuning, accepted 2026-04-23
   - docs/adr/ADR-002-guarded-governance-writes.md — ADR-002: Guarded Governance Writes (lock unification + CI lint + lifecycle frontmatter), accepted 2026-04-25
@@ -101,6 +101,10 @@
 - [Category: rule-placement][Severity: HIGH][Trigger: authoring-safety-rule-or-auditing-rule-surfaces][prev: 3b15e10b] Sort SAFETY rules by hazard reachability, not token cost. A rule that must hold during a 30-second out-of-phase action (destructive commands, secrets, untrusted tool output) MUST live on the always-loaded surface (AGENTS.md Core Directives invariant cluster, cap ~5) - phase/tier-scoped files and platform adapters are probabilistic gates, and a probabilistic gate on an irreversible failure is a design error regardless of token savings. Confirmed 2026-06-11: 'Destructive Command Blocking' was advertised in both READMEs and machine-guarded in ADAPTER copies (validators checked Codex/Antigravity retained it!) while the canonical loaded surface had nothing - a downstream rm -rf cascade destroyed a parent repo working tree. Placement test for every new MUST: hazard reachable from any tool call AND irreversible/exfiltrating -> always-loaded; else phase surface is fine but README/docs must not claim it is always-on.
 - [Category: eval-mapping][Severity: MEDIUM][Trigger: adding-or-retargeting-eval-protects-tag][prev: 14ac98ca] An eval case can silently guard an EMPTY rule: protects-tags resolve at section level, so a case pointing at a section that contains no text for the behavior it tests still 'resolves' and scores green off the model's general training - verifier-without-defense, the inverse of advertised-but-unenforced. Confirmed 2026-06-11: prompt-injection-in-tool-output protected 'AGENTS.md Core Directives' which contained zero injection text for ~2 months. Discipline: when ADDING a rule, land the guarding case in the SAME commit; when ADDING/RETARGETING a case, quote the exact rule sentence it protects in the PR description - if you cannot quote it, the rule does not exist and the case is theatre.
 ## Ship History
+
+### Ship-chore-v1.8.6-release-2026-06-30
+- Feature shipped: v1.8.6 bundles PRs #299–#304 (dev-flow-hardening, all 13 ACs). Banners bumped 1.8.4→1.8.6 across 7 files (deploy.sh ACX_VERSION, CITATION.cff, Model Guide EN+zh-TW, Testing Protocol EN+zh-TW, antigravity-v5-runtime.md). CHANGELOG [1.8.6] prepended. v1.8.5 was cut and reverted (capabilities CI regression); this release skips that number. SSoT sequence 101→102.
+- Tests: Pass (docs-only chore; no engine/test logic change)
 
 ### Ship-claude-dev-flow-spec-settle-2026-06-30
 - **Branch `claude/dev-flow-spec-settle`** (quick-win, governance-runtime) — dev-flow-hardening spec finalized `status: draft` → `status: shipped`; `## Enforcement Notes (post-ship)` section added (AC-2/AC-5 honesty caveats + AC-13 non-required-check rationale + AC-7 no-mutation stance); Spec Index entry added to SSoT (SSoT Spec Index completeness FAIL → PASS). All 13 ACs complete (PRs #299–#303). SSoT sequence 100→101.

--- a/.agentcortex/docs/TESTING_PROTOCOL.md
+++ b/.agentcortex/docs/TESTING_PROTOCOL.md
@@ -1,4 +1,4 @@
-# Testing Protocol v1.8.4
+# Testing Protocol v1.8.6
 
 > **This document guides the AI Agent to produce high-quality, trustworthy, and defensive test code.**
 

--- a/.agentcortex/docs/TESTING_PROTOCOL_zh-TW.md
+++ b/.agentcortex/docs/TESTING_PROTOCOL_zh-TW.md
@@ -1,4 +1,4 @@
-# Testing Protocol (測試教戰守則) v1.8.4
+# Testing Protocol (測試教戰守則) v1.8.6
 >
 > **本文件旨在指引 AI Agent 產出高品質、可信任、且具備防禦性的測試程式碼。**
 

--- a/.agentcortex/docs/guides/antigravity-v5-runtime.md
+++ b/.agentcortex/docs/guides/antigravity-v5-runtime.md
@@ -8,7 +8,7 @@ Date: 2026-04-17
 > **Two version axes — do not conflate.** "Runtime v5" throughout this file is this
 > anti-drift *engine spec's* own generation number; the canonical Antigravity runtime
 > **contract** version is **Runtime v1** (see `AGENTS.md §Agentic OS Runtime v1`). The
-> framework release version (v1.8.4) is tracked separately in `CHANGELOG.md`.
+> framework release version (v1.8.6) is tracked separately in `CHANGELOG.md`.
 Scope: **Antigravity environments** (token-generation agents where shell exit codes don’t halt execution)
 
 ### Why v5 exists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.8.6] - 2026-06-30
+
+Development-flow hardening: 13 acceptance criteria across downstream-state isolation, gate/evidence honesty, CI/security enforcement truth, demonstration-over-green-gates, and developer-command hygiene (PRs #299–#304). Net effect: more governance MUSTs are now machine-enforced rather than self-reported. (v1.8.5 was cut and reverted for a capabilities CI regression; this release skips that number.)
+
+- **Downstream SSoT isolation + dry-run honesty (AC-1/AC-2, #299)**: deploy installs `.agentcortex/context/current_state.md` only from the template and fails closed if it is absent — the source repo's live SSoT is never shipped downstream; dry-run discloses the generated artifact.
+- **Gate/evidence honesty (AC-3/4/5/6, #300)**: `/ship` gate-receipt audit hard-fails on missing required receipts for feature/architecture-change; `Diff Base SHA` split from `Checkpoint SHA`; `verify_agent_evidence.py --strict` + honest 3-state wording; validator escalates current-branch Resume/Test-Gate gaps at handoff/ship to FAIL (historical stays WARN), sh/ps1 parity.
+- **Demonstration over green gates (AC-13, #301)**: user-facing-surface changes require an anchored demonstration — for deploy, a normalized manifest golden asserted against a CI re-run of real `deploy.sh`; honest-ceiling: non-executed surfaces (README render) stay advisory, no screenshot harness.
+- **CI/security enforcement truth (AC-7/8/9/12, #302)**: docs reconciled to the real required-check set; credential scan fails closed on scanner execution error; dependency audit now covers `.github/requirements-ci.txt` — which surfaced **CVE-2025-71176 in pytest 8.4.1**, fixed by bumping to pytest 9.0.3; the docs-only CI classifier no longer lets `.agentcortex/context/*` runtime state skip security-relevant jobs.
+- **Developer-command hygiene (AC-10/AC-11)**: bare `pytest` from repo root no longer dies on a gitignored cache demo (`norecursedirs` + rename + documented canonical command); `validate.ps1 --no-python` is a real alias of `-NoPython`.
+- Spec `docs/specs/dev-flow-hardening.md` finalized `draft → shipped` + indexed (#304).
+
 ## [1.8.4] - 2026-06-28
 
 Patch release: **deploy data-loss fix** (confirmed live in v1.8.3).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ authors:
   - family-names: Wen
     given-names: Kb
 title: "Agentic OS: Governance-First Workflows for AI Coding Agents"
-version: 1.8.4
+version: 1.8.6
 date-released: 2026-06-28
 url: "https://github.com/KbWen/agentic-os"
 abstract: "A governance-first framework for AI coding agents. Portable workflows, delivery gates, engineering guardrails, and 14 professional skills for Claude Code, OpenAI Codex, Google Antigravity, Cursor, GitHub Copilot, and other coding agents."

--- a/docs/AGENT_MODEL_GUIDE.md
+++ b/docs/AGENT_MODEL_GUIDE.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.8.4 — Model Selection Guide
+# Agentic OS v1.8.6 — Model Selection Guide
 
 > For human reference only — this file is not loaded into AI context.
 

--- a/docs/AGENT_MODEL_GUIDE_zh-TW.md
+++ b/docs/AGENT_MODEL_GUIDE_zh-TW.md
@@ -1,4 +1,4 @@
-# Agentic OS v1.8.4 — 模型選擇指南
+# Agentic OS v1.8.6 — 模型選擇指南
 
 > 人類參考用 — 此檔案不會被載入 AI context。
 


### PR DESCRIPTION
## [1.8.6] - 2026-06-30

Development-flow hardening: 13 acceptance criteria across downstream-state isolation, gate/evidence honesty, CI/security enforcement truth, demonstration-over-green-gates, and developer-command hygiene (PRs #299–#304). Net effect: more governance MUSTs are now machine-enforced rather than self-reported. (v1.8.5 was cut and reverted for a capabilities CI regression; this release skips that number.)

- **Downstream SSoT isolation + dry-run honesty (AC-1/AC-2, #299)**: deploy installs `.agentcortex/context/current_state.md` only from the template and fails closed if it is absent — the source repo's live SSoT is never shipped downstream; dry-run discloses the generated artifact.
- **Gate/evidence honesty (AC-3/4/5/6, #300)**: `/ship` gate-receipt audit hard-fails on missing required receipts for feature/architecture-change; `Diff Base SHA` split from `Checkpoint SHA`; `verify_agent_evidence.py --strict` + honest 3-state wording; validator escalates current-branch Resume/Test-Gate gaps at handoff/ship to FAIL (historical stays WARN), sh/ps1 parity.
- **Demonstration over green gates (AC-13, #301)**: user-facing-surface changes require an anchored demonstration — for deploy, a normalized manifest golden asserted against a CI re-run of real `deploy.sh`; honest-ceiling: non-executed surfaces (README render) stay advisory, no screenshot harness.
- **CI/security enforcement truth (AC-7/8/9/12, #302)**: docs reconciled to the real required-check set; credential scan fails closed on scanner execution error; dependency audit now covers `.github/requirements-ci.txt` — which surfaced **CVE-2025-71176 in pytest 8.4.1**, fixed by bumping to pytest 9.0.3; the docs-only CI classifier no longer lets `.agentcortex/context/*` runtime state skip security-relevant jobs.
- **Developer-command hygiene (AC-10/AC-11)**: bare `pytest` from repo root no longer dies on a gitignored cache demo (`norecursedirs` + rename + documented canonical command); `validate.ps1 --no-python` is a real alias of `-NoPython`.
- Spec `docs/specs/dev-flow-hardening.md` finalized `draft → shipped` + indexed (#304).
