### PR TITLE
ci: docs-pins job for docs-only PRs + audit-witness behavioral tests (#112)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -213,6 +213,31 @@ jobs:
           cd /tmp/test-project
           bash .agentcortex/bin/validate.sh
 
+  docs-pins:
+    # Docs-only PRs classify heavy=false and skip the pytest jobs — but the
+    # content-pin tests (README/INSTALL/spec prose) exist precisely to catch
+    # docs edits. This fast job (pure file reads, <1s) runs the pins when the
+    # heavy suite is skipped; heavy PRs already run them via the full suite,
+    # so the two paths are complementary, never double-gated (backlog #112).
+    name: Docs Content Pins
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.heavy != 'true'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: .github/requirements-ci.txt
+
+      - name: Install test dependencies
+        run: pip install -r .github/requirements-ci.txt
+
+      - name: Run docs content-pin tests
+        run: python -m pytest tests/ci/ -m docs_pin -v
+
   test-ci-structural:
     name: CI Structural Tests
     runs-on: ubuntu-latest

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,7 @@
 # don't weaken).
 markers =
     slow: shells out to real deploy.sh/validate.sh subprocesses (~1-5 min each); local fast loop: pytest -m "not slow"
+    docs_pin: pure file-read tests pinning README/INSTALL/spec prose; selected ADDITIVELY by the docs-pins CI job on docs-only PRs (heavy PRs run them via the full suite - never a deselect)
 # Recursion pruning — prevents collection of demo/scratch/temp directories that
 # contain non-test Python files (e.g. API-key-requiring demo scripts). Does NOT
 # narrow what CI collects (CI always passes explicit paths). (AC-10)

--- a/tests/ci/test_audit_witness.py
+++ b/tests/ci/test_audit_witness.py
@@ -9,7 +9,13 @@ mode that let the original tail-truncation gap ship unnoticed.
 
 from __future__ import annotations
 
+import shutil
+import subprocess
+import sys
+import tempfile
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 VALIDATE_SH = ROOT / ".agentcortex" / "bin" / "validate.sh"
@@ -102,3 +108,187 @@ def test_witness_verdict_parity() -> None:
     for v in shared_verdicts:
         assert v in s, f"bash validator missing witness verdict: {v!r}"
         assert v in p, f"powershell validator missing witness verdict: {v!r}"
+
+
+# ---------------------------------------------------------------------------
+# Behavioral (slow, subprocess) — the git append-only witness actually renders
+# the right VERDICT for each input. The string-presence tests above only prove
+# the verdicts exist in the source; these three drive validate.sh over a real
+# fixture repo (deployed framework + git repo + origin/main baseline) and assert
+# the correct witness line fires. Bash validator only — behavioral sh↔ps1 parity
+# is a Windows concern already guarded structurally by test_witness_verdict_parity.
+#
+# Fixture shape (mirrors test_validator_false_positives.py deploy + git helpers):
+#   1. deploy the framework into a temp dir (empty archive/, no INDEX.jsonl);
+#   2. build archive/INDEX.jsonl with N hash-chained entries via
+#      append_chain_entry.py, and create each referenced log file on disk so the
+#      D4 "referenced logs missing" WARN stays quiet;
+#   3. git init -b main + commit, clone --bare as origin, remote add + fetch so
+#      `git merge-base origin/main HEAD` resolves — the witness's precondition.
+# The committed INDEX.jsonl is the baseline; each test then mutates the working
+# copy (uncommitted) and asserts the resulting verdict.
+# ---------------------------------------------------------------------------
+
+DEPLOY_SH = ROOT / ".agentcortex" / "bin" / "deploy.sh"
+
+# bash discovery (mirror test_validator_false_positives.py — avoid the
+# WindowsApps bash stub, which is not a real POSIX shell).
+_git_path = shutil.which("git")
+_git_root = Path(_git_path).parent.parent if _git_path else None
+_bash_candidates = [
+    str(_git_root / "bin" / "bash.exe") if _git_root else None,
+    str(_git_root / "usr" / "bin" / "bash.exe") if _git_root else None,
+    r"C:\Program Files\Git\bin\bash.exe",
+    r"C:\Program Files\Git\usr\bin\bash.exe",
+    shutil.which("bash"),
+]
+bash = next(
+    (c for c in _bash_candidates if c and "WindowsApps" not in c and Path(c).exists()),
+    None,
+)
+requires_bash = pytest.mark.skipif(bash is None, reason="bash not available")
+
+# Witness verdict substrings — the same literals the string-presence tests pin.
+WITNESS_PASS = "append-only invariant holds"
+WITNESS_FAIL_TRUNCATION = "fewer than baseline"
+WITNESS_FAIL_EDIT = "is not a prefix of local"
+
+_ENTRY_TEMPLATE = (
+    '{{"log": "{log}", "branch": "t", "classification": "quick-win", '
+    '"shipped": "2026-07-02"}}'
+)
+
+
+def _run_validate(cwd: Path) -> str:
+    proc = subprocess.run(
+        [bash, str(cwd / ".agentcortex" / "bin" / "validate.sh")],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        cwd=str(cwd),
+    )
+    return proc.stdout + proc.stderr
+
+
+def _witness_line(output: str) -> str:
+    """Return only the witness verdict line, so assertions never trip over an
+    unrelated line elsewhere in the (large) validator output."""
+    for line in output.splitlines():
+        if "append-only witness" in line:
+            return line
+    return ""
+
+
+def _append_entry(target: Path, log_name: str) -> None:
+    """Append one hash-chained INDEX.jsonl entry (prev_sha computed by the
+    helper) and create the referenced log file on disk (quiets D4)."""
+    idx = target / ".agentcortex" / "context" / "archive" / "INDEX.jsonl"
+    proc = subprocess.run(
+        [sys.executable,
+         str(target / ".agentcortex" / "tools" / "append_chain_entry.py"),
+         "append", "--path", str(idx),
+         "--entry", _ENTRY_TEMPLATE.format(log=log_name)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    assert proc.returncode == 0, f"append_chain_entry failed:\n{proc.stderr}"
+    (idx.parent / log_name).write_text(
+        f"# archived log {log_name}\n", encoding="utf-8", newline="\n"
+    )
+
+
+def _build_witness_fixture(td: Path) -> Path:
+    """Deploy the framework, seed a valid 3-entry chained INDEX.jsonl, and make
+    it a git repo with a committed origin/main baseline (so the witness's
+    merge-base precondition holds). Returns the deployed target dir."""
+    target = td / "proj"
+    target.mkdir()
+    deployed = subprocess.run(
+        [bash, str(DEPLOY_SH), str(target)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        cwd=str(ROOT),
+    )
+    assert deployed.returncode == 0, f"deploy failed:\n{deployed.stderr}"
+
+    for name in ("a.md", "b.md", "c.md"):
+        _append_entry(target, name)
+
+    # git repo + committed baseline reachable as origin/main.
+    def _git(*args: str) -> subprocess.CompletedProcess:
+        p = subprocess.run(
+            ["git", "-C", str(target), *args],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+        )
+        assert p.returncode == 0, f"git {' '.join(args)} failed:\n{p.stderr}"
+        return p
+
+    _git("init", "-b", "main")
+    _git("config", "user.email", "witness-fixture@example.com")
+    _git("config", "user.name", "Witness Fixture")
+    _git("add", "-A")
+    _git("commit", "-q", "-m", "seed INDEX.jsonl baseline")
+
+    origin = td / "origin.git"
+    clone = subprocess.run(
+        ["git", "clone", "--bare", "-q", str(target), str(origin)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    assert clone.returncode == 0, f"bare clone failed:\n{clone.stderr}"
+    _git("remote", "add", "origin", str(origin))
+    _git("fetch", "-q", "origin")
+
+    # Precondition the witness depends on: merge-base must resolve.
+    mb = _git("merge-base", "origin/main", "HEAD")
+    assert mb.stdout.strip(), "fixture: git merge-base origin/main HEAD did not resolve"
+    return target
+
+
+@pytest.mark.slow
+@requires_bash
+def test_witness_pass_on_pure_append() -> None:
+    """Appending one MORE chained entry (uncommitted) keeps the committed baseline
+    a prefix of the working copy → PASS. Neither FAIL verdict may appear."""
+    with tempfile.TemporaryDirectory() as td:
+        target = _build_witness_fixture(Path(td))
+        _append_entry(target, "d.md")  # pure append, uncommitted
+
+        line = _witness_line(_run_validate(target))
+        assert WITNESS_PASS in line, f"expected PASS witness verdict; got: {line!r}"
+        assert WITNESS_FAIL_TRUNCATION not in line, f"unexpected truncation FAIL: {line!r}"
+        assert WITNESS_FAIL_EDIT not in line, f"unexpected prefix FAIL: {line!r}"
+
+
+@pytest.mark.slow
+@requires_bash
+def test_witness_fails_on_tail_truncation() -> None:
+    """Deleting the LAST line of INDEX.jsonl (uncommitted) makes the local copy
+    have fewer entries than the committed baseline → FAIL 'fewer than baseline'."""
+    with tempfile.TemporaryDirectory() as td:
+        target = _build_witness_fixture(Path(td))
+        idx = target / ".agentcortex" / "context" / "archive" / "INDEX.jsonl"
+        lines = idx.read_text(encoding="utf-8").splitlines(keepends=True)
+        idx.write_text("".join(lines[:-1]), encoding="utf-8", newline="")
+
+        line = _witness_line(_run_validate(target))
+        assert WITNESS_FAIL_TRUNCATION in line, (
+            f"expected tail-truncation FAIL verdict; got: {line!r}"
+        )
+
+
+@pytest.mark.slow
+@requires_bash
+def test_witness_fails_on_published_entry_edit() -> None:
+    """Editing a field inside the FIRST (published) line, keeping the line count
+    identical, makes the committed baseline no longer a prefix of local → FAIL
+    'is not a prefix of local'."""
+    with tempfile.TemporaryDirectory() as td:
+        target = _build_witness_fixture(Path(td))
+        idx = target / ".agentcortex" / "context" / "archive" / "INDEX.jsonl"
+        lines = idx.read_text(encoding="utf-8").splitlines(keepends=True)
+        assert '"branch": "t"' in lines[0], (
+            f"fixture precondition: first entry should carry branch 't'; got {lines[0]!r}"
+        )
+        lines[0] = lines[0].replace('"branch": "t"', '"branch": "EDITED"')
+        idx.write_text("".join(lines), encoding="utf-8", newline="")
+
+        line = _witness_line(_run_validate(target))
+        assert WITNESS_FAIL_EDIT in line, (
+            f"expected published-entry-edit FAIL verdict; got: {line!r}"
+        )

--- a/tests/ci/test_ci_hardening.py
+++ b/tests/ci/test_ci_hardening.py
@@ -143,3 +143,37 @@ def test_ac10_pytest_ini_has_norecursedirs() -> None:
             f"pytest.ini norecursedirs must include {entry!r} to prevent collecting "
             f"non-test files from that directory (AC-10)"
         )
+
+
+# ---------------------------------------------------------------------------
+# Backlog #112: docs-pins job — content-pin tests must run on docs-only PRs.
+# ---------------------------------------------------------------------------
+
+def test_docs_pins_job_runs_when_heavy_is_false() -> None:
+    """validate.yml must carry a docs-pins job gated on heavy != 'true' running -m docs_pin."""
+    txt = WORKFLOW.read_text(encoding="utf-8")
+    assert "docs-pins:" in txt, "validate.yml must define the docs-pins job (#112)"
+    m = re.search(r"docs-pins:(.*?)\n  [a-z][a-z0-9-]*:", txt, re.DOTALL)
+    block = m.group(1) if m else ""
+    assert "needs.changes.outputs.heavy != 'true'" in block, (
+        "docs-pins must run when heavy jobs are SKIPPED (heavy != 'true') — that is its whole point (#112)"
+    )
+    assert "-m docs_pin" in block, "docs-pins must select tests via the docs_pin marker (#112)"
+
+
+def test_docs_pin_marker_registered_and_selects_tests() -> None:
+    """pytest.ini registers docs_pin, and the marker selects the content-pin tests (>=4)."""
+    assert "docs_pin" in PYTEST_INI.read_text(encoding="utf-8"), (
+        "pytest.ini must register the docs_pin marker (#112)"
+    )
+    import subprocess, sys
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "tests/ci/", "-m", "docs_pin", "--collect-only", "-q"],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", cwd=str(ROOT),
+    )
+    m = re.search(r"(\d+)/\d+ tests collected", proc.stdout)
+    count = int(m.group(1)) if m else 0
+    assert count >= 4, (
+        f"-m docs_pin must select >=4 content-pin tests (got {count}) — a lost tag silently "
+        f"re-opens the docs-only gate hole (#112). {proc.stdout[-400:]}"
+    )

--- a/tests/ci/test_deploy_tiering.py
+++ b/tests/ci/test_deploy_tiering.py
@@ -447,6 +447,7 @@ def test_source_and_downstream_ignore_guard_receipt_directory() -> None:
     assert ".agentcortex/context/.guard_receipts/" in deploy_sh
 
 
+@pytest.mark.docs_pin
 def test_text_only_install_does_not_copy_runtime_context() -> None:
     install = INSTALL.read_text(encoding="utf-8")
     text_only = install.split("<summary><b>Text-only usage", 1)[1].split("</details>", 1)[0]
@@ -547,6 +548,7 @@ def test_validators_check_override_step_parity() -> None:
     assert "Load Override Layer" in VALIDATE_PS1.read_text(encoding="utf-8")
 
 
+@pytest.mark.docs_pin
 def test_readme_fork_guidance_parity() -> None:
     """Fork/clone customization guidance (ADR-004/ADR-005) must stay reachable
     from both language entry points. The English README was slimmed to a

--- a/tests/ci/test_pre_commit_hook.py
+++ b/tests/ci/test_pre_commit_hook.py
@@ -141,6 +141,7 @@ def test_ac3_guard_receipt_warning_is_advisory_only(tmp_path: Path) -> None:
     assert "GUARD WARN: AGENTS.md" in result.stdout
 
 
+@pytest.mark.docs_pin
 def test_ac4_ac5_readme_documents_pre_commit_hook_setup() -> None:
     # The pre-commit hook setup moved from the README to the dedicated install
     # guide (docs/INSTALL.md) when the README was slimmed to a landing page; the

--- a/tests/ci/test_security_workflow.py
+++ b/tests/ci/test_security_workflow.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import re
 import sys
 import unittest
+
+import pytest
 from pathlib import Path
 
 try:
@@ -422,6 +424,7 @@ class TestVersionPinningGlobal(unittest.TestCase):
         )
 
 
+@pytest.mark.docs_pin
 class TestClaimsVsReality(unittest.TestCase):
     """AC-7 (dev-flow-hardening): security spec must not overstate enforcement reality.
 


### PR DESCRIPTION
## What

Backlog **#112** — both P1s from the 2026-07-02 test-quality audit:

**(a) CI docs-only gate hole.** The README/INSTALL/spec content-pin tests lived only in pytest jobs gated `heavy == 'true'`, while `README.md`/`docs/*` classify inert (`heavy=false`) — so the pins **never ran on the docs-only PRs most likely to break them**. A docs-only PR could delete the INSTALL link, the fork guidance, or re-introduce the false pre-merge-gate claim, and CI stayed green.

**(b) Audit-witness had zero behavioral coverage.** The INDEX.jsonl git append-only witness (the ADR-003 tamper-evidence backstop for tail-truncation) was tested only by source-substring presence — the prefix-comparison logic could be inverted and every test would still pass.

Classification: **quick-win** (CI job + test files; classifier arms untouched).

## Changes

**(a) docs-pins job**
- `pytest.ini`: registers a `docs_pin` marker — an ADDITIVE selector, never a deselect (consistent with the file's existing marker philosophy).
- Tagged the 4 pin surfaces: `test_readme_fork_guidance_parity`, `test_text_only_install_does_not_copy_runtime_context` (test_deploy_tiering.py), `test_ac4_ac5_readme_documents_pre_commit_hook_setup` (test_pre_commit_hook.py), `TestClaimsVsReality` (test_security_workflow.py). All pure file reads — `-m docs_pin` runs **5 tests in 0.12s**.
- `validate.yml`: new `docs-pins` job, `if: needs.changes.outputs.heavy != 'true'` — runs exactly when the heavy suite is skipped; heavy PRs already run the pins via the full suite. Complementary, never double-gated. Actions SHA-pinned per repo convention.
- 2 lock tests in `test_ci_hardening.py`: the job stays gated `!= 'true'` with `-m docs_pin`, and the marker keeps selecting ≥4 tests (a lost tag silently re-opens the hole).

**(b) witness behavioral tests** (`test_audit_witness.py`, +190 lines)
- Fixture: deploy → seed a 3-entry hash-chained INDEX.jsonl via `append_chain_entry.py` (+ referenced logs on disk so the D4 WARN stays quiet) → `git init` + commit + bare-clone origin + fetch → assert `merge-base origin/main HEAD` resolves.
- `test_witness_pass_on_pure_append` (PASS verdict + both FAIL verdicts absent), `test_witness_fails_on_tail_truncation` (`fewer than baseline`), `test_witness_fails_on_published_entry_edit` (`is not a prefix of local`). Assertions grep the witness line only (no whole-output flakiness).
- Authored by a delegated subagent under a single-file constraint; independently verified by the orchestrator: scope diff confirmed (only the one file), tests re-run from a clean process.

## Evidence

- `-m docs_pin`: 5 passed, 0.12s. Lock tests: `test_ci_hardening.py` 13 passed. Tagged-file regression: 47 passed.
- Witness behavioral: 12 passed (9 string-presence + 3 behavioral), re-run by the orchestrator.
- `validate.yml` YAML parses; classifier arms untouched (AC-12 pins green).
- Full CI-equiv sweep green before push (see PR checks).
- Note: THIS PR classifies heavy (code+CI changes), so docs-pins will show as **skipped** here — that is correct behavior; the job fires on docs-only PRs.

## Rollback

Revert the commit. The job is additive/non-required; tests are additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
