### PR TITLE
fix(workflows): external-executor safety — baseline capture, abnormal-exit reconciliation, executor provenance

### DIFF
--- a/.agent/rules/engineering_guardrails.md
+++ b/.agent/rules/engineering_guardrails.md
@@ -233,16 +233,16 @@ To prevent Work Log bloat and premature context compaction, agents MUST NOT past
 
 ### 8.2 External Tool Delegation Protocol
 
-External CLI tools (e.g., `ask-openrouter`, `codex`) are **OPTIONAL accelerators**. Projects MAY operate without any of them.
+External CLI tools (e.g., `ask-openrouter`, `codex`, `claude`) are **OPTIONAL accelerators**; projects MAY operate without any.
 
-**Pre/Post-Flight (Mandatory for all external tool invocations)**:
+**Pre/Post-Flight (mandatory, canonical order)**:
 
 - **Pre-Flight** (in order — fail fast):
-  1. **Cost-Tier Confirmation** (memory-only): low-cost → auto-execute; high-cost (quality/max profile) → confirm with user first.
-  2. Update Work Log with `Executor: <tool-name>` (only if cost-tier passes).
-  3. **Availability Check (Silent)**: run health check (e.g., `python -m ask_openrouter --help`, `codex --version`). If unavailable: **silently fall back** to AI-native execution. DO NOT warn user. DO NOT suggest installation. Cache per session.
-- **Post-Flight**: Read tool output, verify scope alignment, update Work Log, apply Gate Check per §10.2.
-- External tool output is treated as **Junior Tool output** — AI MUST review before accepting.
+  1. **Cost-Tier** (memory-only): low-cost → auto-execute; high-cost → confirm with user first.
+  2. Record `Requested Executor: <tool>` in the Work Log **before** probing availability, then **Baseline Capture** the worktree (`git status --porcelain` + `git diff`) so scope reverts can tell executor edits from files already **dirty at baseline**.
+  3. **Availability (silent)**: health-check the tool; if unavailable, silently fall back for *implicit* acceleration (no install prompt; cache per session), but an *explicit* executor request MUST **disclose** the fallback (final handoff at latest). Record `Actual Executor: <tool | native>` (+ reason when it differs from Requested).
+- **Post-Flight**: read output, verify scope, update Work Log, Gate Check per §10.2. On **abnormal exit** (timeout / nonzero / kill): STOP retries, wait for termination, re-derive state from the baseline diff, record partial state, reconcile explicitly before re-invoking. Never whole-file-revert (`git checkout -- <path>`) a path **dirty at baseline** — reverse only executor hunks or escalate.
+- External tool output = **Junior Tool output** — AI MUST review before accepting.
 
 ## 9. Intent Safety Rules
 

--- a/.agent/workflows/claude-cli.md
+++ b/.agent/workflows/claude-cli.md
@@ -7,7 +7,7 @@ tasks:
 
 # /claude-cli
 
-> `[OPTIONAL MODULE]` — This workflow requires Claude Code CLI to be installed and available as the `claude` executable. If unavailable or not authenticated, AI silently falls back to native execution per `engineering_guardrails.md` §8.2.
+> `[OPTIONAL MODULE]` — This workflow requires Claude Code CLI to be installed and available as the `claude` executable. If unavailable or not authenticated, AI falls back to native execution and **discloses** the substitution (this is an explicit executor request) per `engineering_guardrails.md` §8.2.
 > This module is explicit opt-in. The AI should route here only when the user clearly asks to use Claude for the delegated subtask.
 
 Dispatch a task to Claude CLI while ensuring Agentic OS governance compliance.
@@ -40,15 +40,12 @@ implement 交給 claude: [task description]
 
 > Ref: `engineering_guardrails.md` §8.2 (External Tool Delegation Protocol)
 
-AI MUST perform these steps **before** invoking `claude`:
+AI MUST perform these steps **before** invoking `claude` (canonical order per `engineering_guardrails.md` §8.2):
 
-1. **Availability Check**: On first use per session, run `claude -v`. If it fails, silently fall back to AI-native execution and cache the result.
-2. **Auth Check**: Run `claude auth status --text`. If auth is missing or invalid, silently fall back to AI-native execution and cache the result.
-3. **Classify** the task per `engineering_guardrails.md` §10.1.
-4. **Create/Update Work Log** at `.agentcortex/context/work/<worklog-key>.md` with:
-   - Classification, goal, target files, constraints
-   - `Executor: Claude CLI` (to distinguish from AI-direct execution)
-   - Whether the delegated step is implementation, testing, or both
+1. **Record `Requested Executor: Claude CLI`** in the Work Log **first**. `/claude-cli` is an explicit user request, so any later fallback MUST be disclosed (step 3), never silent.
+2. **Classify** the task per `engineering_guardrails.md` §10.1, then **Create/Update Work Log** at `.agentcortex/context/work/<worklog-key>.md` with classification, goal, target files, constraints, and whether the delegated step is implementation, testing, or both.
+3. **Availability + Auth Check**: run `claude -v` and `claude auth status --text` (cache per session). On failure, fall back to native execution, **disclose** the substitution to the user (final handoff at latest), and record `Actual Executor: native (reason: cli-missing | auth-missing)`. On success, record `Actual Executor: Claude CLI`.
+4. **Baseline Capture** (before invoking `claude`): snapshot the worktree with `git status --porcelain` + `git diff` so post-flight rollback can distinguish Claude's edits from files already **dirty at baseline**. Prefer an isolated git worktree for write-capable runs.
 5. **Generate the Claude command** by injecting governance context and a constrained target-file list.
    - The AI agent, not the user, composes the final prompt.
    - The final prompt MUST include task scope, target files, constraints, and the expected output shape before it is sent to `claude`.
@@ -97,17 +94,19 @@ EXPECTED OUTPUT: [summary | diff explanation | test evidence]
 
 ## 3. AI Post-Flight (After Claude Completes)
 
-AI MUST perform these steps **after** Claude returns:
+AI MUST perform these steps **after Claude returns — or after any abnormal exit**:
 
-1. **Verify scope**: Check `git diff` — did Claude modify files outside the target list?
-   - If yes: revert unauthorized changes, log the violation in the Work Log, and warn the user.
+0. **Abnormal exit** (timeout / nonzero exit / killed process / no result payload): a timed-out `claude` can write files before termination, so **STOP — do not retry**. Wait for the process to fully terminate, then re-derive worktree state (`git status --porcelain` + diff against the pre-flight baseline), record the partial state in the Work Log, and require explicit reconciliation before any re-invocation. A retry over an unreconciled partial write duplicates or overlaps edits.
+1. **Verify scope**: Check `git diff` against the pre-flight baseline — did Claude modify files outside the target list?
+   - If yes: reverse only Claude-attributable hunks. **Never whole-file-revert (`git checkout -- <path>`) a path that was dirty at baseline** — that destroys pre-existing user/agent work; reverse the specific hunks surgically or escalate to the user. Log the violation in the Work Log and warn the user.
 2. **Collect evidence**: Capture Claude's output summary and append it to the Work Log.
 3. **Run tests** if applicable: `npm test`, `pytest -q`, or the project-specific verification command.
 4. **Update Work Log** with:
    - Claude execution result (success/partial/failure/fallback)
+   - `Actual Executor` (+ fallback reason if it differed from `Requested Executor`)
    - Files actually modified
    - Test results
-   - Whether GPT-1.0 accepted or rejected the delegated output
+   - Whether the orchestrating agent accepted or rejected the delegated output
 5. **Gate check**: Apply the standard gate for the classification tier (see `engineering_guardrails.md` §10.2).
 
 ## 4. Example Session
@@ -144,10 +143,11 @@ AI → User: Claude 補了 parser 的邊界與錯誤路徑測試，我已經檢�
 
 | Error | AI Action |
 | --- | --- |
-| Claude CLI not installed | Silently fall back to AI-native execution |
-| Claude auth missing | Silently fall back to AI-native execution |
-| Claude modified wrong files | Revert unauthorized changes, log violation, warn user |
-| Claude output unclear | GPT-1.0 reviews the diff manually and applies standard review |
+| Claude CLI not installed | Fall back to native execution; **disclose** the substitution (explicit request) and record `Actual Executor: native` |
+| Claude auth missing | Fall back to native execution; **disclose** the substitution and record `Actual Executor: native` |
+| Claude abnormal exit (timeout / nonzero / kill) | **STOP — do not retry.** Wait for termination, re-derive state vs the pre-flight baseline, record partial state, reconcile before any re-invocation |
+| Claude modified wrong files | Reverse only Claude-attributable hunks; never whole-file-revert a path **dirty at baseline** (surgical revert or escalate); log + warn |
+| Claude output unclear | The orchestrating agent reviews the diff manually and applies standard review |
 | Task too complex for delegation | Reject delegation and continue with native execution |
 
 ## 6. Guardrails Integration

--- a/.agent/workflows/codex-cli.md
+++ b/.agent/workflows/codex-cli.md
@@ -35,14 +35,13 @@ Run this via Codex CLI: [task description]
 
 > Ref: `engineering_guardrails.md` §8.2 (External Tool Delegation Protocol)
 
-AI MUST perform these steps **before** invoking `codex`:
+AI MUST perform these steps **before** invoking `codex` (canonical order per `engineering_guardrails.md` §8.2):
 
-1. **Availability Check**: On first use per session, run `codex --version`. If fails → silently fall back to AI-native execution. Cache result.
-2. **Classify** the task per `engineering_guardrails.md` §10.1.
-3. **Create/Update Work Log** at `.agentcortex/context/work/<worklog-key>.md` with:
-   - Classification, goal, target files, constraints.
-   - `Executor: Codex CLI` (to distinguish from AI-direct execution).
-4. **Generate the Codex command** by injecting governance context:
+1. **Record `Requested Executor: Codex CLI`** in the Work Log **first** — `/codex-cli` is an explicit user request, so unavailability MUST be surfaced (step 3), never silently swapped.
+2. **Classify** the task per `engineering_guardrails.md` §10.1, then **Create/Update Work Log** at `.agentcortex/context/work/<worklog-key>.md` with classification, goal, target files, and constraints.
+3. **Availability Check**: run `codex --version` (cache per session). If unavailable, surface the install/login step and STOP (see §6) rather than silently swapping executors; if the user then approves native fallback, record `Actual Executor: native (reason: codex-missing)`. On success, record `Actual Executor: Codex CLI`.
+4. **Baseline Capture** (before invoking `codex`): snapshot the worktree with `git status --porcelain` + `git diff` so post-flight rollback can distinguish Codex's edits from files already **dirty at baseline**. Prefer an isolated git worktree for write-capable runs.
+5. **Generate the Codex command** by injecting governance context:
 
 ### Interactive Mode (default — user can see and approve changes)
 
@@ -91,14 +90,16 @@ CONSTRAINTS: [from Work Log]
 
 ## 3. AI Post-Flight (After Codex Completes)
 
-AI MUST perform these steps **after** Codex returns:
+AI MUST perform these steps **after Codex returns — or after any abnormal exit**:
 
-1. **Verify scope**: Check `git diff` — did Codex modify files outside the target list?
-   - If yes: revert unauthorized changes, log in Work Log, warn user.
+0. **Abnormal exit** (timeout / nonzero exit / killed process / no result payload): a timed-out `codex` can write files before termination, so **STOP — do not retry**. Wait for the process to fully terminate, then re-derive worktree state (`git status --porcelain` + diff against the pre-flight baseline), record the partial state in the Work Log, and require explicit reconciliation before any re-invocation.
+1. **Verify scope**: Check `git diff` against the pre-flight baseline — did Codex modify files outside the target list?
+   - If yes: reverse only Codex-attributable hunks. **Never whole-file-revert (`git checkout -- <path>`) a path that was dirty at baseline** — that destroys pre-existing user/agent work; reverse the specific hunks surgically or escalate. Log in Work Log, warn user.
 2. **Collect evidence**: Capture Codex's output summary and append to Work Log.
 3. **Run tests** if applicable: `npm test` / `pytest -q` / project-specific test command.
 4. **Update Work Log** with:
    - Codex execution result (success/partial/failure).
+   - `Actual Executor` (+ fallback reason if it differed from `Requested Executor`).
    - Files actually modified.
    - Test results.
 5. **Gate check**: Apply the standard gate for the classification tier (see §10.2).
@@ -180,9 +181,10 @@ codex exec --oss -m <model> "..."     # non-interactive form
 
 | Error | AI Action |
 | --- | --- |
-| Codex not installed | Output: `npm install -g @openai/codex` and stop |
+| Codex not installed | Output: `npm install -g @openai/codex` and stop (record `Actual Executor: native` only if the user approves fallback) |
 | API key missing | Output: run `codex login` or set `OPENAI_API_KEY` and stop |
-| Codex modified wrong files | Auto-revert via `git checkout -- <file>`, log violation, warn user |
+| Codex abnormal exit (timeout / nonzero / kill) | **STOP — do not retry.** Wait for termination, re-derive state vs the pre-flight baseline, record partial state, reconcile before any re-invocation |
+| Codex modified wrong files | Reverse only Codex-attributable hunks; **never whole-file-revert (`git checkout -- <file>`) a path dirty at baseline** — surgical revert or escalate; log + warn |
 | Codex output unclear | AI reviews diff manually, applies standard review |
 | Task too complex for Codex | Reject and suggest direct AI implementation |
 

--- a/tests/ci/test_external_executor_safety.py
+++ b/tests/ci/test_external_executor_safety.py
@@ -1,0 +1,112 @@
+"""Cross-workflow content-pin tests for external-executor safety (2026-07-11 audit).
+
+Pins the write-capable external-executor safety contract so a careless edit cannot
+silently drop any of the four elements the audit (F4/F5/F6) requires from the three
+governing docs — Claude CLI, Codex CLI, and `engineering_guardrails.md` §8.2 (the canon):
+
+  * F4 — abnormal-exit (timeout / nonzero / kill) state reconstruction + retry blocking.
+  * F5 — pre-flight baseline capture and a dirty-baseline whole-file-revert prohibition.
+  * F6 — Requested/Actual executor provenance + disclosure of an explicit-request fallback.
+
+Enforcement teeth for the [enforcement] Global Lesson ("a MUST without a validator is
+theatre"): these are the cross-workflow contract test the audit's acceptance asks for.
+Pure-Python file reads (CI-safe on Linux); `docs_pin`-marked so docs-only PRs run them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+CLAUDE_CLI = ROOT / ".agent" / "workflows" / "claude-cli.md"
+CODEX_CLI = ROOT / ".agent" / "workflows" / "codex-cli.md"
+GUARDRAILS = ROOT / ".agent" / "rules" / "engineering_guardrails.md"
+
+
+def _guardrails_82() -> str:
+    """Slice §8.2 out of engineering_guardrails.md (the canon) so anchors elsewhere in
+    the file cannot mask a missing §8.2 contract element."""
+    text = GUARDRAILS.read_text(encoding="utf-8")
+    start = text.index("### 8.2 External Tool Delegation Protocol")
+    end = text.index("## 9.", start)
+    return text[start:end]
+
+
+# Doc key -> loader. Keys stay ASCII so pytest parametrize IDs are clean on Windows.
+DOCS = {
+    "claude-cli": lambda: CLAUDE_CLI.read_text(encoding="utf-8"),
+    "codex-cli": lambda: CODEX_CLI.read_text(encoding="utf-8"),
+    "guardrails-82": _guardrails_82,
+}
+
+# The four contract elements, as case-insensitive anchor substrings that MUST appear in
+# every governing doc. Each maps back to an audit finding.
+CONTRACT_ANCHORS = {
+    "baseline-capture (F5)": "git status --porcelain",
+    "abnormal-exit branch (F4)": "abnormal exit",
+    "abnormal-exit reconciliation verb (F4)": "reconcil",
+    "dirty-baseline no-whole-file-revert (F5)": "dirty at baseline",
+    "requested-executor provenance (F6)": "requested executor",
+    "actual-executor provenance (F6)": "actual executor",
+}
+
+
+@pytest.mark.docs_pin
+@pytest.mark.parametrize("doc_key", list(DOCS))
+def test_external_executor_contract_anchors_present(doc_key: str) -> None:
+    """All three governing docs must carry all four contract elements."""
+    text = DOCS[doc_key]().lower()
+    for label, anchor in CONTRACT_ANCHORS.items():
+        assert anchor in text, (
+            f"{doc_key} is missing external-executor contract element '{label}' "
+            f"(anchor {anchor!r}) — F4/F5/F6 regression (2026-07-11 audit)."
+        )
+
+
+@pytest.mark.docs_pin
+def test_codex_cli_has_no_unconditional_whole_file_revert() -> None:
+    """F5 regression guard: the old blanket `Auto-revert via git checkout -- <file>`
+    recommendation destroys pre-existing dirty work — it must never come back."""
+    text = CODEX_CLI.read_text(encoding="utf-8")
+    assert "Auto-revert via" not in text, (
+        "codex-cli.md must not prescribe an unconditional whole-file revert "
+        "(`Auto-revert via git checkout -- <file>`) — it erases user work that was dirty "
+        "at baseline (F5). Use a dirty-baseline-guarded surgical revert instead."
+    )
+
+
+@pytest.mark.docs_pin
+def test_abnormal_exit_blocks_retry_in_cli_workflows() -> None:
+    """F4: both CLI workflows must block retries on abnormal exit — not merely name it."""
+    for name, path in (("claude-cli.md", CLAUDE_CLI), ("codex-cli.md", CODEX_CLI)):
+        text = path.read_text(encoding="utf-8").lower()
+        assert "abnormal exit" in text and "do not retry" in text, (
+            f"{name} must document 'do not retry' on abnormal exit (F4 retry-blocking)."
+        )
+
+
+@pytest.mark.docs_pin
+def test_explicit_executor_request_discloses_fallback() -> None:
+    """F6: an explicitly requested executor that falls back must DISCLOSE/SURFACE the
+    substitution — never a silent swap."""
+    for name, path in (("claude-cli.md", CLAUDE_CLI), ("codex-cli.md", CODEX_CLI)):
+        text = path.read_text(encoding="utf-8").lower()
+        assert "disclose" in text or "surface" in text, (
+            f"{name} must require disclosing/surfacing an explicit-request fallback (F6)."
+        )
+    assert "disclose" in _guardrails_82().lower(), (
+        "engineering_guardrails.md §8.2 must require fallback disclosure for explicit "
+        "executor requests (F6 canon)."
+    )
+
+
+@pytest.mark.docs_pin
+def test_guardrails_records_requested_executor_before_availability_probe() -> None:
+    """F6 ordering canon: §8.2 records `Requested Executor` BEFORE probing availability
+    (the ordering the audit found reversed in claude-cli.md)."""
+    g = _guardrails_82().lower()
+    assert g.index("requested executor") < g.index("availability"), (
+        "§8.2 must record `Requested Executor` before the availability probe (F6 ordering)."
+    )


### PR DESCRIPTION
## What & why

WP2 of the 3-package remediation wave from the 2026-07-11 external-executor governance audit (`docs/reviews/2026-07-11-govern-audit-external-executor.md`, PR #337). Hardens the write-capable external-executor delegation contract across the three governing docs. **Docs-only + one new content-pin test — no engine/logic change.**

### F4 — abnormal-exit state reconstruction
A timed-out `claude`/`codex` CLI can write files before termination while returning nothing; a naive retry then duplicates/overlaps those writes (the audit reproduced exit 124 at 604s with all 5 allowlisted files already modified). Post-flight in both CLI workflows (+ the §8.2 canon) now mandates: on timeout / nonzero / kill → **STOP, do not retry**, wait for termination, re-derive state (`git status --porcelain` + diff vs the pre-flight baseline), record the partial state, and require explicit reconciliation before any re-invocation. Added an abnormal-exit row to both error tables.

### F5 — dirty-worktree preservation
Pre-flight captured no worktree baseline, and rollback prescribed a blanket revert — `codex-cli.md` literally recommended `Auto-revert via git checkout -- <file>`, which erases pre-existing uncommitted user work in a file that was already dirty. Now: pre-flight **captures a baseline** (`git status --porcelain` + `git diff`); rollback reverses only executor-attributable hunks and **MUST NOT whole-file-revert (`git checkout -- <path>`) a path dirty at baseline** (surgical revert or escalate). An isolated worktree is recommended for write-capable executors. (`ask-local.md` is immune by design — junior returns a patch, primary applies — and is untouched.)

### F6 — executor provenance + ordering drift
`§8.2` ordered cost-tier → record executor → probe; `claude-cli.md` reversed it and **silently** fell back even though `/claude-cli` is an explicit request. Adjudicated invariant: **explicit executor request → any fallback MUST be disclosed to the user (final handoff at latest); implicit generic acceleration keeps its silent zero-cost-absent fallback.** `§8.2` is now the canon (record `Requested Executor` before probing; record `Actual Executor` + reason on mismatch); pre-flight ordering unified across all three docs; `claude-cli.md`'s fallback rows now disclose. `codex-cli.md`'s existing install-and-stop is the correct side of the invariant and is preserved.

### Rider
The two stale `GPT-1.0` orchestrator mentions in `claude-cli.md` §3 step 4 and §5 → "the orchestrating agent". Per instruction, **no other cosmetic edits** — the remaining GPT-1.0 mentions in the intro blockquote, the model-policy table, the §4 example, and §6 are intentionally left (out of the rewritten sections).

## Adopter delta (governance user running `/claude-cli` or `/codex-cli`)

| | Before | After |
|---|---|---|
| CLI times out mid-run | retry from a stale status sample → silent duplicate/partial edits | STOP; reconcile partial writes vs baseline before any retry |
| Executor touches an already-dirty out-of-scope file | whole-file `git checkout --` wipes your uncommitted work | only executor hunks reversed; dirty-at-baseline paths never whole-file-reverted |
| Requested Claude/Codex but CLI missing/unauth | silently ran on native model; Work Log said otherwise | fallback **disclosed**; Work Log records `Requested` vs `Actual Executor` + reason |

Engine behavior is otherwise unchanged; these are governance-contract (doc) changes with a CI pin as the enforcement teeth.

## Evidence

- New test `tests/ci/test_external_executor_safety.py` (`docs_pin`): **7 passed** — pins all four contract elements across `claude-cli.md`, `codex-cli.md`, and `§8.2`, plus an F5 negative regression guard on the removed blanket-revert line and F4 retry-blocking / F6 disclosure / F6 ordering semantics.
- Full CI-equivalent suite `pytest tests/ci tests/guard .agentcortex/tests -m "not slow"`: **597 passed**, 77 deselected.
- `validate.sh`: `pass=114 warn=3 fail=0 skip=2`; `validate.ps1`: `pass=114 warn=3 fail=0 skip=2` (parity). The 3 warns are the pre-existing eval-coverage advisory (unchanged from prior ship).
- Token lifecycle aggregate: **354,937 → 354,937 (unchanged)**. The analyzer counts phase-workflow files + skill `detail_ref`s only; none of the three edited docs qualify, so the 355k ceiling is untouched. `§8.2` was still kept compressed (+494 chars of uncounted governance prose) per the tight-ratchet discipline.
- `docs_pin` collected count: **12** (≥4 guard holds).

## Scope notes

- Canonical live copies are `.agent/workflows/` (singular). The `.agents/workflows/` (plural) copies are vestigial (unreferenced repo-wide, absent from the deploy golden, already drifted) — out of scope, untouched.
- No zh-TW mirror of `§8.2`/executor content exists; no compact-index regen needed (none of the 3 docs are `detail_ref`s).

## Rollback

Revert this PR. Docs + one additive test file only; no data or schema migration.
