### PR TITLE
fix(claude-adapter): remove unconditional guardrails required-read from 10 command stubs

### DIFF
--- a/.claude/commands/bootstrap.md
+++ b/.claude/commands/bootstrap.md
@@ -5,7 +5,6 @@ Execute the canonical workflow: `.agent/workflows/bootstrap.md`
 ## Required reads before execution
 
 1. `AGENTS.md` — global directives (Intent Router, Gate Engine, Sentinel)
-2. `.agent/rules/engineering_guardrails.md` — classification tiers and gate rules
 3. `.agent/rules/state_machine.md` — phase transitions
 4. `.agentcortex/context/current_state.md` — SSoT
 

--- a/.claude/commands/govern-docs.md
+++ b/.claude/commands/govern-docs.md
@@ -5,7 +5,6 @@ Execute the canonical workflow: `.agent/workflows/govern-docs.md`
 ## Required reads before execution
 
 1. `AGENTS.md` — global directives (Intent Router, Gate Engine, Sentinel)
-2. `.agent/rules/engineering_guardrails.md` — constitution for all engineering work
 3. `.agentcortex/context/current_state.md` — SSoT
 
 ## Execution

--- a/.claude/commands/hotfix.md
+++ b/.claude/commands/hotfix.md
@@ -5,7 +5,6 @@ Execute the canonical workflow: `.agent/workflows/hotfix.md`
 ## Required reads before execution
 
 1. `AGENTS.md` — global directives (Intent Router, Gate Engine, Sentinel)
-2. `.agent/rules/engineering_guardrails.md` — classification tiers and gate rules
 3. `.agent/rules/state_machine.md` — phase transitions
 4. `.agentcortex/context/current_state.md` — SSoT
 

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -5,7 +5,6 @@ Execute the canonical workflow: `.agent/workflows/implement.md`
 ## Required reads before execution
 
 1. `AGENTS.md` — global directives
-2. `.agent/rules/engineering_guardrails.md` — change safety (§2), scope discipline (§7)
 3. `.agent/rules/security_guardrails.md` — auto-enforced during implementation
 4. Active Work Log — must contain plan reference before proceeding
 

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -5,7 +5,6 @@ Execute the canonical workflow: `.agent/workflows/plan.md`
 ## Required reads before execution
 
 1. `AGENTS.md` — global directives
-2. `.agent/rules/engineering_guardrails.md` — gate rules (§4 Design Before Implementation)
 3. Active Work Log at `.agentcortex/context/work/<worklog-key>.md`
 
 ## Execution

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -5,7 +5,6 @@ Execute the canonical workflow: `.agent/workflows/ship.md`
 ## Required reads before execution
 
 1. `AGENTS.md` — global directives (Delivery Gates, No Evidence = No Ship)
-2. `.agent/rules/engineering_guardrails.md` — §10.5 Handoff/Ship Hard Gate
 3. `.agent/rules/security_guardrails.md` — final security check
 4. Active Work Log — must contain handoff references:
    `ship:[doc=<path>][code=<path>][log=<path>]`

--- a/.claude/commands/spec-intake.md
+++ b/.claude/commands/spec-intake.md
@@ -5,7 +5,6 @@ Execute the canonical workflow: `.agent/workflows/spec-intake.md`
 ## Required reads before execution
 
 1. `AGENTS.md` — global directives (Spec Intake Gate, Intent Router)
-2. `.agent/rules/engineering_guardrails.md` — §4 Design Before Implementation
 3. `.agentcortex/context/current_state.md` — check for existing `_product-backlog.md`
 
 ## Execution

--- a/.claude/commands/test-classify.md
+++ b/.claude/commands/test-classify.md
@@ -5,7 +5,6 @@ Execute the canonical workflow: `.agent/workflows/test-classify.md`
 ## Required reads before execution
 
 1. `AGENTS.md` — global directives
-2. `.agent/rules/engineering_guardrails.md` — §5 Testing & Verification, §10.2 Gate Evidence
 3. Active Work Log — must contain classification
 
 ## Execution

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -5,7 +5,6 @@ Execute the canonical workflow: `.agent/workflows/test.md`
 ## Required reads before execution
 
 1. `AGENTS.md` — global directives
-2. `.agent/rules/engineering_guardrails.md` — testing & verification (§5)
 3. Active Work Log — must contain implementation evidence
 
 ## Execution

--- a/.claude/commands/worktree-first.md
+++ b/.claude/commands/worktree-first.md
@@ -5,7 +5,6 @@ Execute the canonical workflow: `.agent/workflows/worktree-first.md`
 ## Required reads before execution
 
 1. `AGENTS.md` — global directives (Intent Router, Gate Engine, Sentinel)
-2. `.agent/rules/engineering_guardrails.md` — classification tiers and gate rules
 3. `.agentcortex/context/current_state.md` — SSoT
 
 ## Execution


### PR DESCRIPTION
## Summary

Removes the unconditional `.agent/rules/engineering_guardrails.md` "Required read before execution" list item from the 10 `.claude/commands/` stubs that carried it (bootstrap, plan, implement, ship, hotfix, test, govern-docs, spec-intake, test-classify, worktree-first).

The line contradicted the canonical conditional-loading rules on three surfaces:
- `CLAUDE.md` Startup step 4 — *Skip for tiny-fix and quick-win*
- `engineering_guardrails.md` Quick Mode / Skip Mode — *Do NOT read this file*
- `bootstrap.md` TOKEN LEAK BLOCK — reading it for tiny-fix/quick-win is a structural Token Leak violation

The canonical workflows own conditional rule-loading and cite specific guardrails sections at point of use, so the blanket stub line was redundant for heavy tiers and wrong for the most common ones. Same defect class as the shipped #118 adapter-sync fix. Backlog row #126.

`ask-local.md` is deliberately NOT edited: its guardrails mention is a functional §8.2 fallback citation, not a required-read (verified during implementation; logged in the Work Log Drift Log).

**Adopter delta**: on quick-win/tiny-fix `/plan`, `/implement`, etc., a Claude Code adopter's agent is no longer instructed to pre-load a ~3k-token guardrails read the workflow forbids; feature/arch/hotfix behavior unchanged (canonical workflows still load guardrails per their own tables).

## Evidence

- Diff: exactly 10 files × 1 deletion; `.agent/workflows/<cmd>.md` dispatch strings (pinned by `check_command_sync.py`) untouched.
- `pytest tests/ci tests/guard .agentcortex/tests -m "not slow"` → 581 passed.
- `validate.sh` → pass=113 warn=3 fail=0 (WARNs pre-existing/unrelated).
- Independent adversarial review: **PASS** (8/8 criteria PROVEN; reviewer independently reproduced both evidence commands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
