### PR TITLE
fix(guard): retry file_lock on Windows delete-pending PermissionError

### DIFF
--- a/.agentcortex/tools/guard_context_write.py
+++ b/.agentcortex/tools/guard_context_write.py
@@ -364,6 +364,19 @@ def file_lock(
                     ) from exc
                 time.sleep(backoff_ms / 1000.0)
                 backoff_ms = min(int(backoff_ms * 2), 1000)
+            except PermissionError:
+                # Windows: a lock file in delete-pending state (holder mid-unlink,
+                # or AV/indexer briefly holding it) surfaces as ACCESS_DENIED from
+                # os.open — NOT FileExistsError — during a window of a few ms.
+                # Sibling quirk to the WinError 32 note on the unlink side below.
+                # Treat as lock-busy and retry with backoff; if it persists past
+                # the deadline, re-raise the ORIGINAL PermissionError so a genuine
+                # ACL misconfiguration stays diagnosable (unlike the busy-timeout
+                # RuntimeError above).
+                if time.monotonic() >= deadline:
+                    raise
+                time.sleep(backoff_ms / 1000.0)
+                backoff_ms = min(int(backoff_ms * 2), 1000)
         if handle is None:
             raise RuntimeError(f"lock busy: {lock_path.name}")
     except BaseException:

--- a/tests/guard/test_d2_1_guard_race.py
+++ b/tests/guard/test_d2_1_guard_race.py
@@ -103,5 +103,56 @@ class TestConcurrentAppendSubprocess(unittest.TestCase):
             self.assertEqual(seen, set(range(N_CONCURRENT)))
 
 
+class TestWindowsDeletePendingPermissionError(unittest.TestCase):
+    """file_lock must survive the Windows delete-pending window, where os.open
+    on a lock file being unlinked by the previous holder raises PermissionError
+    (ACCESS_DENIED) instead of FileExistsError. Observed twice on windows-latest
+    CI (2026-07-02, PR #311): the retry loop caught only FileExistsError, so the
+    subprocess crashed. Deterministic reproduction: fail os.open once with
+    PermissionError, then delegate to the real os.open."""
+
+    def test_permission_error_is_retried_as_busy(self) -> None:
+        import os as _os
+
+        real_open = _os.open
+        calls = {"n": 0}
+
+        def flaky_open(path, flags, *a, **kw):
+            if str(path).endswith(".guard.lock") and calls["n"] == 0:
+                calls["n"] += 1
+                raise PermissionError(13, "Access is denied (delete-pending sim)", str(path))
+            return real_open(path, flags, *a, **kw)
+
+        with tempfile.TemporaryDirectory() as td:
+            lock_path = Path(td) / "sim.jsonl.guard.lock"
+            gw.os.open = flaky_open
+            try:
+                with gw.file_lock(lock_path, max_wait_seconds=5.0):
+                    pass  # acquired despite the injected delete-pending window
+            finally:
+                gw.os.open = real_open
+        self.assertEqual(calls["n"], 1, "the PermissionError branch must have been exercised")
+
+    def test_persistent_permission_error_reraises_original(self) -> None:
+        import os as _os
+
+        real_open = _os.open
+
+        def always_denied(path, flags, *a, **kw):
+            if str(path).endswith(".guard.lock"):
+                raise PermissionError(13, "Access is denied (persistent)", str(path))
+            return real_open(path, flags, *a, **kw)
+
+        with tempfile.TemporaryDirectory() as td:
+            lock_path = Path(td) / "acl.jsonl.guard.lock"
+            gw.os.open = always_denied
+            try:
+                with self.assertRaises(PermissionError):
+                    with gw.file_lock(lock_path, max_wait_seconds=0.3):
+                        pass
+            finally:
+                gw.os.open = real_open
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

PR #311's `Pytest (Windows) (2)` failed **twice** on `test_d2_1_guard_race` with `PermissionError: [Errno 13]` from `guard_context_write.py:354` — a **pre-existing** bug on main (#311 touches no guard code; local Windows passes; the 2-core hosted runner widens the window).

**Root cause**: on Windows, `os.open(O_CREAT|O_EXCL)` on a lock file in the **delete-pending** state (previous holder mid-`unlink`, or AV/indexer briefly holding it) raises `PermissionError`, not `FileExistsError` — and `file_lock`'s retry loop caught only `FileExistsError`, so the acquirer crashed instead of retrying. The unlink side already documents the sibling WinError 32 quirk; the open side was missed.

## Fix

One `except PermissionError` arm in the retry loop: same busy backoff; if it persists past the deadline, **re-raise the original PermissionError** (a genuine ACL misconfiguration stays diagnosable, unlike the busy-timeout RuntimeError). Cross-platform — no platform gate — so it's deterministically testable.

## Tests

- `test_permission_error_is_retried_as_busy`: injected one-shot PermissionError → lock still acquired; asserts the new arm actually executed.
- `test_persistent_permission_error_reraises_original`: persistent denial → original PermissionError re-raised after the deadline.
- `test_d2_1_guard_race.py` 4 passed; `tests/guard/` non-slow 274 passed.

## Rollback

Revert the commit (one except-arm + tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)