### PR TITLE
fix(validate): receipt integrity — canonical worklog-key normalization + receipt/SHA value validation

### DIFF
--- a/.agentcortex/bin/validate.ps1
+++ b/.agentcortex/bin/validate.ps1
@@ -1147,6 +1147,7 @@ if (Test-Path -Path $worklogDir -PathType Container) {
     # Work Log evidence chain check (per AGENTS.md Work Log Contract)
     $phaseFieldMissing = 0
     $checkpointMissing = 0
+    $checkpointViolationList = New-Object System.Collections.Generic.List[string]
     $gateEvidenceMissing = 0
     $legacyGateEvidenceMissing = 0
     $gateProgressionIllegal = 0
@@ -1209,7 +1210,22 @@ if (Test-Path -Path $worklogDir -PathType Container) {
                 $curBranch = & git -C $root rev-parse --abbrev-ref HEAD 2>$null
             }
             if ($LASTEXITCODE -eq 0 -and $curBranch -and $curBranch -ne 'HEAD') {
-                $curKey = $curBranch.Trim() -replace '/', '-'
+                # F10 (2026-07-11 receipt-integrity audit): apply the canonical
+                # Work Log key normalization (bootstrap.md:123-131) in full —
+                # (1) chars outside [a-zA-Z0-9._-] -> '-', (2) collapse '-'
+                # runs, (3) strip leading/trailing '-'/'.', (4) lowercase,
+                # (5) truncate to 100 chars. Previously this only replaced '/'
+                # with '-'; -eq/-like are already case-insensitive in
+                # PowerShell so the case half was accidentally masked here,
+                # but punctuation (e.g. "release/v1.2:rc") still mismatched
+                # the canonical key on both platforms (F10 audit finding).
+                $normalized = $curBranch.Trim() -replace '[^a-zA-Z0-9._-]', '-'
+                $normalized = $normalized -replace '-+', '-'
+                $normalized = $normalized -replace '^[-.]+', ''
+                $normalized = $normalized -replace '[-.]+$', ''
+                $normalized = $normalized.ToLowerInvariant()
+                if ($normalized.Length -gt 100) { $normalized = $normalized.Substring(0, 100) }
+                $curKey = $normalized
             }
         }
     } catch {}
@@ -1219,7 +1235,11 @@ if (Test-Path -Path $worklogDir -PathType Container) {
         # AC-6: flag whether this worklog belongs to the current branch.
         $isCurrentBranch = $false
         if ($curKey) {
-            $wlBasename = [System.IO.Path]::GetFileName($wl.FullName)
+            # F10: lowercase the basename too (curKey is already lowercase) so
+            # the comparison is explicit case-insensitive on both sides —
+            # defense against a non-conforming log filename, and independent
+            # of -eq/-like's implicit case-insensitivity.
+            $wlBasename = [System.IO.Path]::GetFileName($wl.FullName).ToLowerInvariant()
             if ($wlBasename -eq "${curKey}.md" -or $wlBasename -like "*-${curKey}.md") {
                 $isCurrentBranch = $true
             }
@@ -1246,7 +1266,93 @@ if (Test-Path -Path $worklogDir -PathType Container) {
         $isLegacyGateEvidenceLog = $createdDate -and $createdDate -lt $legacyGateEvidenceCutoff
         # Accept list or table form for header fields (see .agentcortex/templates/worklog.md)
         if ($content -notmatch '(?m)(^- (`Current Phase`|Current Phase):|^\| (`Current Phase`|Current Phase) +\|)') { $phaseFieldMissing++ }
-        if ($content -notmatch '(?m)(^- (`Checkpoint SHA`|Checkpoint SHA):|^\| (`Checkpoint SHA`|Checkpoint SHA) +\|)') { $checkpointMissing++ }
+        if ($content -notmatch '(?m)(^- (`Checkpoint SHA`|Checkpoint SHA):|^\| (`Checkpoint SHA`|Checkpoint SHA) +\|)') {
+            $checkpointMissing++
+        } else {
+            # F8 (2026-07-11 receipt-integrity audit): value-shape + (current-
+            # branch-only) resolvability validation. Previously presence-only:
+            # a heading with a non-SHA value (e.g. "not-a-sha") passed silently.
+            # Accepts a hex object id (7-40 chars, optionally followed by
+            # trailing note text) or an observed legitimate placeholder —
+            # "none", "pending-commit" (both seen in real archived logs), or
+            # the unfilled template default "<git-sha or none>" (templates/
+            # worklog.md; two real active logs still carry it). Mutates the
+            # pre-existing $checkpointMissing / $checkpointViolationList
+            # counters (ADR-006 native-extension path — see Work Log Drift
+            # Log — not a new Add-Result call site).
+            $cpVal = $null
+            $cpM = [regex]::Match($content, '(?m)^-\s*`?Checkpoint SHA`?\s*:\s*(.+)$')
+            if ($cpM.Success) {
+                $cpVal = $cpM.Groups[1].Value
+            } else {
+                $cpM2 = [regex]::Match($content, '(?m)^\|\s*`?Checkpoint SHA`?\s*\|\s*([^|]*)\|')
+                if ($cpM2.Success) { $cpVal = $cpM2.Groups[1].Value }
+            }
+            if ($cpVal) {
+                $cpVal = ($cpVal -replace '<!--.*?-->', '') -replace '`', ''
+                $cpVal = $cpVal.Trim()
+            }
+            if ($cpVal) {
+                $cpLc = $cpVal.ToLowerInvariant()
+                if ($cpLc -ne 'none' -and $cpLc -ne 'pending-commit' -and $cpLc -ne '<git-sha or none>') {
+                    $cpVerify = $null
+                    if ($cpLc -match '^[0-9a-f]{7,40}$') {
+                        $cpVerify = $cpVal
+                    } else {
+                        $cpFirstTok = ($cpLc -split '\s+')[0]
+                        if ($cpFirstTok -match '^[0-9a-f]{7,40}$') { $cpVerify = ($cpVal -split '\s+')[0] }
+                    }
+                    if (-not $cpVerify) {
+                        $checkpointMissing++
+                        $checkpointViolationList.Add("  invalid Checkpoint SHA value ('$cpVal') in $($wl.Name)")
+                    } elseif ($isCurrentBranch) {
+                        & git -C $root rev-parse --verify "$cpVerify^{commit}" 2>$null | Out-Null
+                        if ($LASTEXITCODE -ne 0) {
+                            $checkpointMissing++
+                            $checkpointViolationList.Add("  unresolvable Checkpoint SHA ('$cpVerify') in $($wl.Name) (git rev-parse --verify failed)")
+                        }
+                    }
+                }
+            }
+        }
+        # F8: Diff Base SHA gets the same value treatment when present. No
+        # pre-existing presence check for this field — presence is NOT newly
+        # required here, only value-shape/resolvability when the field IS
+        # present.
+        $dbVal = $null
+        $dbM = [regex]::Match($content, '(?m)^-\s*`?Diff Base SHA`?\s*:\s*(.+)$')
+        if ($dbM.Success) {
+            $dbVal = $dbM.Groups[1].Value
+        } else {
+            $dbM2 = [regex]::Match($content, '(?m)^\|\s*`?Diff Base SHA`?\s*\|\s*([^|]*)\|')
+            if ($dbM2.Success) { $dbVal = $dbM2.Groups[1].Value }
+        }
+        if ($dbVal) {
+            $dbVal = ($dbVal -replace '<!--.*?-->', '') -replace '`', ''
+            $dbVal = $dbVal.Trim()
+        }
+        if ($dbVal) {
+            $dbLc = $dbVal.ToLowerInvariant()
+            if ($dbLc -ne 'none' -and $dbLc -ne 'pending-commit' -and $dbLc -ne '<git-sha or none>') {
+                $dbVerify = $null
+                if ($dbLc -match '^[0-9a-f]{7,40}$') {
+                    $dbVerify = $dbVal
+                } else {
+                    $dbFirstTok = ($dbLc -split '\s+')[0]
+                    if ($dbFirstTok -match '^[0-9a-f]{7,40}$') { $dbVerify = ($dbVal -split '\s+')[0] }
+                }
+                if (-not $dbVerify) {
+                    $checkpointMissing++
+                    $checkpointViolationList.Add("  invalid Diff Base SHA value ('$dbVal') in $($wl.Name)")
+                } elseif ($isCurrentBranch) {
+                    & git -C $root rev-parse --verify "$dbVerify^{commit}" 2>$null | Out-Null
+                    if ($LASTEXITCODE -ne 0) {
+                        $checkpointMissing++
+                        $checkpointViolationList.Add("  unresolvable Diff Base SHA ('$dbVerify') in $($wl.Name) (git rev-parse --verify failed)")
+                    }
+                }
+            }
+        }
         if ($content -notmatch '(?m)^## Gate Evidence') {
             if ($isLegacyGateEvidenceLog -and -not $isCurrentBranch) {
                 $legacyGateEvidenceMissing++
@@ -1557,9 +1663,13 @@ if (Test-Path -Path $worklogDir -PathType Container) {
         Add-Result -Level 'PASS' -Message 'all active work logs have Current Phase field'
     }
     if ($checkpointMissing -gt 0) {
-        Add-Result -Level 'WARN' -Message "work logs missing Checkpoint SHA field: $checkpointMissing"
+        # F8: message now covers the field being absent OR present-with-an-
+        # invalid-or-unresolvable value (previously presence-only for
+        # Checkpoint SHA; Diff Base SHA had no coverage at all).
+        Add-Result -Level 'WARN' -Message "work logs with missing/invalid Checkpoint SHA field or invalid/unresolvable Diff Base SHA / Checkpoint SHA values: $checkpointMissing"
+        foreach ($line in $checkpointViolationList) { Write-Output $line }
     } elseif ($worklogs.Count -gt 0) {
-        Add-Result -Level 'PASS' -Message 'all active work logs have Checkpoint SHA field'
+        Add-Result -Level 'PASS' -Message 'all active work logs have well-formed Checkpoint SHA / Diff Base SHA values'
     }
     if ($gateEvidenceMissing -gt 0) {
         Add-Result -Level 'FAIL' -Message "work logs missing gate evidence receipts: $gateEvidenceMissing"
@@ -1637,12 +1747,34 @@ if (Test-Path -Path $worklogDir -PathType Container) {
 
     # Gate receipt schema validation (§4.5 structural check) — parity with validate.sh.
     # Every pipe-format gate receipt in ## Gate Evidence must include Verdict: and
-    # Classification: fields. WARN not FAIL (partial receipts are a process gap).
+    # Classification: fields. WARN not FAIL (archived Work Logs may predate this
+    # check — a SEPARATE archive loop below covers Verdict/Classification presence
+    # only for archive/*.md and is untouched by F7/F9); active logs with partial
+    # receipts are a process gap, not a ship-blocking error.
+    # F7 (2026-07-11 receipt-integrity audit): also require a Timestamp: field
+    # with at least an ISO date. Order-of-appearance remains authoritative for
+    # gate progression (see templates/worklog.md ## Gate Evidence note) —
+    # Timestamp is provenance metadata only; no monotonic/chronological check.
+    # F9: also compare each receipt's Classification value (case-insensitive)
+    # against the Work Log header Classification. Mismatch is WARN, not FAIL —
+    # reclassification epochs are legal (state machine rollback-to-CLASSIFIED)
+    # and epoch parsing is out of scope for this check.
     $gateSchemaViolations = 0
     $gateSchemaViolationList = New-Object System.Collections.Generic.List[string]
     foreach ($wl in $worklogs) {
         $wlContent = Get-Content -Path $wl.FullName -Raw -Encoding utf8 -ErrorAction SilentlyContinue
         if (-not $wlContent) { continue }
+        # F9: header Classification value — same strict "starts with a letter"
+        # extraction the gate-progression parser already uses, so an unfilled/
+        # malformed header (still the literal template placeholder) yields
+        # empty and is skipped rather than compared (nothing meaningful to
+        # compare against).
+        $hdrClass = ''
+        $hdrClassM = [regex]::Match($wlContent, '(?m)^-\s*\*{0,2}Classification\*{0,2}\s*:\s*`?([a-zA-Z][a-zA-Z0-9_-]*)')
+        if (-not $hdrClassM.Success) {
+            $hdrClassM = [regex]::Match($wlContent, '(?m)^\|\s*\*{0,2}Classification\*{0,2}\s*\|\s*`?([a-zA-Z][a-zA-Z0-9_-]*)')
+        }
+        if ($hdrClassM.Success) { $hdrClass = $hdrClassM.Groups[1].Value.ToLowerInvariant() }
         foreach ($receiptLine in ([regex]::Matches($wlContent, '(?im)^-\s+Gate\s*:.*$') | ForEach-Object { $_.Value })) {
             if ($receiptLine -notmatch '(?i)Verdict\s*:') {
                 $gateSchemaViolations++
@@ -1654,13 +1786,33 @@ if (Test-Path -Path $worklogDir -PathType Container) {
                 $gateSchemaViolationList.Add("  malformed gate receipt (missing Classification:) in $($wl.Name)")
                 break
             }
+            # F7: Timestamp field must be present with a parseable ISO date (a
+            # full ISO datetime like 2026-07-10T12:20:00Z is also accepted —
+            # the date-only regex matches its leading YYYY-MM-DD).
+            if ($receiptLine -notmatch '(?i)Timestamp\s*:\s*\d{4}-\d{2}-\d{2}') {
+                $gateSchemaViolations++
+                $gateSchemaViolationList.Add("  malformed gate receipt (missing/unparseable Timestamp:) in $($wl.Name): $receiptLine")
+                break
+            }
+            # F9: receipt Classification must agree with the header Classification.
+            if ($hdrClass) {
+                $receiptClassM = [regex]::Match($receiptLine, '(?i)Classification\s*:\s*([a-zA-Z][a-zA-Z0-9_-]*)')
+                if ($receiptClassM.Success) {
+                    $receiptClass = $receiptClassM.Groups[1].Value.ToLowerInvariant()
+                    if ($receiptClass -ne $hdrClass) {
+                        $gateSchemaViolations++
+                        $gateSchemaViolationList.Add("  receipt Classification ('$receiptClass') differs from header Classification ('$hdrClass') in $($wl.Name): $receiptLine")
+                        break
+                    }
+                }
+            }
         }
     }
     if ($gateSchemaViolations -gt 0) {
-        Add-Result -Level 'WARN' -Message "active work log gate receipts missing required fields (Verdict/Classification): $gateSchemaViolations"
+        Add-Result -Level 'WARN' -Message "active work log gate receipts with schema violations (missing Verdict/Classification/Timestamp, or Classification mismatched with header): $gateSchemaViolations"
         foreach ($line in $gateSchemaViolationList) { Write-Output $line }
     } elseif ($worklogs.Count -gt 0) {
-        Add-Result -Level 'PASS' -Message 'all active work log gate receipts have required fields (gate/verdict/classification)'
+        Add-Result -Level 'PASS' -Message 'all active work log gate receipts have required fields and consistent Classification (gate/verdict/classification/timestamp)'
     }
 
     # Advisory lock staleness check — reads JSON fields per config.yaml §worklog_lock

--- a/.agentcortex/bin/validate.sh
+++ b/.agentcortex/bin/validate.sh
@@ -1123,7 +1123,18 @@ if command -v git >/dev/null 2>&1 && git -C "$ROOT" rev-parse --git-dir >/dev/nu
   _cur_branch="$(git -C "$ROOT" symbolic-ref --short HEAD 2>/dev/null)" \
     || _cur_branch="$(git -C "$ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null)" || true
   if [[ -n "$_cur_branch" && "$_cur_branch" != "HEAD" ]]; then
-    cur_key="${_cur_branch//\//-}"
+    # F10 (2026-07-11 receipt-integrity audit): apply the canonical Work Log
+    # key normalization (bootstrap.md:123-131) in full — (1) chars outside
+    # [a-zA-Z0-9._-] -> '-', (2) collapse '-' runs, (3) strip leading/trailing
+    # '-'/'.', (4) lowercase, (5) truncate to 100 chars. Previously this only
+    # replaced '/' with '-' and stayed case-sensitive, so an uppercase or
+    # punctuated branch (e.g. "Feat/X", "release/v1.2:rc") mismatched the
+    # canonical lowercase Work Log filename and was misdetected as historical,
+    # downgrading current-branch-only Resume/Test-Gate escalations FAIL->WARN.
+    cur_key="$(printf '%s' "$_cur_branch" \
+      | sed -E 's/[^a-zA-Z0-9._-]/-/g; s/-+/-/g; s/^[-.]+//; s/[-.]+$//' \
+      | tr '[:upper:]' '[:lower:]' \
+      | cut -c1-100)"
   fi
 fi
 if [[ -d "$WORKLOG_DIR" ]]; then
@@ -1187,6 +1198,7 @@ if [[ -d "$WORKLOG_DIR" ]]; then
   # Work Log evidence chain check (per AGENTS.md Work Log Contract)
   phase_field_missing=0
   checkpoint_missing=0
+  checkpoint_violation_list=""
   gate_evidence_missing=0
   legacy_gate_evidence_missing=0
   gate_progression_illegal=0
@@ -1207,6 +1219,50 @@ if [[ -d "$WORKLOG_DIR" ]]; then
   # ONE new native record_result FAIL site handles both (baseline +1).
   current_branch_gate_fail=0
   current_branch_gate_fail_list=""
+  # F8 (2026-07-11 receipt-integrity audit): shared value-shape + resolvability
+  # check for header SHA-like fields (Checkpoint SHA / Diff Base SHA). Previously
+  # presence-only: a heading with a non-SHA value (e.g. "not-a-sha") passed
+  # silently. Accepts a hex object id (7-40 chars, optionally followed by
+  # trailing note text) or an observed legitimate placeholder — "none",
+  # "pending-commit" (both seen in real archived logs), or the unfilled
+  # template default "<git-sha or none>" (templates/worklog.md; two real active
+  # logs still carry it) — anything else is a WARN-tier violation. Current-
+  # branch logs additionally get a `git rev-parse --verify` resolvability
+  # check; historical logs are shape-checked only (squash/rebase legitimately
+  # invalidates old SHAs). Mutates the pre-existing checkpoint_missing /
+  # checkpoint_violation_list counters (ADR-006 native-extension path — see
+  # Work Log Drift Log — not a new record_result call site).
+  _acx_check_sha_field() {
+    local content="$1" field="$2" is_cur="$3" wl_label="$4"
+    local raw val lc verify_val
+    raw="$(printf '%s' "$content" | grep -m1 -iE "(^-[[:space:]]*\`?${field}\`?:|^\|[[:space:]]*\`?${field}\`?[[:space:]]*\|)")" || true
+    [[ -z "$raw" ]] && return 0
+    if [[ "$raw" == -* ]]; then
+      val="$(printf '%s' "$raw" | sed -E "s/^-[[:space:]]*\`?${field}\`?:[[:space:]]*//")"
+    else
+      val="$(printf '%s' "$raw" | awk -F'|' '{print $3}')"
+    fi
+    val="$(printf '%s' "$val" | sed -E 's/<!--.*-->//' | tr -d '`\r' | xargs)" || true
+    [[ -z "$val" ]] && return 0  # unparseable — presence is already covered separately; degrade silently
+    lc="$(printf '%s' "$val" | tr '[:upper:]' '[:lower:]')"
+    if [[ "$lc" == "none" || "$lc" == "pending-commit" || "$lc" == "<git-sha or none>" ]]; then
+      return 0
+    fi
+    if [[ "$lc" =~ ^[0-9a-f]{7,40}$ ]]; then
+      verify_val="$val"
+    elif [[ "${lc%% *}" =~ ^[0-9a-f]{7,40}$ ]]; then
+      verify_val="${val%% *}"
+    else
+      checkpoint_missing=$((checkpoint_missing + 1))
+      checkpoint_violation_list="${checkpoint_violation_list}  invalid ${field} value ('${val}') in ${wl_label}\n"
+      return 0
+    fi
+    if [[ "$is_cur" -eq 1 ]] && ! git -C "$ROOT" rev-parse --verify "${verify_val}^{commit}" >/dev/null 2>&1; then
+      checkpoint_missing=$((checkpoint_missing + 1))
+      checkpoint_violation_list="${checkpoint_violation_list}  unresolvable ${field} ('${verify_val}') in ${wl_label} (git rev-parse --verify failed)\n"
+    fi
+    return 0
+  }
   for wl in "$WORKLOG_DIR"/*.md; do
     [[ -f "$wl" ]] || continue
     wl_content="$(cat "$wl" 2>/dev/null)"
@@ -1214,7 +1270,10 @@ if [[ -d "$WORKLOG_DIR" ]]; then
     # Match <cur_key>.md OR <owner>-<cur_key>.md (owner prefix pattern).
     is_current_branch=0
     if [[ -n "$cur_key" ]]; then
-      wl_basename="$(basename "$wl")"
+      # F10: lowercase the basename too (cur_key is already lowercase) so the
+      # comparison is case-insensitive on both sides — defense against a
+      # non-conforming log filename that wasn't written in canonical case.
+      wl_basename="$(basename "$wl" | tr '[:upper:]' '[:lower:]')"
       if [[ "$wl_basename" == "${cur_key}.md" ]] || [[ "$wl_basename" == *"-${cur_key}.md" ]]; then
         is_current_branch=1
       fi
@@ -1236,7 +1295,14 @@ if [[ -d "$WORKLOG_DIR" ]]; then
     # Header field: Checkpoint SHA — accept list OR table form
     if ! printf '%s' "$wl_content" | grep -qE '(^- (`Checkpoint SHA`|Checkpoint SHA):|^\| (`Checkpoint SHA`|Checkpoint SHA) +\|)'; then
       checkpoint_missing=$((checkpoint_missing + 1))
+    else
+      # F8: value-shape + (current-branch-only) resolvability validation.
+      _acx_check_sha_field "$wl_content" "Checkpoint SHA" "$is_current_branch" "$(basename "$wl")"
     fi
+    # F8: Diff Base SHA gets the same value treatment when present. No pre-
+    # existing presence check for this field — presence is NOT newly required
+    # here, only value-shape/resolvability when the field IS present.
+    _acx_check_sha_field "$wl_content" "Diff Base SHA" "$is_current_branch" "$(basename "$wl")"
     # Runtime section: ## Gate Evidence — check existence, receipt format,
     # AND phase progression legality. Illegal progression = FAIL.
     if ! printf '%s' "$wl_content" | grep -q '^## Gate Evidence'; then
@@ -1688,9 +1754,13 @@ PYEOF
     record_result PASS "all active work logs have Current Phase field"
   fi
   if [[ "$checkpoint_missing" -gt 0 ]]; then
-    record_result WARN "work logs missing Checkpoint SHA field: ${checkpoint_missing}"
+    # F8: message now covers the field being absent OR present-with-an-invalid-
+    # or-unresolvable value (previously presence-only for Checkpoint SHA; Diff
+    # Base SHA had no coverage at all).
+    record_result WARN "work logs with missing/invalid Checkpoint SHA field or invalid/unresolvable Diff Base SHA / Checkpoint SHA values: ${checkpoint_missing}"
+    printf '%b' "$checkpoint_violation_list"
   elif [[ "$worklog_count" -gt 0 ]]; then
-    record_result PASS "all active work logs have Checkpoint SHA field"
+    record_result PASS "all active work logs have well-formed Checkpoint SHA / Diff Base SHA values"
   fi
   if [[ "$gate_evidence_missing" -gt 0 ]]; then
     record_result FAIL "work logs missing gate evidence receipts: ${gate_evidence_missing}"
@@ -1775,13 +1845,37 @@ PYEOF
   fi
   # Gate receipt schema validation (§4.5 structural check) — every pipe-format gate
   # receipt in ## Gate Evidence must include Verdict: and Classification: fields.
-  # WARN not FAIL: archived Work Logs may predate this check; active logs with partial
-  # receipts are a process gap, not a ship-blocking error.
+  # WARN not FAIL: archived Work Logs may predate this check (a SEPARATE archive
+  # loop below covers Verdict/Classification presence only for archive/*.md and
+  # is untouched by F7/F9); active logs with partial receipts are a process gap,
+  # not a ship-blocking error.
+  # F7 (2026-07-11 receipt-integrity audit): also require a Timestamp: field with
+  # at least an ISO date. Order-of-appearance remains authoritative for gate
+  # progression (see templates/worklog.md ## Gate Evidence note) — Timestamp is
+  # provenance metadata only; no monotonic/chronological check is performed.
+  # F9: also compare each receipt's Classification value (case-insensitive)
+  # against the Work Log header Classification. Mismatch is WARN, not FAIL —
+  # reclassification epochs are legal (state machine rollback-to-CLASSIFIED) and
+  # epoch parsing is out of scope for this check.
   gate_schema_violations=0
   gate_schema_violation_list=""
   for wl in "$WORKLOG_DIR"/*.md; do
     [[ -f "$wl" ]] || continue
     wl_name="$(basename "$wl")"
+    wl_content="$(cat "$wl" 2>/dev/null)"
+    # F9: header Classification value — same strict "starts with a letter"
+    # extraction the gate-progression parser already uses, so an unfilled/
+    # malformed header (still the literal template placeholder) yields empty
+    # and is skipped rather than compared (nothing meaningful to compare).
+    hdr_class="$(printf '%s' "$wl_content" \
+      | grep -m1 -iE '^-[[:space:]]*\*{0,2}Classification\*{0,2}[[:space:]]*:[[:space:]]*`?[a-zA-Z]' \
+      | sed -E 's/^-[[:space:]]*\*{0,2}Classification\*{0,2}[[:space:]]*:[[:space:]]*`?([a-zA-Z][a-zA-Z0-9_-]*).*/\1/')" || true
+    if [[ -z "$hdr_class" ]]; then
+      hdr_class="$(printf '%s' "$wl_content" \
+        | grep -m1 -iE '^\|[[:space:]]*\*{0,2}Classification\*{0,2}[[:space:]]*\|[[:space:]]*`?[a-zA-Z]' \
+        | sed -E 's/^\|[[:space:]]*\*{0,2}Classification\*{0,2}[[:space:]]*\|[[:space:]]*`?([a-zA-Z][a-zA-Z0-9_-]*).*/\1/')" || true
+    fi
+    hdr_class="$(printf '%s' "$hdr_class" | tr '[:upper:]' '[:lower:]')"
     # Extract gate evidence section lines (pipe-format receipts starting with "- Gate:")
     while IFS= read -r receipt_line; do
       # Each receipt must contain Verdict: (case-insensitive) and Classification: (case-insensitive)
@@ -1795,13 +1889,32 @@ PYEOF
         gate_schema_violation_list="${gate_schema_violation_list}  malformed gate receipt (missing Classification:) in ${wl_name}\n"
         break
       fi
+      # F7: Timestamp field must be present with a parseable ISO date (a full ISO
+      # datetime like 2026-07-10T12:20:00Z is also accepted — the date-only regex
+      # matches its leading YYYY-MM-DD).
+      if ! printf '%s' "$receipt_line" | grep -qiE 'Timestamp[[:space:]]*:[[:space:]]*[0-9]{4}-[0-9]{2}-[0-9]{2}'; then
+        gate_schema_violations=$((gate_schema_violations + 1))
+        gate_schema_violation_list="${gate_schema_violation_list}  malformed gate receipt (missing/unparseable Timestamp:) in ${wl_name}: ${receipt_line}\n"
+        break
+      fi
+      # F9: receipt Classification must agree with the header Classification.
+      if [[ -n "$hdr_class" ]]; then
+        receipt_class="$(printf '%s' "$receipt_line" \
+          | sed -nE 's/.*[Cc]lassification[[:space:]]*:[[:space:]]*([a-zA-Z][a-zA-Z0-9_-]*).*/\1/p' \
+          | tr '[:upper:]' '[:lower:]')" || true
+        if [[ -n "$receipt_class" && "$receipt_class" != "$hdr_class" ]]; then
+          gate_schema_violations=$((gate_schema_violations + 1))
+          gate_schema_violation_list="${gate_schema_violation_list}  receipt Classification ('${receipt_class}') differs from header Classification ('${hdr_class}') in ${wl_name}: ${receipt_line}\n"
+          break
+        fi
+      fi
     done < <(grep -iE '^\-[[:space:]]+[Gg]ate[[:space:]]*:' "$wl" 2>/dev/null || true)
   done
   if [[ "$gate_schema_violations" -gt 0 ]]; then
-    record_result WARN "active work log gate receipts missing required fields (Verdict/Classification): ${gate_schema_violations}"
+    record_result WARN "active work log gate receipts with schema violations (missing Verdict/Classification/Timestamp, or Classification mismatched with header): ${gate_schema_violations}"
     printf '%b' "$gate_schema_violation_list"
   elif [[ "$worklog_count" -gt 0 ]]; then
-    record_result PASS "all active work log gate receipts have required fields (gate/verdict/classification)"
+    record_result PASS "all active work log gate receipts have required fields and consistent Classification (gate/verdict/classification/timestamp)"
   fi
   # Advisory lock staleness check — reads JSON fields per config.yaml §worklog_lock.
   # All JSON parsing and stale logic stays inside Python to avoid eval/injection.

--- a/.agentcortex/templates/worklog.md
+++ b/.agentcortex/templates/worklog.md
@@ -72,6 +72,7 @@ none
 
 > Gate receipts written by each phase. Format: `- Gate: <phase> | Verdict: PASS | Classification: <type> | Timestamp: <ISO>`
 > **Critical**: `|` pipe separators are mandatory. Receipts placed inside markdown code fences are silently masked and NOT counted by validate.sh — always write receipts as plain list lines.
+> Receipt order-of-appearance is authoritative for phase progression; `Timestamp` is provenance metadata only (validators require it to be present and parseable, but do NOT enforce monotonic/chronological ordering).
 
 none
 

--- a/tests/ci/test_validator_false_positives.py
+++ b/tests/ci/test_validator_false_positives.py
@@ -1175,3 +1175,488 @@ def test_not_ready_re_review_hint_source_parity() -> None:
         assert NOT_READY_HINT in src, f"{label} missing NOT-READY remediation hint"
         assert NOT_READY_HINT_REMEDY in src, f"{label} missing remedy phrasing"
         assert "review.md §Reverse Transition" in src, f"{label} missing review.md §Reverse Transition cite"
+
+
+# ---------------------------------------------------------------------------
+# 2026-07-11 receipt-integrity audit (docs/reviews/2026-07-11-govern-audit-
+# receipt-integrity.md): F10 canonical Work Log key normalization, F7 receipt
+# Timestamp requirement, F9 receipt/header Classification agreement, F8
+# Checkpoint SHA / Diff Base SHA value-shape + resolvability validation.
+# ---------------------------------------------------------------------------
+
+GATE_SCHEMA_WARN = "active work log gate receipts with schema violations"
+CHECKPOINT_SHA_WARN_MSG = "invalid Checkpoint SHA value"
+DIFF_BASE_SHA_WARN_MSG = "invalid Diff Base SHA value"
+
+
+def _write_receipt_schema_worklog(
+    target: Path,
+    name: str,
+    *,
+    header_classification: str,
+    gate_lines: str,
+    checkpoint_sha: str = "0000000000000000000000000000000000000000",
+    extra_header: str = "",
+) -> None:
+    """Minimal Work Log fixture for F7/F8/F9 receipt-schema tests — a leaner
+    header than `_write_worklog` so tests can inject a deliberately malformed
+    Classification header, an overridden Checkpoint SHA, an extra Diff Base
+    SHA line (via extra_header), or omit Timestamp from individual receipts.
+    NOTE: Checkpoint SHA has exactly ONE emission site (the `checkpoint_sha`
+    param) — do NOT also inject a "- Checkpoint SHA:" line via extra_header,
+    or validate.sh/.ps1's `grep -m1` / first-match extraction will silently
+    prefer whichever line comes first, masking the intended override."""
+    work_dir = target / ".agentcortex" / "context" / "work"
+    work_dir.mkdir(parents=True, exist_ok=True)
+    (work_dir / name).write_text(
+        f"""# Work Log: {name}
+
+## Header
+
+- Branch: `test/{name}`
+- Classification: `{header_classification}`
+- Current Phase: `ship`
+- Checkpoint SHA: `{checkpoint_sha}`
+{extra_header}
+---
+
+## Phase Summary
+
+Receipt-schema fixture. ACX
+
+---
+
+## Gate Evidence
+
+{gate_lines}
+
+---
+
+## Drift Log
+
+- ADR Coverage Check: test fixture.
+
+---
+
+## Resume
+
+none
+
+---
+
+## Evidence
+
+- Fixture evidence.
+""",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+# --- F10: canonical Work Log key normalization ------------------------------
+#
+# bootstrap.md:123-131 canonical algorithm: (1) chars outside [a-zA-Z0-9._-]
+# -> '-', (2) collapse '-' runs, (3) strip leading/trailing '-'/'.',
+# (4) lowercase, (5) truncate to 100 chars. Branch "Feat/Add##Auth-" exercises
+# steps 1 (slash + double-hash -> dashes), 2 (collapse), 3 (trailing-dash
+# trim), and 4 (lowercase) all at once; canonical key = "feat-add-auth".
+
+F10_COMBINED_BRANCH = "Feat/Add##Auth-"
+F10_COMBINED_KEY = "feat-add-auth"
+
+
+@pytest.mark.slow
+@requires_bash
+def test_f10_combined_normalization_current_log_detected_as_current_sh() -> None:
+    """An uppercase + punctuated + trailing-dash branch must still canonicalize
+    to its documented Work Log key and be detected as the CURRENT-branch log —
+    missing Resume at handoff must FAIL (not WARN). Reproduces the audit's
+    exact failure mode (case-sensitive compare in bash) plus the punctuation
+    gap the case-only reproduction did not cover."""
+    with tempfile.TemporaryDirectory() as td:
+        target = _deploy_with_git_branch(Path(td), F10_COMBINED_BRANCH)
+        _write_worklog(
+            target,
+            f"{F10_COMBINED_KEY}.md",
+            classification="architecture-change",
+            phase="handoff",
+            gates=("bootstrap", "plan", "implement", "review", "test", "handoff"),
+            resume="none",
+        )
+        out = _run_validate(target)
+        assert AC6_FAIL_MSG in out, (
+            f"validate.sh must detect the canonical log as CURRENT for a "
+            f"combined uppercase/punctuation/trailing-dash branch (F10). "
+            f"Output:\n{out[-1200:]}"
+        )
+        assert _resume_warn_count(out) == 0 or _resume_warn_count(out) is None, (
+            f"validate.sh must not WARN (downgrade) once F10 is fixed. Output:\n{out[-1200:]}"
+        )
+
+
+@pytest.mark.slow
+@requires_windows
+@requires_bash
+@requires_powershell
+def test_f10_combined_normalization_current_log_detected_as_current_ps1() -> None:
+    """validate.ps1 parity. PowerShell's -eq/-like are already case-insensitive
+    (masking the case half pre-fix), but punctuation was NOT normalized on
+    either platform before F10 — this branch still discriminates old vs new
+    ps1 behavior via the double-hash + trailing-dash steps."""
+    with tempfile.TemporaryDirectory() as td:
+        target = _deploy_with_git_branch(Path(td), F10_COMBINED_BRANCH)
+        _write_worklog(
+            target,
+            f"{F10_COMBINED_KEY}.md",
+            classification="architecture-change",
+            phase="handoff",
+            gates=("bootstrap", "plan", "implement", "review", "test", "handoff"),
+            resume="none",
+        )
+        out = _run_validate_ps1(target)
+        assert AC6_FAIL_MSG in out, (
+            f"validate.ps1 must detect the canonical log as CURRENT for a "
+            f"combined uppercase/punctuation/trailing-dash branch (F10 parity). "
+            f"Output:\n{out[-1200:]}"
+        )
+        assert _resume_warn_count(out) == 0 or _resume_warn_count(out) is None, (
+            f"validate.ps1 must not WARN (downgrade) once F10 is fixed. Output:\n{out[-1200:]}"
+        )
+
+
+@pytest.mark.slow
+@requires_bash
+def test_f10_non_matching_log_stays_historical_warn_sh() -> None:
+    """Negative control: a Work Log that does NOT match the (correctly
+    normalized) current-branch key must stay a historical WARN, not escalate
+    to FAIL — proves F10 did not make detection overly permissive."""
+    with tempfile.TemporaryDirectory() as td:
+        target = _deploy_with_git_branch(Path(td), F10_COMBINED_BRANCH)
+        _write_worklog(
+            target,
+            "totally-unrelated-branch-log.md",
+            classification="architecture-change",
+            phase="handoff",
+            gates=("bootstrap", "plan", "implement", "review", "test", "handoff"),
+            resume="none",
+        )
+        out = _run_validate(target)
+        assert AC6_FAIL_MSG not in out, (
+            f"validate.sh must NOT FAIL for a log that doesn't match the "
+            f"current-branch key. Output:\n{out[-1200:]}"
+        )
+        assert _resume_warn_count(out) == 1, (
+            f"non-matching log must still WARN as historical. Output:\n{out[-1200:]}"
+        )
+
+
+@pytest.mark.slow
+@requires_bash
+def test_f10_truncation_100_chars_current_log_detected_as_current_sh() -> None:
+    """Step 5: a >100-char branch name canonicalizes to a 100-char-truncated
+    key, and that truncated filename is still detected as CURRENT."""
+    long_branch = "feat/" + ("x" * 105)  # "feat-" (5) + 105 x's = 110 raw chars
+    truncated_key = ("feat-" + ("x" * 105))[:100]
+    with tempfile.TemporaryDirectory() as td:
+        target = _deploy_with_git_branch(Path(td), long_branch)
+        _write_worklog(
+            target,
+            f"{truncated_key}.md",
+            classification="architecture-change",
+            phase="handoff",
+            gates=("bootstrap", "plan", "implement", "review", "test", "handoff"),
+            resume="none",
+        )
+        out = _run_validate(target)
+        assert AC6_FAIL_MSG in out, (
+            f"validate.sh must truncate a >100-char branch to 100 chars and still "
+            f"detect the resulting log as CURRENT (F10 step 5). Output:\n{out[-1200:]}"
+        )
+
+
+def test_f10_source_parity_five_step_normalization() -> None:
+    """Structural (fast, no subprocess): both validators must implement all 5
+    canonical normalization steps, not just slash->dash."""
+    sh = VALIDATE_SH.read_text(encoding="utf-8")
+    ps1 = VALIDATE_PS1.read_text(encoding="utf-8")
+    # step 1: replace non-conforming chars with '-'
+    assert "[^a-zA-Z0-9._-]" in sh, "validate.sh missing F10 step-1 char-class replacement"
+    assert "[^a-zA-Z0-9._-]" in ps1, "validate.ps1 missing F10 step-1 char-class replacement"
+    # step 2: collapse consecutive dashes
+    assert "-+" in sh, "validate.sh missing F10 step-2 dash-collapse"
+    # step 4: lowercase
+    assert "tr '[:upper:]' '[:lower:]'" in sh, "validate.sh cur_key must lowercase (F10 step 4)"
+    assert "ToLowerInvariant()" in ps1, "validate.ps1 curKey must lowercase (F10 step 4)"
+    # step 5: truncate to 100 chars
+    assert "cut -c1-100" in sh, "validate.sh cur_key must truncate to 100 chars (F10 step 5)"
+    assert "Substring(0, 100)" in ps1, "validate.ps1 curKey must truncate to 100 chars (F10 step 5)"
+    # filename comparison must be explicitly case-insensitive on both sides
+    assert 'wl_basename="$(basename "$wl" | tr' in sh, (
+        "validate.sh must lowercase wl_basename before comparing (F10 defense)"
+    )
+    assert "GetFileName($wl.FullName).ToLowerInvariant()" in ps1, (
+        "validate.ps1 must lowercase wlBasename before comparing (F10 defense)"
+    )
+
+
+# --- F7: receipt Timestamp requirement --------------------------------------
+
+
+@pytest.mark.slow
+@requires_bash
+def test_f7_missing_timestamp_warns_sh() -> None:
+    """F7: a receipt with no Timestamp: field must trigger the schema WARN."""
+    with tempfile.TemporaryDirectory() as td:
+        target = _deploy_for_validator_fixture(Path(td))
+        gate_lines = "\n".join([
+            "- Gate: bootstrap | Verdict: PASS | Classification: quick-win",
+            "- Gate: plan | Verdict: PASS | Classification: quick-win | Timestamp: 2026-07-11T00:00:00Z",
+        ])
+        _write_receipt_schema_worklog(
+            target, "f7-missing-timestamp.md",
+            header_classification="quick-win", gate_lines=gate_lines,
+        )
+        out = _run_validate(target)
+        assert GATE_SCHEMA_WARN in out, out[-1200:]
+        assert "missing/unparseable Timestamp" in out, out[-1200:]
+
+
+@pytest.mark.slow
+@requires_windows
+@requires_bash
+@requires_powershell
+def test_f7_missing_timestamp_warns_ps1() -> None:
+    """validate.ps1 parity for F7."""
+    with tempfile.TemporaryDirectory() as td:
+        target = _deploy_for_validator_fixture(Path(td))
+        gate_lines = "- Gate: bootstrap | Verdict: PASS | Classification: quick-win"
+        _write_receipt_schema_worklog(
+            target, "f7-missing-timestamp.md",
+            header_classification="quick-win", gate_lines=gate_lines,
+        )
+        out = _run_validate_ps1(target)
+        assert GATE_SCHEMA_WARN in out, out[-1200:]
+        assert "missing/unparseable Timestamp" in out, out[-1200:]
+
+
+@pytest.mark.slow
+@requires_bash
+def test_f7_date_only_timestamp_accepted_sh() -> None:
+    """F7: a date-only ISO Timestamp (no time component) is accepted — the
+    audit's acceptance criterion explicitly permits a bare YYYY-MM-DD."""
+    with tempfile.TemporaryDirectory() as td:
+        target = _deploy_for_validator_fixture(Path(td))
+        gate_lines = "- Gate: bootstrap | Verdict: PASS | Classification: quick-win | Timestamp: 2026-07-11"
+        _write_receipt_schema_worklog(
+            target, "f7-date-only.md",
+            header_classification="quick-win", gate_lines=gate_lines,
+        )
+        out = _run_validate(target)
+        assert "missing/unparseable Timestamp" not in out, out[-1200:]
+
+
+# --- F9: receipt Classification must agree with header Classification -------
+
+
+@pytest.mark.slow
+@requires_bash
+def test_f9_classification_mismatch_warns_sh() -> None:
+    """F9: a receipt claiming a different Classification than the header must WARN."""
+    with tempfile.TemporaryDirectory() as td:
+        target = _deploy_for_validator_fixture(Path(td))
+        gate_lines = "- Gate: bootstrap | Verdict: PASS | Classification: tiny-fix | Timestamp: 2026-07-11T00:00:00Z"
+        _write_receipt_schema_worklog(
+            target, "f9-mismatch.md",
+            header_classification="feature", gate_lines=gate_lines,
+        )
+        out = _run_validate(target)
+        assert GATE_SCHEMA_WARN in out, out[-1200:]
+        assert "differs from header Classification" in out, out[-1200:]
+
+
+@pytest.mark.slow
+@requires_windows
+@requires_bash
+@requires_powershell
+def test_f9_classification_mismatch_warns_ps1() -> None:
+    """validate.ps1 parity for F9."""
+    with tempfile.TemporaryDirectory() as td:
+        target = _deploy_for_validator_fixture(Path(td))
+        gate_lines = "- Gate: bootstrap | Verdict: PASS | Classification: tiny-fix | Timestamp: 2026-07-11T00:00:00Z"
+        _write_receipt_schema_worklog(
+            target, "f9-mismatch.md",
+            header_classification="feature", gate_lines=gate_lines,
+        )
+        out = _run_validate_ps1(target)
+        assert GATE_SCHEMA_WARN in out, out[-1200:]
+        assert "differs from header Classification" in out, out[-1200:]
+
+
+@pytest.mark.slow
+@requires_bash
+def test_f9_unfilled_header_classification_not_compared_sh() -> None:
+    """F9: an unfilled/malformed header Classification (still the literal
+    template placeholder — the exact state of two real active Work Logs in
+    this repo at audit time) must NOT be compared; nothing meaningful to
+    compare against, so it must not spuriously WARN."""
+    with tempfile.TemporaryDirectory() as td:
+        target = _deploy_for_validator_fixture(Path(td))
+        gate_lines = "- Gate: bootstrap | Verdict: PASS | Classification: quick-win | Timestamp: 2026-07-11T00:00:00Z"
+        _write_receipt_schema_worklog(
+            target, "f9-unfilled-header.md",
+            header_classification="<tiny-fix | quick-win | hotfix | feature | architecture-change>",
+            gate_lines=gate_lines,
+        )
+        out = _run_validate(target)
+        assert "differs from header Classification" not in out, out[-1200:]
+
+
+@pytest.mark.slow
+@requires_bash
+def test_f9_matching_classification_no_warn_sh() -> None:
+    """Regression guard: receipts whose Classification agrees with the header
+    must not warn (the common case — every real receipt in this repo today)."""
+    with tempfile.TemporaryDirectory() as td:
+        target = _deploy_for_validator_fixture(Path(td))
+        gate_lines = "\n".join([
+            "- Gate: bootstrap | Verdict: PASS | Classification: quick-win | Timestamp: 2026-07-11T00:00:00Z",
+            "- Gate: plan | Verdict: PASS | Classification: quick-win | Timestamp: 2026-07-11T00:05:00Z",
+        ])
+        _write_receipt_schema_worklog(
+            target, "f9-matching.md",
+            header_classification="quick-win", gate_lines=gate_lines,
+        )
+        out = _run_validate(target)
+        assert GATE_SCHEMA_WARN not in out, out[-1200:]
+
+
+# --- F8: Checkpoint SHA / Diff Base SHA value-shape + resolvability ---------
+
+
+@pytest.mark.slow
+@requires_bash
+def test_f8_invalid_checkpoint_sha_warns_sh() -> None:
+    """F8: a non-hex, non-placeholder Checkpoint SHA value must WARN — the
+    audit's exact repro value ('not-a-sha')."""
+    with tempfile.TemporaryDirectory() as td:
+        target = _deploy_for_validator_fixture(Path(td))
+        gate_lines = "- Gate: bootstrap | Verdict: PASS | Classification: quick-win | Timestamp: 2026-07-11T00:00:00Z"
+        _write_receipt_schema_worklog(
+            target, "f8-bad-sha.md",
+            header_classification="quick-win", gate_lines=gate_lines,
+            checkpoint_sha="not-a-sha",
+        )
+        out = _run_validate(target)
+        assert CHECKPOINT_SHA_WARN_MSG in out, out[-1200:]
+
+
+@pytest.mark.slow
+@requires_windows
+@requires_bash
+@requires_powershell
+def test_f8_invalid_checkpoint_sha_warns_ps1() -> None:
+    """validate.ps1 parity for F8."""
+    with tempfile.TemporaryDirectory() as td:
+        target = _deploy_for_validator_fixture(Path(td))
+        gate_lines = "- Gate: bootstrap | Verdict: PASS | Classification: quick-win | Timestamp: 2026-07-11T00:00:00Z"
+        _write_receipt_schema_worklog(
+            target, "f8-bad-sha.md",
+            header_classification="quick-win", gate_lines=gate_lines,
+            checkpoint_sha="not-a-sha",
+        )
+        out = _run_validate_ps1(target)
+        assert CHECKPOINT_SHA_WARN_MSG in out, out[-1200:]
+
+
+@pytest.mark.slow
+@requires_bash
+def test_f8_accepted_placeholders_no_warn_sh() -> None:
+    """F8: 'none', 'pending-commit', and the unfilled template default must
+    NOT warn — observed legitimate placeholders (grepped from this repo's real
+    active/archived Work Logs and templates/worklog.md before implementing)."""
+    with tempfile.TemporaryDirectory() as td:
+        target = _deploy_for_validator_fixture(Path(td))
+        work_dir = target / ".agentcortex" / "context" / "work"
+        for i, val in enumerate(["none", "pending-commit", "<git-sha or none>", "abc1234"]):
+            gate_lines = "- Gate: bootstrap | Verdict: PASS | Classification: quick-win | Timestamp: 2026-07-11T00:00:00Z"
+            _write_receipt_schema_worklog(
+                target, f"f8-placeholder-{i}.md",
+                header_classification="quick-win", gate_lines=gate_lines,
+                checkpoint_sha=val,
+            )
+        out = _run_validate(target)
+        assert CHECKPOINT_SHA_WARN_MSG not in out, out[-1200:]
+
+
+@pytest.mark.slow
+@requires_bash
+def test_f8_unresolvable_current_branch_sha_warns_but_historical_does_not_sh() -> None:
+    """F8: a well-formed but non-existent SHA on the CURRENT-branch log must
+    WARN (resolvability check, git rev-parse --verify); the identical value on
+    a non-current (historical) log must NOT trigger resolvability — shape-only
+    (squash/rebase legitimately invalidates old SHAs)."""
+    branch = "feat/f8-resolve-test"
+    current_log = "feat-f8-resolve-test.md"
+    fake_sha = "deadbeefcafe"  # well-formed hex, does not resolve to a real commit
+    with tempfile.TemporaryDirectory() as td:
+        target = _deploy_with_git_branch(Path(td), branch)
+        gate_lines = "- Gate: bootstrap | Verdict: PASS | Classification: quick-win | Timestamp: 2026-07-11T00:00:00Z"
+        for name in (current_log, "historical-other-branch.md"):
+            _write_receipt_schema_worklog(
+                target, name,
+                header_classification="quick-win", gate_lines=gate_lines,
+                checkpoint_sha=fake_sha,
+            )
+        out = _run_validate(target)
+        assert out.count(f"unresolvable Checkpoint SHA ('{fake_sha}')") == 1, (
+            f"exactly one (the current-branch) log must get the resolvability WARN:\n{out[-1500:]}"
+        )
+        assert f"unresolvable Checkpoint SHA ('{fake_sha}') in {current_log}" in out, (
+            f"the resolvability WARN must name the current-branch log:\n{out[-1500:]}"
+        )
+        assert f"unresolvable Checkpoint SHA ('{fake_sha}') in historical-other-branch.md" not in out, (
+            f"the non-current-branch log must NOT get the resolvability WARN (shape-only):\n{out[-1500:]}"
+        )
+
+
+@pytest.mark.slow
+@requires_bash
+def test_f8_diff_base_sha_invalid_value_warns_sh() -> None:
+    """F8: Diff Base SHA gets the same value treatment as Checkpoint SHA even
+    though (verified before implementing) it has no pre-existing presence
+    check in either validator."""
+    with tempfile.TemporaryDirectory() as td:
+        target = _deploy_for_validator_fixture(Path(td))
+        gate_lines = "- Gate: bootstrap | Verdict: PASS | Classification: quick-win | Timestamp: 2026-07-11T00:00:00Z"
+        _write_receipt_schema_worklog(
+            target, "f8-bad-diffbase.md",
+            header_classification="quick-win", gate_lines=gate_lines,
+            checkpoint_sha="none",
+            extra_header="- Diff Base SHA: `also-not-a-sha`\n",
+        )
+        out = _run_validate(target)
+        assert DIFF_BASE_SHA_WARN_MSG in out, out[-1200:]
+
+
+def test_f8_source_parity_accepted_vocabulary_and_resolvability() -> None:
+    """Structural (fast, no subprocess): both validators must accept the same
+    placeholder vocabulary and both must resolvability-check via `git
+    rev-parse --verify ...^{commit}`, gated on the current-branch flag."""
+    sh = VALIDATE_SH.read_text(encoding="utf-8")
+    ps1 = VALIDATE_PS1.read_text(encoding="utf-8")
+    for token in ("pending-commit", "<git-sha or none>", "rev-parse --verify"):
+        assert token in sh, f"validate.sh missing F8 token: {token!r}"
+        assert token in ps1, f"validate.ps1 missing F8 token: {token!r}"
+    assert "Diff Base SHA" in sh and "Diff Base SHA" in ps1, (
+        "both validators must extend value-validation to Diff Base SHA (F8)"
+    )
+
+
+def test_f7_f9_source_parity_messages() -> None:
+    """Structural (fast, no subprocess): both validators must emit the same
+    F7/F9 violation message substrings."""
+    sh = VALIDATE_SH.read_text(encoding="utf-8")
+    ps1 = VALIDATE_PS1.read_text(encoding="utf-8")
+    for token in ("missing/unparseable Timestamp", "differs from header Classification"):
+        assert token in sh, f"validate.sh missing token: {token!r}"
+        assert token in ps1, f"validate.ps1 missing token: {token!r}"


### PR DESCRIPTION
## Summary

WP3 of the 2026-07-11 receipt-integrity remediation wave (`docs/reviews/2026-07-11-govern-audit-receipt-integrity.md`, PR #338). Hardens both validators against 4 findings — every finding was independently re-verified against the actual code before implementing.

- **F10 (P1)** — bash's current-branch Work Log detection only replaced `/` with `-` and compared case-sensitively, so an uppercase or punctuated branch (`Feat/X`, `release/v1.2:rc`) never matched its canonical lowercase Work Log filename and was misdetected as *historical* — silently downgrading a current-branch Resume/Test-Gate FAIL to a WARN. Both validators now implement the full 5-step canonical algorithm (`bootstrap.md:123-131`): replace non-`[a-zA-Z0-9._-]` chars → collapse dash runs → trim leading/trailing `-`/`.` → lowercase → truncate to 100 chars. The filename comparison is now also explicitly case-insensitive on both sides (defense against non-conforming filenames).
- **F8 (P2)** — `Checkpoint SHA` was presence-only (`not-a-sha` passed silently); `Diff Base SHA` had no validator coverage at all. Both fields now get value-shape validation (hex `[0-9a-fA-F]{7,40}` or an observed legitimate placeholder — see Adopter Delta) plus a `git rev-parse --verify` resolvability check, scoped to the **current-branch log only** (historical/archived logs are shape-checked only, since squash/rebase legitimately invalidates old SHAs).
- **F7 (P3)** — gate receipts could omit or forge `Timestamp` with no signal (only `Verdict`/`Classification` were checked). Receipts must now carry a `Timestamp:` with at least an ISO date. Per the adjudicated fix, **no monotonic/chronological check** is performed — receipt order-of-appearance stays authoritative for phase progression (now stated explicitly in `templates/worklog.md`).
- **F9 (P3)** — a receipt's `Classification:` was never compared against the Work Log header's `Classification:` (a `feature` header could accept 7 receipts all claiming `tiny-fix`). Receipts now must agree with the header (case-insensitive) or WARN, naming the log file and the offending receipt line. Comparison is skipped when the header itself doesn't parse as a real tier (nothing meaningful to compare against — see Adopter Delta).

All four are WARN-tier (never FAIL) per the adjudicated fixes, and reuse the two existing native `record_result`/`Add-Result` call sites (`Checkpoint SHA` and the gate-receipt-schema check) rather than adding new ones — **the ADR-006 native-check ratchet baseline (`validate_sh: 197`, `validate_ps1: 198`) is unchanged**, verified by `tests/ci/test_validator_native_check_ratchet.py` passing unmodified.

## Adopter delta (what changes for a governance user)

- **Before**: an uppercase/punctuated feature branch could silently skip the current-branch Resume/Test-Gate-Results FAIL escalation on Linux/macOS/Git Bash (PowerShell was accidentally safe on case, but not on punctuation). A Work Log could carry `Checkpoint SHA: not-a-sha` or omit `Diff Base SHA` entirely with zero signal from either validator. Gate receipts could omit `Timestamp` or claim any `Classification` regardless of the header, with no WARN.
- **After**: all four are now visible. A downstream adopter running `validate.sh`/`validate.ps1` today gets identical WARN text on both platforms for each condition; nothing that was previously green (`PASS`) turns red — verified against this repo's own real active Work Logs (see Evidence).
- **What stays unchanged**: nothing here escalates a WARN to FAIL, and no existing legitimate Work Log gains a new WARN — two of this repo's own real active Work Logs still carry the literal *unfilled* template placeholder (`` `<git-sha or none>` ``) for both SHA fields and an unfilled header `Classification`; both are explicitly accepted (accommodated, not silently ignored — see `## Known Risk` in the Work Log for the pre-existing, unrelated gap this incidentally surfaced).

## Placeholder vocabulary adopted for F8

Grepped from this repo's real `context/work/*.md` (2 files) and `context/archive/*.md` (112 tracked files) before implementing, plus `templates/worklog.md`:

- Hex object id: `[0-9a-fA-F]{7,40}` (optionally followed by trailing note text — one real archived log had `f3ac21c (implementation commit)`; the first whitespace token is used)
- `none` (case-insensitive)
- `pending-commit` (case-insensitive; seen in real archived logs)
- `<git-sha or none>` (case-insensitive; the literal *unfilled* template default — two real active Work Logs still carry it verbatim for both `Diff Base SHA` and `Checkpoint SHA`)

## Diff Base — contract-field question

Confirmed before implementing: the field is **always** `Diff Base SHA` in `templates/worklog.md` and in all real usage (29 of 112 archived logs); a bare standalone `Diff Base` field does not exist anywhere. Neither validator had *any* prior check (presence or value) for `Diff Base SHA` — this PR is net-new coverage for it (value-shape + resolvability only; no new presence-required gate was invented, since none existed before).

## Evidence

- New/changed tests: `tests/ci/test_validator_false_positives.py` — 19 new tests (behavioral fixtures for all 4 findings + structural sh/ps1 source-parity pins). `python -m pytest tests/ci/test_validator_false_positives.py -k "f10 or f7 or f8 or f9"` → **19 passed** in 344s.
- Full CI-equivalent: `python -m pytest tests/ci tests/guard .agentcortex/tests -m "not slow"` → **593 passed**, 0 failed, in 111s.
- Both validators run standalone on this repo: `pass=112 warn=4 fail=1 skip=2` on **both** sh and ps1, byte-identical before and after this change (the pre-existing `fail=1` is two real active Work Logs with an unrelated, pre-existing unfilled-header-Classification bug that causes an "illegal gate progression" — untouched by this PR, noted in the Work Log `## Known Risk`).
- Before/after comparison method: the repo's 2 real active Work Logs were temporarily copied (read-only, gitignored) into the PR's worktree, validated, then removed — the main checkout was never edited.

## Rollback

Revert this PR. Both validators, the test file, and the one template sentence are self-contained — no schema migration, no downstream state changes. The ADR-006 native-check ratchet baseline file (`tests/ci/validator_native_baseline.json`) was **not** touched (zero new call sites), so no counter-revert is needed there either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
