### PR TITLE
docs(audit): record governance fail-open and executor safety findings

### DIFF
--- a/docs/reviews/2026-07-11-govern-audit-external-executor.md
+++ b/docs/reviews/2026-07-11-govern-audit-external-executor.md
@@ -1,0 +1,181 @@
+# Governance Self-Audit — External Executor Safety — 2026-07-11
+
+Scope: two additional Codex-led passes over external CLI delegation governance.
+Pass 1 traced timeout, retry, and post-flight state transitions. Pass 2 tested
+executor attribution, dirty-worktree preservation, and explicit Claude handoff.
+
+External-signal status: `same-vendor-only` for the audit verdict. Claude is the
+designated implementation executor after this audit-only pull request; Claude's
+patch remains junior-tool output and requires independent Codex or human review.
+
+## Validator Baseline
+
+- Command: `.agentcortex/bin/validate.ps1`
+- Result: `pass=114 warn=4 fail=0 skip=2`
+- The extra local warning versus the prior snapshot is one stale advisory Work
+  Log lock from the intentionally paused remediation attempt. The other warnings
+  are the known historical receipts and eval-coverage inventory.
+
+## Already Known and Excluded
+
+- Backlog #105 covers deploy version drift and interrupted half-upgrades, not
+  external executor process timeout or retry state.
+- Backlog #113 covers no-Python validator divergence, not tool process failures.
+- Backlog #120 covers missing default-on downstream enforcement, not executor
+  attribution or worktree preservation.
+- The first 2026-07-11 audit covers command adapters and `routing_actions`
+  parsing. Those findings are not repeated here.
+- The Global Lesson on errored mutation batches warns operators to re-derive
+  state, but the external-tool workflow does not operationalize that lesson.
+
+## Round 1 — Failure-State and Retry Audit
+
+### P1 — Timeout has no mandatory post-failure state reconstruction
+
+The Claude workflow defines post-flight only "after Claude returns" and its error
+table has no timeout, killed-process, partial-output, or nonzero-exit branch. A
+timed-out executor can write files before termination while returning no usable
+summary. Retrying from an earlier status sample can then overlap or duplicate
+those changes.
+
+Observed reproduction:
+
+1. A bounded Claude CLI implementation command was started with a 600-second
+   shell timeout and a five-file allowlist.
+2. A mid-run `git status --short` sample was empty; the command later exited 124
+   at 604 seconds without a Claude result payload.
+3. Before the retry completed, all five allowed files were present in the diff;
+   the retry reported that negative tests "were already added by a prior pass."
+4. The recovered changes were preserved in the local diagnostic stash named
+   `scope-creep escalation: codex/governance-two-pass-audit claude-wip`.
+
+Evidence:
+
+- `.agent/workflows/claude-cli.md:98-110` runs post-flight only after normal
+  completion.
+- `.agent/workflows/claude-cli.md:143-151` omits timeout and nonzero-exit cases.
+- `.agent/rules/engineering_guardrails.md:238-245` requires post-flight review
+  but does not define failure-state reconstruction.
+- No test under `tests/` or `.agentcortex/tests/` exercises Claude/Codex CLI
+  timeout, late writes, or retry behavior.
+
+Impact: duplicate edits, acceptance of an unreported partial patch, or a second
+executor mutating a worktree whose state the orchestrator incorrectly considers
+clean.
+
+Required fix: every abnormal executor exit must stop retries, wait for process
+termination, re-run `git status` plus a baseline-relative diff, record partial
+state, and require explicit reconciliation before another invocation.
+
+## Round 2 — Attribution and Worktree-Preservation Audit
+
+### P1 — Unauthorized-file rollback can erase pre-existing user work
+
+Claude and Codex pre-flight steps do not capture the starting worktree or a
+per-file diff baseline. Post-flight then instructs the orchestrator to revert
+files outside the target list; the Codex workflow explicitly recommends
+`git checkout -- <file>`. If an out-of-scope file was already dirty before the
+executor touched it, an entire-file revert cannot distinguish user changes from
+executor changes and can destroy both.
+
+Evidence:
+
+- `.agent/workflows/claude-cli.md:39-54` has no clean-tree check, status snapshot,
+  or baseline diff capture.
+- `.agent/workflows/claude-cli.md:98-103` orders scope verification only after
+  execution and mandates a revert on violation.
+- `.agent/workflows/codex-cli.md:92-102,179-185` mirrors the gap and names the
+  destructive whole-file checkout directly.
+- `ask-local` avoids this class because the junior model returns a patch and the
+  primary applies it; it never writes the worktree directly.
+
+Impact: loss of unrelated human or agent changes in a dirty worktree while the
+governance system claims it is restoring scope.
+
+Required fix: capture the pre-flight dirty-file set and diff, prefer an isolated
+worktree for write-capable executors, and never whole-file-revert a path that was
+dirty at baseline. Reject or surgically reverse only executor-attributable hunks.
+
+### P2 — Explicit Claude delegation can silently become a different executor
+
+The canonical guardrail requires `Executor: <tool>` before availability probing
+and then silently falls back when the tool is unavailable. The Claude workflow
+reverses that order by probing first and creating/updating the Work Log later.
+Neither contract requires the final user-facing handoff to state that an
+explicitly requested Claude execution was actually performed by the native
+orchestrator.
+
+Evidence:
+
+- `.agent/rules/engineering_guardrails.md:240-244` orders executor recording
+  before the silent availability fallback.
+- `.agent/workflows/claude-cli.md:44-54` probes availability/auth first, then
+  writes `Executor: Claude CLI`.
+- `.agent/workflows/claude-cli.md:145-151` silently falls back for missing CLI or
+  auth, while post-flight recording is described only after Claude completes.
+- `.agent/workflows/codex-cli.md:179-185` instead tells the user to install/login
+  and stop, demonstrating cross-module policy drift for the same §8.2 contract.
+
+Impact: inaccurate executor provenance in Work Logs and a user believing Claude
+made a change when a different model actually did.
+
+Required fix: distinguish optional acceleration from explicit executor intent;
+always record `Requested Executor`, `Actual Executor`, and fallback reason. A
+fallback may remain low-noise, but final completion and handoff must disclose an
+executor mismatch.
+
+## Closed With Reason
+
+- The stale `GPT-1.0` orchestrator wording in CLI examples is cosmetic and does
+  not change runtime behavior. Close unless it causes a real adapter failure.
+- `bypassPermissions` is not independently reported: bounded prompts plus
+  post-flight review are a valid defense when the new pre-flight baseline and
+  abnormal-exit reconciliation requirements above are added.
+
+## Backlog Disposition
+
+No backlog rows were added. All three surviving findings are `do-now` inputs for
+the user-requested Claude implementation after this audit PR is opened.
+
+## Claude Implementation Handoff
+
+Do not add fixes to this audit-only PR. Start from updated `main` after the audit
+PR is merged, or use a clearly labeled stacked branch if implementation must
+start earlier.
+
+Recommended work split:
+
+1. `feature/validator-fail-open-hardening`: implement the three findings from
+   `docs/reviews/2026-07-11-govern-audit.md`. The preserved local stash is
+   evidence, not an approved patch; inspect it with `git stash show -p` and do
+   not apply it before feature bootstrap/spec/plan gates pass.
+2. `feature/external-executor-safety`: implement timeout reconciliation,
+   dirty-tree baselines, safe scope rollback, and requested/actual executor
+   receipts from this report.
+
+Acceptance minimum:
+
+- Negative behavioral tests for timeout/partial writes and retry blocking.
+- Dirty-worktree fixture proving unrelated pre-existing hunks survive a scope
+  violation.
+- Work Log fixture proving requested and actual executors cannot be conflated.
+- Cross-workflow contract test covering Claude CLI, Codex CLI, and §8.2.
+- Full `pytest` CI-equivalent suite and both validators pass before review.
+
+## routing_actions
+
+```yaml
+routing_actions:
+  - finding: "External executor timeout and nonzero exits require baseline-relative state reconstruction before retry."
+    target_doc: "docs/architecture/document-governance.md"
+    status: pending
+    owner: "claude-implementation-handoff"
+  - finding: "Write-capable executor rollback must preserve files and hunks that were dirty at pre-flight baseline."
+    target_doc: "docs/architecture/document-governance.md"
+    status: pending
+    owner: "claude-implementation-handoff"
+  - finding: "Requested and actual external executors require distinct, user-visible provenance."
+    target_doc: "docs/architecture/document-governance.md"
+    status: pending
+    owner: "claude-implementation-handoff"
+```

--- a/docs/reviews/2026-07-11-govern-audit.md
+++ b/docs/reviews/2026-07-11-govern-audit.md
@@ -1,0 +1,150 @@
+# Governance Self-Audit — 2026-07-11
+
+Scope: two-pass audit of governance gates, validators, adapter wiring, and
+finding-routing enforcement. Pass 1 mapped rule-to-validator/test/CI coverage;
+Pass 2 attacked the resulting seams with isolated fixtures.
+
+External-signal status: `same-vendor-only` at snapshot time. The verified
+findings are scheduled for a Claude CLI follow-up after this report commit.
+
+## Validator Baseline
+
+- Command: `.agentcortex/bin/validate.ps1`
+- Result: `pass=98 warn=3 fail=0 skip=2`
+- Existing warnings: three historical gate-bypass logs, one malformed historical
+  receipt, and 28 MUST-bearing sections without behavioral eval coverage.
+
+## Already Known and Excluded
+
+- Backlog #105 already tracks version drift and interrupted half-upgrades. It
+  does not cover manifest deletion changing repository identity and disabling
+  adapter validation.
+- Backlog #113 tracks no-Python validator divergence; no duplicate filed.
+- Backlog #116 fixed command enumeration coverage. It does not verify the
+  semantic dispatch target of ordinary command stubs.
+- Backlog #122 tracks honor-system MUST deletion/evaluation; the 28 uncovered
+  sections remain excluded from this report.
+- Backlog #134 tracks template placeholder false-passes; no duplicate filed.
+- The 2026-07-01 premortems already cover stale routing actions, default-branch
+  Work Log collisions, reduced assurance, and WARN taxonomy.
+
+## Verified Findings — Do Now
+
+### P1 — Claude command sync validates substring presence, not the dispatch directive
+
+The checker accepts a stub when the expected workflow path appears anywhere in
+the file. In an isolated clone, changing the canonical execution directive from
+`.agent/workflows/review.md` to `.agent/workflows/nonexistent.md` still returned
+exit 0 while a later explanatory sentence retained the expected string. An
+adapter can therefore dispatch to the wrong workflow while the sync gate stays
+green.
+
+Evidence:
+
+- `.agentcortex/tools/check_command_sync.py:89-97` uses an unscoped substring
+  membership check.
+- `.agentcortex/tests/test_trigger_metadata_tools.py:300-350` checks repository
+  pass, set equality, and alias targets, but does not behaviorally mutate and
+  verify ordinary dispatch directives.
+- Isolated fixture command: `python .agentcortex/tools/check_command_sync.py --root .`
+  with a broken primary directive and a residual expected-path mention returned
+  `Command sync check passed (28 commands verified, 2 aliases verified, 30 total)`.
+
+Impact: a Claude command can execute a nonexistent or unintended workflow,
+skipping the canonical phase instructions despite a green validator.
+
+Required fix: parse and require exactly one canonical execution directive per
+ordinary stub, then add a negative behavioral test where only a comment or later
+prose retains the expected path.
+
+### P1 — Missing deploy manifest fail-opens adapter validation
+
+Repository identity is inferred from the absence of `.agentcortex-manifest`.
+Both the top-level validators and command-sync tool treat that absence as source
+mode and skip adapter checks, even though this source repository tracks all 30
+Claude command stubs. In an isolated clone, a fully broken review adapter failed
+with a manifest present and returned exit 0 immediately after only the manifest
+was removed.
+
+Evidence:
+
+- `.agentcortex/tools/check_command_sync.py:71-76` equates missing manifest with
+  source identity and exits 0.
+- `.agentcortex/bin/validate.sh:27-31,307-315` and
+  `.agentcortex/bin/validate.ps1:324-360` use the same source-mode skip.
+- `.agentcortex/bin/deploy.sh:914-950` deploys both the canonical deploy script
+  and command-sync tool downstream, so deploy-script presence plus missing
+  manifest is a reachable downstream state.
+- Isolated fixture: broken all references to `.agent/workflows/review.md`;
+  manifest present produced exit 1, manifest absent produced
+  `Source repo detected — .claude/commands/ sync check skipped.` and exit 0.
+
+Impact: accidental deletion or a malicious change can remove the identity file
+and simultaneously disable the checks most likely to catch adapter drift.
+
+Required fix: use a positive, non-user-removable source marker for source-only
+skips, or validate tracked adapters in both modes. Add a deploy fixture proving
+manifest deletion cannot turn a broken adapter green.
+
+### P1 — routing_actions validation accepts malformed inline maps without validating values
+
+The validators first search the whole report for required field substrings, then
+validate only standalone `target_doc:` and `status:` lines. A syntactically valid
+inline YAML mapping contains every required substring but matches neither value
+parser. Invalid paths and statuses therefore pass as structurally valid.
+
+Evidence:
+
+- `.agentcortex/bin/validate.sh:943-971` scopes required-field checks to the
+  entire file and value checks to anchored standalone lines.
+- `.agentcortex/bin/validate.ps1:913-944` mirrors the same split parsing model.
+- Isolated fixture used:
+
+  ```yaml
+  routing_actions:
+    - {finding: "escape canonical docs", target_doc: "../../escape.md", status: bogus, owner: attacker}
+  ```
+
+- Full `.agentcortex/bin/validate.ps1` result on that fixture:
+  `[PASS] routing_actions contract is structurally valid when present` and
+  `Summary: pass=98 warn=3 fail=0 skip=2`.
+
+Impact: a report can claim routed findings while pointing outside canonical docs
+or using an unrecognized status, defeating the audit-to-canonical-doc closure
+contract.
+
+Required fix: parse only the fenced `routing_actions` YAML block into structured
+records, reject malformed/non-list forms, validate every record, and add inline
+map plus fields-outside-block negative tests for both validators.
+
+## Backlog Disposition
+
+No new backlog rows. All three findings are `do-now` because the user requested
+immediate Claude remediation after the two audit passes.
+
+## Dropped False Alarms
+
+- No-Python gate progression weakness: already tracked by #113.
+- Empty Work Log Evidence placeholder: already tracked by #134.
+- Governance eval coverage count: already tracked by #122 and emitted by the
+  current validator.
+- Manifest version/half-upgrade drift: the overlapping portion is already #105;
+  only the independently reproduced identity fail-open remains above.
+
+## routing_actions
+
+```yaml
+routing_actions:
+  - finding: "Claude command sync must validate the canonical dispatch directive, not any substring occurrence."
+    target_doc: "docs/architecture/document-governance.md"
+    status: pending
+    owner: "codex-governance-two-pass-audit"
+  - finding: "Missing deploy manifest must not disable adapter validation or imply source identity."
+    target_doc: "docs/architecture/document-governance.md"
+    status: pending
+    owner: "codex-governance-two-pass-audit"
+  - finding: "routing_actions validators must structurally parse and validate every action record."
+    target_doc: "docs/architecture/document-governance.md"
+    status: pending
+    owner: "codex-governance-two-pass-audit"
+```


### PR DESCRIPTION
## What changed

- Added a two-pass governance audit covering Claude command-adapter validation and `routing_actions` parser fail-open paths.
- Added a second two-pass audit covering external executor timeout recovery, dirty-worktree preservation, and requested-vs-actual executor provenance.
- Included verified reproductions, known-finding deduplication, routing actions, and a bounded Claude implementation handoff.

## Why

The current validators can report green while malformed adapter/routing records bypass their intended checks. External write-capable CLI workflows also lack a safe abnormal-exit reconciliation path and a pre-flight baseline for preserving existing user changes.

## Impact

Audit-only: this PR changes no runtime, validator, workflow, or governance rule behavior. Actual fixes are explicitly handed off to Claude on separate feature branches after review/merge.

## Validation

- `.agentcortex/bin/validate.ps1` — `pass=114 warn=4 fail=0 skip=2`
- `python .agentcortex/tools/scan_credentials.py <each new report>` — clean
- `git diff --check` — clean

## Handoff

See `docs/reviews/2026-07-11-govern-audit-external-executor.md#claude-implementation-handoff`. The prior candidate patch is preserved only as a local diagnostic stash and is not part of this PR.