### PR TITLE
fix(validate): close command-sync, manifest-identity, and routing_actions fail-open paths

### DIFF
--- a/.agentcortex/bin/validate.ps1
+++ b/.agentcortex/bin/validate.ps1
@@ -242,6 +242,7 @@ $archiveIndexJsonl = Join-NormalPath $root '.agentcortex/context/archive/INDEX.j
 $lessonChainCheck = Join-NormalPath $root '.agentcortex/tools/check_lesson_chain.py'
 $ssotCurrentState = Join-NormalPath $root '.agentcortex/context/current_state.md'
 $commandSyncCheck = Join-NormalPath $root '.agentcortex/tools/check_command_sync.py'
+$routingActionsCheck = Join-NormalPath $root '.agentcortex/tools/check_routing_actions.py'
 $skillProvenanceCheck = Join-NormalPath $root '.agentcortex/tools/check_skill_provenance.py'
 $triggerRegistry = Join-NormalPath $root '.agentcortex/metadata/trigger-registry.yaml'
 $triggerCompactIndex = Join-NormalPath $root '.agentcortex/metadata/trigger-compact-index.json'
@@ -886,6 +887,14 @@ else {
     Add-Result -Level 'PASS' -Message 'domain doc candidates declare the full L1 contract when present'
 }
 
+# routing_actions structural contract (governance self-audit F3) — mirror of
+# validate.sh. Structural parsing lives in check_routing_actions.py (ADR-006) so
+# inline-map / fields-outside-block bypasses are rejected. The native block in
+# the else is the no-python degraded backstop (backlog #113).
+if ($script:PythonCommand -and (Test-Path -Path $routingActionsCheck -PathType Leaf)) {
+    Invoke-PythonCheck -Label 'routing_actions contract (structural)' -MissingPythonLevel 'FAIL' -ScriptPath $routingActionsCheck -Arguments @('--root', $root)
+}
+else {
 $routingActionErrors = 0
 $routingActionWarnings = 0
 $routingActionStaleWarnings = 0
@@ -967,6 +976,7 @@ if ($routingActionWarnings -gt 0) {
 }
 if ($routingActionStaleWarnings -gt 0) {
     Add-Result -Level 'WARN' -Message "stale pending routing_actions need canonical-doc follow-up: $routingActionStaleWarnings"
+}
 }
 
 Test-ContainsLiteral -Path $canonicalDeploySh -Pattern 'LEGACY_IGNORE_START="# AI Brain OS - Agent System & Local Context"' -SuccessMessage 'deploy script supports legacy ignore marker migration' -FailureMessage 'deploy script missing legacy ignore marker support'

--- a/.agentcortex/bin/validate.sh
+++ b/.agentcortex/bin/validate.sh
@@ -50,6 +50,7 @@ ARCHIVE_INDEX_JSONL="$ROOT/.agentcortex/context/archive/INDEX.jsonl"
 LESSON_CHAIN_CHECK="$ROOT/.agentcortex/tools/check_lesson_chain.py"
 SSOT_CURRENT_STATE="$ROOT/.agentcortex/context/current_state.md"
 COMMAND_SYNC_CHECK="$ROOT/.agentcortex/tools/check_command_sync.py"
+ROUTING_ACTIONS_CHECK="$ROOT/.agentcortex/tools/check_routing_actions.py"
 SKILL_PROVENANCE_CHECK="$ROOT/.agentcortex/tools/check_skill_provenance.py"
 TRIGGER_REGISTRY="$ROOT/.agentcortex/metadata/trigger-registry.yaml"
 TRIGGER_COMPACT_INDEX="$ROOT/.agentcortex/metadata/trigger-compact-index.json"
@@ -919,6 +920,15 @@ else
   record_result PASS "domain doc candidates declare the full L1 contract when present"
 fi
 
+# routing_actions structural contract (governance self-audit F3). Structural
+# parsing lives in a Python tool (ADR-006, check_routing_actions.py) so
+# inline-map / fields-outside-block bypasses are rejected. The native block in
+# the else branch is the no-python degraded backstop (backlog #113): weaker
+# (whole-file substring + standalone-anchor based) but keeps reduced-assurance
+# coverage + the stale-pending WARN when Python is unavailable.
+if [[ -n "${PYTHON_BIN:-}" ]] && [[ -f "$ROUTING_ACTIONS_CHECK" ]]; then
+  run_python_check "routing_actions contract (structural)" FAIL "$ROUTING_ACTIONS_CHECK" --root "$ROOT"
+else
 routing_action_errors=0
 routing_action_warnings=0
 routing_action_stale_warnings=0
@@ -993,6 +1003,7 @@ if [[ "$routing_action_warnings" -gt 0 ]]; then
 fi
 if [[ "$routing_action_stale_warnings" -gt 0 ]]; then
   record_result WARN "stale pending routing_actions need canonical-doc follow-up: ${routing_action_stale_warnings}"
+fi
 fi
 shopt -u nullglob
 

--- a/.agentcortex/tests/test_trigger_metadata_tools.py
+++ b/.agentcortex/tests/test_trigger_metadata_tools.py
@@ -36,6 +36,53 @@ def run_tool(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _build_adapter_fixture(root: Path, *, manifest: bool, break_review: bool) -> None:
+    """Create a minimal Claude adapter surface under *root*.
+
+    Every EXPECTED_COMMANDS + ALIAS stub gets a valid canonical dispatch directive
+    and its workflow file. When *break_review* is set, review.md's dispatch
+    directive points at a NONEXISTENT workflow while a residual mention of the
+    correct path survives in prose — the exact fail-open F1 closes. When *manifest*
+    is set a .agentcortex-manifest is written (downstream identity); its absence
+    MUST NOT change the verdict (F2)."""
+    import check_command_sync as checker
+
+    commands = root / ".claude" / "commands"
+    workflows = root / ".agent" / "workflows"
+    commands.mkdir(parents=True, exist_ok=True)
+    workflows.mkdir(parents=True, exist_ok=True)
+
+    def _stub(cmd: str, directive: str) -> str:
+        return (
+            f"# /{cmd}\n\n"
+            f"Execute the canonical workflow: `{directive}`\n\n"
+            f"Follow every step in `{directive}` sequentially.\n"
+        )
+
+    for cmd in checker.EXPECTED_COMMANDS:
+        directive = f".agent/workflows/{cmd}.md"
+        (commands / f"{cmd}.md").write_text(_stub(cmd, directive), encoding="utf-8")
+        (workflows / f"{cmd}.md").write_text(f"# {cmd}\n", encoding="utf-8")
+
+    for cmd, reason in checker.ALIAS_EXCLUSIONS.items():
+        target = reason.rsplit("references ", 1)[-1].split(",")[0]
+        (commands / f"{cmd}.md").write_text(_stub(cmd, target), encoding="utf-8")
+        (workflows / f"{cmd}.md").write_text(f"# {cmd}\n", encoding="utf-8")
+
+    if break_review:
+        (commands / "review.md").write_text(
+            "# /review\n\n"
+            "Execute the canonical workflow: `.agent/workflows/nonexistent.md`\n\n"
+            "See `.agent/workflows/review.md` for the real steps.\n",
+            encoding="utf-8",
+        )
+
+    if manifest:
+        (root / ".agentcortex-manifest").write_text(
+            "scaffold .claude/commands/review.md sha256:deadbeef\n", encoding="utf-8"
+        )
+
+
 def load_registry_entry(skill_id: str) -> dict[str, object]:
     if skill_id == "writing-plans":
         return {
@@ -349,6 +396,59 @@ agentcortex:
                 content,
                 f".claude/commands/{cmd}.md no longer references documented alias target {target_ref}",
             )
+
+    def test_command_sync_rejects_broken_directive_despite_residual_mention(self) -> None:
+        """F1: a stub whose canonical dispatch directive points at the WRONG
+        workflow must FAIL even when a later prose line still mentions the correct
+        path (the unscoped-substring fail-open)."""
+        with tempfile.TemporaryDirectory() as td:
+            _build_adapter_fixture(Path(td), manifest=True, break_review=True)
+            result = run_tool(".agentcortex/tools/check_command_sync.py", "--root", td)
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("dispatch directive references", result.stderr)
+
+    def test_command_sync_manifest_deletion_cannot_turn_broken_adapter_green(self) -> None:
+        """F2: removing .agentcortex-manifest must NOT flip a broken adapter from
+        FAIL to PASS. Before the fix, manifest-absence self-skipped the check and
+        returned exit 0 on the identical broken adapter."""
+        with tempfile.TemporaryDirectory() as td:
+            _build_adapter_fixture(Path(td), manifest=False, break_review=True)
+            result = run_tool(".agentcortex/tools/check_command_sync.py", "--root", td)
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("dispatch directive references", result.stderr)
+
+    def test_command_sync_runs_and_passes_without_manifest(self) -> None:
+        """F2: a valid adapter surface with NO manifest runs the real check and
+        PASSES — the check is manifest-agnostic (source and downstream alike)."""
+        with tempfile.TemporaryDirectory() as td:
+            _build_adapter_fixture(Path(td), manifest=False, break_review=False)
+            result = run_tool(".agentcortex/tools/check_command_sync.py", "--root", td)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Command sync check passed", result.stdout)
+
+    def test_command_sync_rejects_alias_directive_retarget(self) -> None:
+        """F1 (alias): an alias whose dispatch directive is retargeted must FAIL
+        even if prose still mentions the documented alias target."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _build_adapter_fixture(root, manifest=False, break_review=False)
+            (root / ".claude" / "commands" / "execute-plan.md").write_text(
+                "# /execute-plan\n\n"
+                "Execute the canonical workflow: `.agent/workflows/plan.md`\n\n"
+                "Alias for /implement — see `.agent/workflows/implement.md`.\n",
+                encoding="utf-8",
+            )
+            result = run_tool(".agentcortex/tools/check_command_sync.py", "--root", td)
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("(alias) dispatch directive references", result.stderr)
+
+    def test_command_sync_skips_only_when_surface_genuinely_absent(self) -> None:
+        """F2: skip ONLY when the adapter surface is genuinely absent (a bare
+        checkout with no .claude/commands/), regardless of manifest presence."""
+        with tempfile.TemporaryDirectory() as td:
+            result = run_tool(".agentcortex/tools/check_command_sync.py", "--root", td)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("adapter surface not present", result.stdout)
 
     def test_writing_plans_manifest_validates(self) -> None:
         skill_dir = self.fixture_root / ".agents" / "skills" / "writing-plans"

--- a/.agentcortex/tools/check_command_sync.py
+++ b/.agentcortex/tools/check_command_sync.py
@@ -1,13 +1,23 @@
 #!/usr/bin/env python3
 """Check that .claude/commands/ dispatch files are in sync with .agent/workflows/.
 
-In source-repo context (no .agentcortex-manifest), this check is skipped because
-.claude/commands/ is an adapter surface created by deploy in downstream repos.
+The check is manifest-agnostic: it runs whenever the Claude adapter surface
+(.claude/commands/) exists, regardless of .agentcortex-manifest presence, and
+skips only when that surface is genuinely absent (a bare checkout with no
+adapters). Repository identity is NOT inferred from manifest presence — deleting
+the manifest downstream must not turn a broken adapter green (governance
+self-audit 2026-07-11, F2).
+
+Each ordinary stub must carry a single canonical dispatch directive
+("Execute the canonical workflow: `.agent/workflows/<cmd>.md`") that references
+the expected workflow. A residual mention of the path elsewhere in the file is
+NOT accepted — the directive itself must be correct (F1).
 """
 from __future__ import annotations
 
 import argparse
 import pathlib
+import re
 import sys
 
 
@@ -59,6 +69,23 @@ ALIAS_EXCLUSIONS = {
 }
 
 
+# The single canonical dispatch directive every stub carries on its own line.
+# We require THIS line to reference the expected workflow — not merely that the
+# path appears somewhere in the file. A broken directive that points at the wrong
+# (or a nonexistent) workflow must fail even if later prose still mentions the
+# correct path (governance self-audit 2026-07-11, F1).
+CANONICAL_DIRECTIVE_RE = re.compile(
+    r"Execute the canonical workflow:\s*`(\.agent/workflows/[^`]+\.md)`"
+)
+
+
+def _directive_target(content: str) -> str | None:
+    """Return the workflow path referenced by the stub's canonical execution
+    directive, or None when the stub has no such directive line."""
+    match = CANONICAL_DIRECTIVE_RE.search(content)
+    return match.group(1) if match else None
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Check Claude command adapter sync.")
     parser.add_argument("--root", type=pathlib.Path, default=".")
@@ -69,18 +96,21 @@ def main() -> int:
     args = parse_args()
     root = args.root.resolve()
 
-    # Source-repo detection: skip if no manifest (adapter surfaces don't exist yet)
-    if not (root / ".agentcortex-manifest").is_file():
-        print("Source repo detected — .claude/commands/ sync check skipped.")
-        return 0
-
     commands_dir = root / ".claude" / "commands"
     workflows_dir = root / ".agent" / "workflows"
     errors: list[str] = []
 
+    # Manifest-agnostic surface detection (governance self-audit F2): run the
+    # sync check whenever the Claude adapter surface exists, regardless of
+    # .agentcortex-manifest presence. Skip ONLY when the surface is genuinely
+    # absent (a bare checkout that never had adapters) — a deleted manifest must
+    # NOT disable adapter-drift detection or imply source identity.
     if not commands_dir.is_dir():
-        print(f"Missing directory: {commands_dir.relative_to(root)}")
-        return 1
+        print(
+            ".claude/commands/ absent; Claude adapter surface not present, "
+            "sync check skipped."
+        )
+        return 0
 
     for cmd in EXPECTED_COMMANDS:
         cmd_file = commands_dir / f"{cmd}.md"
@@ -94,12 +124,20 @@ def main() -> int:
             errors.append(f"command {cmd}.md exists but workflow .agent/workflows/{cmd}.md is missing")
             continue
 
-        # Verify the command file references the workflow
+        # Verify the stub's canonical dispatch directive references the expected
+        # workflow — not merely that the path appears somewhere in the file (F1).
         content = cmd_file.read_text(encoding="utf-8")
         expected_ref = f".agent/workflows/{cmd}.md"
-        if expected_ref not in content:
+        directive_target = _directive_target(content)
+        if directive_target is None:
             errors.append(
-                f".claude/commands/{cmd}.md does not reference {expected_ref}"
+                f".claude/commands/{cmd}.md has no canonical dispatch directive "
+                f"(expected 'Execute the canonical workflow: `{expected_ref}`')"
+            )
+        elif directive_target != expected_ref:
+            errors.append(
+                f".claude/commands/{cmd}.md dispatch directive references "
+                f"{directive_target}, expected {expected_ref}"
             )
 
     # Aliases are checked separately: verify the stub + its OWN redirect-stub
@@ -121,12 +159,22 @@ def main() -> int:
             continue
 
         content = cmd_file.read_text(encoding="utf-8")
-        # The alias reason string documents which target path it must reference.
+        # The alias reason string documents which target path its directive must
+        # reference. Parse the canonical directive (not any substring) so a
+        # retargeted alias directive is caught even if prose still mentions the
+        # documented target (F1).
         target_ref = ALIAS_EXCLUSIONS[cmd].rsplit("references ", 1)[-1].split(",")[0]
-        if target_ref not in content:
+        directive_target = _directive_target(content)
+        if directive_target is None:
             errors.append(
-                f".claude/commands/{cmd}.md (alias) no longer references {target_ref} — "
-                f"update ALIAS_EXCLUSIONS or fix the stub"
+                f".claude/commands/{cmd}.md (alias) has no canonical dispatch "
+                f"directive (expected it to reference {target_ref})"
+            )
+        elif directive_target != target_ref:
+            errors.append(
+                f".claude/commands/{cmd}.md (alias) dispatch directive references "
+                f"{directive_target}, expected {target_ref} — update "
+                f"ALIAS_EXCLUSIONS or fix the stub"
             )
 
     if errors:

--- a/.agentcortex/tools/check_routing_actions.py
+++ b/.agentcortex/tools/check_routing_actions.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Structural validator for `routing_actions` blocks in docs/reviews/*.md (ADR-006).
+
+Governance self-audit 2026-07-11 (F3): the native validators searched the WHOLE
+review file for required-field substrings ('finding:', 'target_doc:', ...) and
+validated only standalone `target_doc:`/`status:` lines. A single inline YAML
+mapping —
+
+    routing_actions:
+      - {finding: "x", target_doc: "../../escape.md", status: bogus, owner: y}
+
+— contains every required substring but matches neither value parser, so invalid
+paths (path traversal / non-canonical docs) and unrecognized statuses passed as
+"structurally valid".
+
+This tool closes that hole by parsing ONLY the fenced/keyed routing_actions block
+into structured records and validating every record:
+
+  * required fields present (finding, target_doc, status, owner) WITHIN the block
+  * target_doc matches `^docs/(architecture|specs)/.+\\.md$` with no `..` traversal
+  * status in {pending, merged, rejected}
+  * inline-map (`- { ... }`) and non-list forms are rejected outright (unvalidated)
+
+target_doc that is well-formed but missing on disk is a WARN (advisory, as today),
+as is a stale `pending` action whose review file is older than the configured
+threshold. Structural violations FAIL (exit 1); everything else exits 0.
+
+Only the CANONICAL column-0 `routing_actions:` block is validated. Indented
+occurrences are in-prose examples (an audit report may quote an attack fixture
+inside a list item) and are skipped — otherwise a report documenting a malformed
+form would false-FAIL on its own evidence.
+
+Dependency-free: no PyYAML assumption — a small deterministic line parser is used
+so inline-map rejection behaves identically whether or not PyYAML is installed
+(the shared _yaml_loader would silently mis-parse or leniently accept inline maps
+depending on backend).
+
+Exit codes:
+  0  no structural violations (WARN advisories, if any, are printed to stdout)
+  1  one or more structural violations (printed to stdout as `FAIL: ...`)
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import re
+import sys
+from pathlib import Path
+
+REQUIRED_FIELDS = ("finding", "target_doc", "status", "owner")
+VALID_STATUSES = {"pending", "merged", "rejected"}
+TARGET_DOC_RE = re.compile(r"^docs/(architecture|specs)/.+\.md$")
+DEFAULT_PENDING_WARN_DAYS = 14
+
+_ROUTING_KEY_RE = re.compile(r"^(?P<indent>[ \t]*)routing_actions:[ \t]*$")
+_LIST_ITEM_RE = re.compile(r"^(?P<indent>[ \t]*)-[ \t]*(?P<body>.*)$")
+_KV_RE = re.compile(r"^[ \t]*(?P<key>[A-Za-z_][A-Za-z0-9_]*):[ \t]*(?P<val>.*?)[ \t]*$")
+_FILENAME_DATE_RE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})")
+
+
+def _indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip(" \t"))
+
+
+def _unquote(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value
+
+
+class RoutingBlock:
+    """One parsed routing_actions block: its records and any parse-time errors."""
+
+    def __init__(self) -> None:
+        self.records: list[dict[str, str]] = []
+        self.errors: list[str] = []
+
+
+def parse_routing_blocks(text: str) -> list[RoutingBlock]:
+    """Parse every `routing_actions:` block in *text* into structured records.
+
+    A block is bounded by the `routing_actions:` key line and the first code
+    fence (```) or dedent to a sibling key. Inline-map list items (`- { ... }`)
+    are recorded as errors and produce no record.
+    """
+    lines = text.splitlines()
+    blocks: list[RoutingBlock] = []
+    n = len(lines)
+    i = 0
+    while i < n:
+        key_match = _ROUTING_KEY_RE.match(lines[i])
+        if not key_match:
+            i += 1
+            continue
+        key_indent = len(key_match.group("indent"))
+        if key_indent != 0:
+            # An INDENTED `routing_actions:` is an in-prose example (e.g. an audit
+            # report quoting an attack fixture inside a list item), not the
+            # canonical column-0 block that /govern-audit emits and /ship consumes.
+            # Validating quoted examples would false-FAIL reports that document the
+            # very malformed forms this tool rejects.
+            i += 1
+            continue
+        block = RoutingBlock()
+        current: dict[str, str] | None = None
+        item_indent: int | None = None
+        i += 1
+        while i < n:
+            line = lines[i]
+            stripped = line.strip()
+            if stripped == "":
+                i += 1
+                continue
+            if stripped.startswith("```"):
+                break  # code fence terminates the block
+            indent = _indent_of(line)
+            item = _LIST_ITEM_RE.match(line)
+            if item and (item_indent is None or indent == item_indent):
+                if item_indent is None:
+                    item_indent = indent
+                body = item.group("body").strip()
+                if body.startswith("{"):
+                    block.errors.append(
+                        "inline-map form not permitted; use block mappings "
+                        "(`- finding:` on its own line): " + stripped
+                    )
+                    current = None
+                    i += 1
+                    continue
+                current = {}
+                block.records.append(current)
+                kv = _KV_RE.match(body)
+                if kv:
+                    current[kv.group("key")] = _unquote(kv.group("val"))
+                i += 1
+                continue
+            if current is not None and item_indent is not None and indent > item_indent:
+                kv = _KV_RE.match(stripped)
+                if kv:
+                    current[kv.group("key")] = _unquote(kv.group("val"))
+                i += 1
+                continue
+            if indent <= key_indent:
+                break  # dedent to a sibling key / section ends the block
+            i += 1  # deeper orphan line with no active record — ignore
+        blocks.append(block)
+    return blocks
+
+
+def _pending_warn_days(config_path: Path) -> int:
+    """Read document_lifecycle.routing_actions_pending_warn_days (default 14)."""
+    if not config_path.is_file():
+        return DEFAULT_PENDING_WARN_DAYS
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from _yaml_loader import load_data  # type: ignore  # noqa: E402
+
+        data = load_data(config_path)
+        lifecycle = data.get("document_lifecycle") or {}
+        return int(lifecycle.get("routing_actions_pending_warn_days", DEFAULT_PENDING_WARN_DAYS))
+    except Exception:
+        return DEFAULT_PENDING_WARN_DAYS
+
+
+def _review_age_days(name: str, today: _dt.date) -> int | None:
+    """Age in days from a leading YYYY-MM-DD in the review filename, or None."""
+    m = _FILENAME_DATE_RE.match(name)
+    if not m:
+        return None
+    try:
+        review_date = _dt.date(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+    except ValueError:
+        return None
+    return (today - review_date).days
+
+
+def validate_review(
+    review: Path, root: Path, pending_warn_days: int, today: _dt.date
+) -> tuple[list[str], list[str]]:
+    """Return (errors, warnings) for a single review file."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    try:
+        text = review.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:  # pragma: no cover - IO edge
+        return [f"could not read {review.name}: {exc}"], []
+
+    blocks = parse_routing_blocks(text)
+    if not blocks:
+        return errors, warnings  # no routing_actions in this file
+
+    has_pending = False
+    for block in blocks:
+        errors.extend(f"{review.name}: {e}" for e in block.errors)
+        if not block.records and not block.errors:
+            errors.append(
+                f"{review.name}: routing_actions present but no valid action "
+                "records parsed (expected a YAML list of block mappings)"
+            )
+        for idx, record in enumerate(block.records):
+            for field in REQUIRED_FIELDS:
+                if not record.get(field):
+                    errors.append(
+                        f"{review.name}: routing_actions record #{idx + 1} missing "
+                        f"required field '{field}'"
+                    )
+            target = record.get("target_doc", "")
+            if target:
+                if ".." in target or not TARGET_DOC_RE.match(target):
+                    errors.append(
+                        f"{review.name}: routing_actions target_doc must match "
+                        "^docs/(architecture|specs)/.+.md$ with no path traversal: "
+                        f"{target}"
+                    )
+                elif not (root / target).is_file():
+                    warnings.append(
+                        f"{review.name}: routing_actions target_doc does not exist "
+                        f"yet: {target}"
+                    )
+            status = record.get("status", "")
+            if status and status not in VALID_STATUSES:
+                errors.append(
+                    f"{review.name}: routing_actions status must be pending, merged, "
+                    f"or rejected: {status}"
+                )
+            if status == "pending":
+                has_pending = True
+
+    if has_pending:
+        age = _review_age_days(review.name, today)
+        if age is not None and age >= pending_warn_days:
+            warnings.append(
+                f"{review.name}: stale pending routing_actions ({age}d old, "
+                f"threshold {pending_warn_days}d) needs canonical-doc follow-up"
+            )
+    return errors, warnings
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Structurally validate routing_actions blocks in docs/reviews/*.md. "
+            "Exit 1 on structural violations; WARN advisories print but exit 0."
+        )
+    )
+    ap.add_argument("--root", default=".", help="Repo root (default: cwd)")
+    ap.add_argument(
+        "--reviews-dir",
+        default=None,
+        help="Reviews directory (default: <root>/docs/reviews)",
+    )
+    ap.add_argument(
+        "--config",
+        default=None,
+        help="Config file for the pending-warn threshold (default: <root>/.agent/config.yaml)",
+    )
+    return ap.parse_args()
+
+
+def main() -> int:
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
+    args = parse_args()
+    root = Path(args.root).resolve()
+    reviews_dir = Path(args.reviews_dir) if args.reviews_dir else root / "docs" / "reviews"
+    config_path = Path(args.config) if args.config else root / ".agent" / "config.yaml"
+
+    if not reviews_dir.is_dir():
+        # Capability-by-presence: no reviews to validate.
+        print("routing_actions: no docs/reviews directory; nothing to check.")
+        return 0
+
+    pending_warn_days = _pending_warn_days(config_path)
+    today = _dt.datetime.now(_dt.timezone.utc).date()
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    checked = 0
+    for review in sorted(reviews_dir.glob("*.md")):
+        if not review.is_file():
+            continue
+        file_errors, file_warnings = validate_review(review, root, pending_warn_days, today)
+        errors.extend(file_errors)
+        warnings.extend(file_warnings)
+        checked += 1
+
+    for warning in warnings:
+        print(f"WARN: {warning}")
+    for error in errors:
+        print(f"FAIL: {error}")
+
+    if errors:
+        print(f"routing_actions: {len(errors)} structural violation(s) across {checked} review file(s).")
+        return 1
+
+    print(
+        f"routing_actions: structurally valid across {checked} review file(s)"
+        + (f" ({len(warnings)} advisory warning(s))" if warnings else "")
+        + "."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/guard/test_routing_actions_check.py
+++ b/tests/guard/test_routing_actions_check.py
@@ -1,0 +1,223 @@
+"""Structural tests for check_routing_actions.py (governance self-audit F3).
+
+The native validators searched the whole review file for required-field
+substrings and validated only standalone target_doc:/status: lines, so an inline
+YAML map passed every substring check while escaping value validation. These
+tests pin the structural fix: inline-map / fields-outside-block / traversal /
+bad-status forms must FAIL, valid blocks PASS, and a column-0-only scope keeps
+in-prose examples (an audit report quoting an attack fixture) from false-FAILing.
+
+ADR: docs/adr/ADR-006-validator-python-core-strangler.md
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / ".agentcortex" / "tools" / "check_routing_actions.py"
+VALIDATE_SH = ROOT / ".agentcortex" / "bin" / "validate.sh"
+VALIDATE_PS1 = ROOT / ".agentcortex" / "bin" / "validate.ps1"
+
+
+def _write_review(root: Path, name: str, body: str) -> None:
+    reviews = root / "docs" / "reviews"
+    reviews.mkdir(parents=True, exist_ok=True)
+    (reviews / name).write_text(body, encoding="utf-8")
+
+
+def _run(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(TOOL), "--root", str(root)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+def _fenced(records_yaml: str) -> str:
+    return "# Review\n\n## routing_actions\n\n```yaml\n" + records_yaml + "```\n"
+
+
+def _valid_block() -> str:
+    return _fenced(
+        "routing_actions:\n"
+        '  - finding: "A real finding."\n'
+        '    target_doc: "docs/architecture/foo.md"\n'
+        "    status: pending\n"
+        '    owner: "tester"\n'
+    )
+
+
+def _seed_target(root: Path) -> None:
+    doc = root / "docs" / "architecture" / "foo.md"
+    doc.parent.mkdir(parents=True, exist_ok=True)
+    doc.write_text("# foo\n", encoding="utf-8")
+
+
+def test_valid_block_passes(tmp_path: Path) -> None:
+    _seed_target(tmp_path)
+    _write_review(tmp_path, "2099-01-01-ok.md", _valid_block())
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "structurally valid" in result.stdout
+
+
+def test_inline_map_is_rejected(tmp_path: Path) -> None:
+    """The core F3 fixture: an inline YAML map carries every required substring
+    but must be rejected outright (values never validated otherwise)."""
+    _write_review(
+        tmp_path,
+        "2099-01-01-inline.md",
+        _fenced(
+            "routing_actions:\n"
+            '  - {finding: "x", target_doc: "../../escape.md", status: bogus, owner: y}\n'
+        ),
+    )
+    result = _run(tmp_path)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "inline-map form not permitted" in result.stdout
+
+
+def test_path_traversal_target_is_rejected(tmp_path: Path) -> None:
+    _write_review(
+        tmp_path,
+        "2099-01-01-traversal.md",
+        _fenced(
+            "routing_actions:\n"
+            '  - finding: "x"\n'
+            '    target_doc: "docs/architecture/../../etc/passwd.md"\n'
+            "    status: pending\n"
+            '    owner: "y"\n'
+        ),
+    )
+    result = _run(tmp_path)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "path traversal" in result.stdout or "target_doc must match" in result.stdout
+
+
+def test_non_canonical_target_is_rejected(tmp_path: Path) -> None:
+    _write_review(
+        tmp_path,
+        "2099-01-01-noncanon.md",
+        _fenced(
+            "routing_actions:\n"
+            '  - finding: "x"\n'
+            '    target_doc: "README.md"\n'
+            "    status: pending\n"
+            '    owner: "y"\n'
+        ),
+    )
+    result = _run(tmp_path)
+    assert result.returncode == 1, result.stdout + result.stderr
+
+
+def test_bad_status_is_rejected(tmp_path: Path) -> None:
+    _seed_target(tmp_path)
+    _write_review(
+        tmp_path,
+        "2099-01-01-status.md",
+        _fenced(
+            "routing_actions:\n"
+            '  - finding: "x"\n'
+            '    target_doc: "docs/architecture/foo.md"\n'
+            "    status: bogus\n"
+            '    owner: "y"\n'
+        ),
+    )
+    result = _run(tmp_path)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "status must be pending, merged, or rejected" in result.stdout
+
+
+def test_required_field_outside_block_is_rejected(tmp_path: Path) -> None:
+    """Fields-outside-block fixture: 'owner:' appears in prose elsewhere in the
+    file, but the record itself omits it. The whole-file substring check passed
+    this; structural parsing must reject the record."""
+    _seed_target(tmp_path)
+    body = (
+        "# Review\n\nThe owner: of this finding is documented elsewhere.\n\n"
+        "## routing_actions\n\n```yaml\n"
+        "routing_actions:\n"
+        '  - finding: "x"\n'
+        '    target_doc: "docs/architecture/foo.md"\n'
+        "    status: pending\n"
+        "```\n"
+    )
+    _write_review(tmp_path, "2099-01-01-missingfield.md", body)
+    result = _run(tmp_path)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "missing required field 'owner'" in result.stdout
+
+
+def test_nonexistent_target_is_warn_not_fail(tmp_path: Path) -> None:
+    """A well-formed target_doc that does not exist on disk is advisory (WARN),
+    not a structural failure — preserving the native 'exists → WARN' behavior."""
+    _write_review(tmp_path, "2099-01-01-missingdoc.md", _valid_block())
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "does not exist yet" in result.stdout
+    assert result.stdout.count("WARN:") >= 1
+
+
+def test_indented_example_is_ignored(tmp_path: Path) -> None:
+    """A routing_actions block quoted INSIDE a list item (indented, column>0) is
+    an example, not the canonical block — it must not FAIL the report."""
+    body = (
+        "# Audit Report\n\n"
+        "- Isolated fixture used:\n\n"
+        "  ```yaml\n"
+        "  routing_actions:\n"
+        '    - {finding: "x", target_doc: "../../escape.md", status: bogus, owner: y}\n'
+        "  ```\n"
+    )
+    _write_review(tmp_path, "2099-01-01-example.md", body)
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_non_list_form_is_rejected(tmp_path: Path) -> None:
+    _write_review(
+        tmp_path,
+        "2099-01-01-nonlist.md",
+        _fenced("routing_actions:\n  just a bare scalar, not a list\n"),
+    )
+    result = _run(tmp_path)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "no valid action records" in result.stdout
+
+
+def test_no_reviews_dir_passes(tmp_path: Path) -> None:
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_real_repo_passes() -> None:
+    """The framework's own review snapshots must be structurally valid."""
+    result = subprocess.run(
+        [sys.executable, str(TOOL), "--root", str(ROOT)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_both_validators_wire_structural_check_with_native_backstop() -> None:
+    """Cross-platform parity: both validators invoke check_routing_actions.py
+    behind the python seam AND retain the native block as the no-python backstop."""
+    sh = VALIDATE_SH.read_text(encoding="utf-8")
+    ps1 = VALIDATE_PS1.read_text(encoding="utf-8")
+    for text, which in ((sh, "validate.sh"), (ps1, "validate.ps1")):
+        assert "check_routing_actions.py" in text, f"{which} missing structural tool wiring"
+        assert "routing_actions contract (structural)" in text, f"{which} missing python check label"
+        # Native no-python backstop must still be present (else-branch).
+        assert "routing_actions contract is structurally valid when present" in text, (
+            f"{which} dropped the native no-python backstop"
+        )


### PR DESCRIPTION
## Summary

Closes three verified validator fail-open paths from the 2026-07-11 governance self-audit (`docs/reviews/2026-07-11-govern-audit.md`, PRs #337/#338). Each was independently re-verified against the code before this change.

### F1 — command-sync validated a substring, not the dispatch directive
`check_command_sync.py` accepted a stub if the expected workflow path appeared *anywhere* in the file. A stub whose `Execute the canonical workflow:` directive pointed at `.agent/workflows/nonexistent.md` still passed as long as a later prose line mentioned the correct path — so an adapter could dispatch to the wrong (or a missing) workflow with a green gate.
**Fix:** parse the canonical directive line itself and require it to reference `.agent/workflows/<cmd>.md` (ordinary commands *and* aliases; alias handling preserved).

### F2 — a missing deploy manifest fail-opened adapter validation
The tool inferred repository identity from `.agentcortex-manifest` absence and self-skipped ("Source repo detected"). Downstream deploys ship the manifest, so **deleting it downstream made the repo look like source and silently disabled the adapter-drift check** — a broken adapter went green.
**Fix:** the check is now **manifest-agnostic** — it runs whenever the `.claude/commands/` adapter surface exists and skips only when that surface is genuinely absent (a bare checkout). Both validators already invoke the check unconditionally, so no `IS_SOURCE_REPO` change was needed. Net effect: the source repo now runs the *real* sync check (28 commands + 2 aliases = 30 verified) instead of self-skipping.

### F3 — routing_actions accepted malformed inline maps without validating values
The validators grepped the whole review file for required-field substrings and validated only standalone `target_doc:`/`status:` lines. An inline YAML map — `- {finding: "x", target_doc: "../../escape.md", status: bogus, owner: y}` — contained every substring but matched neither value parser, so path traversal and unknown statuses passed as "structurally valid".
**Fix:** new `check_routing_actions.py` structurally parses the canonical column-0 `routing_actions` block, rejects inline-map / non-list / fields-outside-block forms outright, and validates every record (`target_doc` must match `^docs/(architecture|specs)/.+\.md$` with no `..`; `status` in `{pending, merged, rejected}`). Wired into **both** validators behind the existing `run_python_check` / `Invoke-PythonCheck` seam (ADR-006). The existing native block is retained as the **no-python degraded backstop** (backlog #113). Column-0 scoping ignores in-prose example fixtures (e.g. an audit report quoting the attack) so reports don't false-FAIL on their own evidence.

## Adopter delta (governance user)

- **Before:** `/govern-audit` and adapter checks could report green while (a) a Claude command dispatched to a nonexistent workflow, (b) a downstream repo with its manifest removed disabled adapter-drift detection, or (c) a review report routed a finding to `../../escape.md`.
- **After:** all three now FAIL the validator. No behavior change for well-formed repos — `validate.sh` and `validate.ps1` are byte-for-byte green on clean state (see evidence). The engine's verdict tiers are unchanged; the only new outcome is that the three malformed states above stop passing.
- **No-python users:** unchanged — the native routing_actions backstop still runs; the structural F3 upgrade activates only where Python + the tool are present (source repo / CI). The F1/F2 command-sync fixes are pure-Python and already gated by the existing python seam.

## Evidence

- `pytest tests/ci tests/guard .agentcortex/tests -m "not slow"` → **607 passed**.
- New tests: 5 command-sync negatives/positives (F1/F2) in `.agentcortex/tests/test_trigger_metadata_tools.py`; 12 structural tests (F3) in `tests/guard/test_routing_actions_check.py`.
- Slow suite: the 2 `stale_pending_routing_actions` tests pass (confirm the native no-python backstop still fires in a deployed fixture).
- `validate.sh` and `validate.ps1`, before **and** after: `pass=114 warn=3 fail=0 skip=2` (green, parity, count-neutral).
- ADR-006 native-check ratchet unchanged at **197/198** (`test_validator_native_check_ratchet.py` green) — F3 adds zero native result lines.

## Rollback

Revert this PR. The change is additive (one new tool + one new test file) plus in-place edits to `check_command_sync.py` and the two validators' routing_actions wiring; no data migration, no state change. Reverting restores the prior (weaker) checks.

## Notes / scope

- Deliberately **not** added to `deploy.sh` `runtime_tools`: `check_routing_actions.py` stays a source/CI validator; downstream repos keep the native backstop (per the finding's accepted degradation). Flagged for the reviewer in case downstream structural coverage is wanted as a follow-up.
- The finding suggested `tests/deploy/`; that directory does not exist and CI collects only `tests/ci tests/guard .agentcortex/tests`, so the F2 fixture tests live with the other command-sync tests (and run in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
