### PR TITLE
fix: validate.sh SIGPIPE (141) abort on Work Logs larger than the 64 KB pipe buffer (#336)

### DIFF
--- a/.agentcortex/bin/validate.sh
+++ b/.agentcortex/bin/validate.sh
@@ -1194,8 +1194,8 @@ if [[ -d "$WORKLOG_DIR" ]]; then
     # Accept list form ("- Branch:" or "- **Branch**:") AND table form
     # ("| Branch | ... |") — the canonical template at .agentcortex/templates/worklog.md
     # uses a table for readability; earlier versions only matched list form.
-    if ! printf '%s' "$wl_content" | grep -Eq '(^- (\*\*Branch\*\*|Branch):|^\| (\*\*Branch\*\*|Branch) +\|)' || \
-       ! printf '%s' "$wl_content" | grep -q '^## '; then
+    if ! <<< "$wl_content" grep -Eq '(^- (\*\*Branch\*\*|Branch):|^\| (\*\*Branch\*\*|Branch) +\|)' || \
+       ! <<< "$wl_content" grep -q '^## '; then
       printf '  possibly truncated work log: %s\n' "$(basename "$wl")"
       worklog_truncated=$((worklog_truncated + 1))
     fi
@@ -1294,17 +1294,17 @@ if [[ -d "$WORKLOG_DIR" ]]; then
     # list or table form; a bold-only parser left this empty for every real log,
     # silently disabling the legacy exemption (and its D5 refinement). Extract the
     # YYYY-MM-DD regardless of surrounding markup.
-    created_date="$(printf '%s' "$wl_content" | sed -n -E 's/^-[[:space:]]*\*{0,2}Created Date\*{0,2}:[[:space:]]*`?([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/p; s/^\|[[:space:]]*\*{0,2}Created Date\*{0,2}[[:space:]]*\|[[:space:]]*`?([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/p' | head -n 1 | tr -d '\r')"
+    created_date="$(<<< "$wl_content" sed -n -E 's/^-[[:space:]]*\*{0,2}Created Date\*{0,2}:[[:space:]]*`?([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/p; s/^\|[[:space:]]*\*{0,2}Created Date\*{0,2}[[:space:]]*\|[[:space:]]*`?([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/p' | head -n 1 | tr -d '\r')"
     legacy_gate_evidence=0
     if [[ -n "$created_date" ]] && [[ "$created_date" < "$WORKLOG_GATE_EVIDENCE_LEGACY_CUTOFF" ]]; then
       legacy_gate_evidence=1
     fi
     # Header field: Current Phase — accept list OR table form (see template/worklog.md)
-    if ! printf '%s' "$wl_content" | grep -qE '(^- (`Current Phase`|Current Phase):|^\| (`Current Phase`|Current Phase) +\|)'; then
+    if ! <<< "$wl_content" grep -qE '(^- (`Current Phase`|Current Phase):|^\| (`Current Phase`|Current Phase) +\|)'; then
       phase_field_missing=$((phase_field_missing + 1))
     fi
     # Header field: Checkpoint SHA — accept list OR table form
-    if ! printf '%s' "$wl_content" | grep -qE '(^- (`Checkpoint SHA`|Checkpoint SHA):|^\| (`Checkpoint SHA`|Checkpoint SHA) +\|)'; then
+    if ! <<< "$wl_content" grep -qE '(^- (`Checkpoint SHA`|Checkpoint SHA):|^\| (`Checkpoint SHA`|Checkpoint SHA) +\|)'; then
       checkpoint_missing=$((checkpoint_missing + 1))
     else
       # F8: value-shape + (current-branch-only) resolvability validation.
@@ -1316,7 +1316,7 @@ if [[ -d "$WORKLOG_DIR" ]]; then
     _acx_check_sha_field "$wl_content" "Diff Base SHA" "$is_current_branch" "$(basename "$wl")"
     # Runtime section: ## Gate Evidence — check existence, receipt format,
     # AND phase progression legality. Illegal progression = FAIL.
-    if ! printf '%s' "$wl_content" | grep -q '^## Gate Evidence'; then
+    if ! <<< "$wl_content" grep -q '^## Gate Evidence'; then
       if [[ "$legacy_gate_evidence" -eq 1 ]] && [[ "$is_current_branch" -eq 0 ]]; then
         legacy_gate_evidence_missing=$((legacy_gate_evidence_missing + 1))
       else
@@ -1326,7 +1326,7 @@ if [[ -d "$WORKLOG_DIR" ]]; then
         # Deny the legacy WARN downgrade and treat as a FAIL-tier miss.
         gate_evidence_missing=$((gate_evidence_missing + 1))
       fi
-    elif ! printf '%s' "$wl_content" | grep -qiE '^(`?- )?gate:.*verdict:'; then
+    elif ! <<< "$wl_content" grep -qiE '^(`?- )?gate:.*verdict:'; then
       if [[ "$legacy_gate_evidence" -eq 1 ]] && [[ "$is_current_branch" -eq 0 ]]; then
         legacy_gate_evidence_missing=$((legacy_gate_evidence_missing + 1))
       else
@@ -1586,9 +1586,9 @@ PYEOF
         # minimum prerequisite gates (plan + implement). Cannot verify legal ordering
         # but can detect obvious bypasses. Increments gate_progression_illegal so FAIL
         # is recorded — a shipped log without plan/implement is always a violation.
-        if printf '%s' "$wl_content" | grep -qiE 'Gate:[[:space:]]*ship[[:space:]]*\|[^|]*Verdict:[[:space:]]*PASS'; then
-          has_plan=$(printf '%s' "$wl_content" | grep -ciE 'Gate:[[:space:]]*plan[[:space:]]*\|[^|]*Verdict:[[:space:]]*PASS') || true
-          has_impl=$(printf '%s' "$wl_content" | grep -ciE 'Gate:[[:space:]]*implement[[:space:]]*\|[^|]*Verdict:[[:space:]]*PASS') || true
+        if <<< "$wl_content" grep -qiE 'Gate:[[:space:]]*ship[[:space:]]*\|[^|]*Verdict:[[:space:]]*PASS'; then
+          has_plan=$(<<< "$wl_content" grep -ciE 'Gate:[[:space:]]*plan[[:space:]]*\|[^|]*Verdict:[[:space:]]*PASS') || true
+          has_impl=$(<<< "$wl_content" grep -ciE 'Gate:[[:space:]]*implement[[:space:]]*\|[^|]*Verdict:[[:space:]]*PASS') || true
           if [[ "$has_plan" -eq 0 ]] || [[ "$has_impl" -eq 0 ]]; then
             printf '  [bash-fallback] shipped without plan/implement gate in %s\n' "$(basename "$wl")"
             gate_progression_illegal=$((gate_progression_illegal + 1))
@@ -1597,7 +1597,7 @@ PYEOF
       fi
     fi
     # Runtime section: ## Phase Summary
-    if ! printf '%s' "$wl_content" | grep -q '^## Phase Summary'; then
+    if ! <<< "$wl_content" grep -q '^## Phase Summary'; then
       phase_summary_missing=$((phase_summary_missing + 1))
     fi
     # Sentinel marker discoverability — Work Log Phase Summary SHOULD contain
@@ -1605,8 +1605,8 @@ PYEOF
     # audit trail (chat output is ephemeral). WARN-only — does not break ship.
     # Accept either the emoji form "⚡ ACX" or the plain "ACX" tag for
     # terminals that strip non-ASCII.
-    if printf '%s' "$wl_content" | grep -q '^## Phase Summary' \
-       && ! printf '%s' "$wl_content" | grep -qE '(⚡[[:space:]]?ACX|[[:space:]]ACX([[:space:]]|$))'; then
+    if <<< "$wl_content" grep -q '^## Phase Summary' \
+       && ! <<< "$wl_content" grep -qE '(⚡[[:space:]]?ACX|[[:space:]]ACX([[:space:]]|$))'; then
       sentinel_marker_missing=$((sentinel_marker_missing + 1))
     fi
     # Test Gate Results — engineering_guardrails.md §12.2 requires evidence be recorded
@@ -1629,24 +1629,24 @@ for l in sys.stdin.read().splitlines():
     if m: print(m.group(1).lower()); break
 PYEOF
 )
-      wl_class="$(printf '%s' "$wl_content" | "$PYTHON_BIN" -c "$_acx_wlclass_py" 2>/dev/null)"
+      wl_class="$(<<< "$wl_content" "$PYTHON_BIN" -c "$_acx_wlclass_py" 2>/dev/null)"
     else
       # Python unavailable: list-form-only fallback.
       # (#336) Capture ALL matches then take the first line in bash. Piping sed
       # into `head -n 1` closes the pipe after one line, so sed/printf take
       # SIGPIPE (141) on a >64 KB log and pipefail aborts the run before the
       # Summary prints. sed here reads to EOF, so nothing closes the pipe early.
-      _wl_class_all="$(printf '%s' "$wl_content" | sed -n 's/^- \(**\)\?Classification\1\?:[[:space:]]*//p' | tr -d '\r\`')"
+      _wl_class_all="$(<<< "$wl_content" sed -n 's/^- \(**\)\?Classification\1\?:[[:space:]]*//p' | tr -d '\r\`')"
       wl_class="${_wl_class_all%%$'\n'*}"
     fi
     if [[ "$wl_class" == "feature" || "$wl_class" == "architecture-change" ]]; then
-      if printf '%s' "$wl_content" | grep -qi 'Gate: implement'; then
-        if ! printf '%s' "$wl_content" | grep -qiE '^#+[[:space:]]+Test Gate Results'; then
+      if <<< "$wl_content" grep -qi 'Gate: implement'; then
+        if ! <<< "$wl_content" grep -qiE '^#+[[:space:]]+Test Gate Results'; then
           # AC-6: current-branch at handoff/ship → FAIL; otherwise WARN.
           # Use gate-receipt presence only here (wl_phase_for_resume is set later in this iteration).
           wl_at_handoff_ship=0
           if [[ "$is_current_branch" -eq 1 ]]; then
-            if printf '%s' "$wl_content" | grep -qiE 'Gate:[[:space:]]*(handoff|ship)[[:space:]]*\|[^|]*Verdict:[[:space:]]*PASS'; then
+            if <<< "$wl_content" grep -qiE 'Gate:[[:space:]]*(handoff|ship)[[:space:]]*\|[^|]*Verdict:[[:space:]]*PASS'; then
               wl_at_handoff_ship=1
             fi
           fi
@@ -1664,8 +1664,8 @@ PYEOF
     # Direct approach: flag if review PASS co-exists with any UNPROVEN row not tagged [NEEDS_HUMAN].
     # (The prior ! grep -qvE condition was always false because header/gate lines don't match
     # the UNPROVEN pattern, causing grep -qvE to succeed and the check to be permanently skipped.)
-    if printf '%s' "$wl_content" | grep -qiE 'Gate:[[:space:]]*review[[:space:]]*\|.*Verdict:[[:space:]]*PASS'; then
-      unproven_untagged="$(printf '%s' "$wl_content" | grep '✗ UNPROVEN' | grep -v '\[NEEDS_HUMAN\]' | head -1)" || true
+    if <<< "$wl_content" grep -qiE 'Gate:[[:space:]]*review[[:space:]]*\|.*Verdict:[[:space:]]*PASS'; then
+      unproven_untagged="$(<<< "$wl_content" grep '✗ UNPROVEN' | grep -v '\[NEEDS_HUMAN\]' | head -1)" || true
       if [[ -n "$unproven_untagged" ]]; then
         review_pass_with_unproven=$((review_pass_with_unproven + 1))
       fi
@@ -1673,8 +1673,8 @@ PYEOF
     # MEDIUM-3 (M5): evidence non-empty check for shipped feature/arch-change/quick-win logs.
     # The bootstrap placeholder "Pending: bootstrap only" is not real evidence.
     if [[ "$wl_class" == "feature" || "$wl_class" == "architecture-change" || "$wl_class" == "quick-win" ]]; then
-      if printf '%s' "$wl_content" | grep -qiE 'Gate:[[:space:]]*ship[[:space:]]*\|.*Verdict:[[:space:]]*PASS'; then
-        evidence_body="$(printf '%s' "$wl_content" | sed -n '/^## Evidence/,/^## /p' | tail -n +2 | grep -v '^## ' | grep -v '^$' | head -5)" || true
+      if <<< "$wl_content" grep -qiE 'Gate:[[:space:]]*ship[[:space:]]*\|.*Verdict:[[:space:]]*PASS'; then
+        evidence_body="$(<<< "$wl_content" sed -n '/^## Evidence/,/^## /p' | tail -n +2 | grep -v '^## ' | grep -v '^$' | head -5)" || true
         if [[ -z "$evidence_body" || "$evidence_body" == *"Pending: bootstrap only"* ]]; then
           evidence_placeholder_only=$((evidence_placeholder_only + 1))
         fi
@@ -1682,8 +1682,8 @@ PYEOF
     fi
     # Current Phase consistency (HIGH-2): if a ship PASS receipt exists,
     # Current Phase should be 'ship'. Divergence means the header was not updated.
-    if printf '%s' "$wl_content" | grep -qiE 'Gate:[[:space:]]*ship[[:space:]]*\|.*Verdict:[[:space:]]*PASS'; then
-      cp_val="$(printf '%s' "$wl_content" | grep -m1 -iE '^-[[:space:]]*\*?\*?Current Phase\*?\*?:' \
+    if <<< "$wl_content" grep -qiE 'Gate:[[:space:]]*ship[[:space:]]*\|.*Verdict:[[:space:]]*PASS'; then
+      cp_val="$(<<< "$wl_content" grep -m1 -iE '^-[[:space:]]*\*?\*?Current Phase\*?\*?:' \
         | sed 's/.*Current Phase[^:]*:[[:space:]]*//' | tr -d '`\r' | tr '[:upper:]' '[:lower:]' | xargs)" || true
       if [[ -n "$cp_val" && "$cp_val" != "ship" ]]; then
         current_phase_incoherent=$((current_phase_incoherent + 1))
@@ -1697,9 +1697,9 @@ PYEOF
     # Finding 9 (HIGH): Reclassification state inconsistency — Drift Log records
     # "Reclassification:" but Classification header was never reset to CLASSIFIED,
     # leaving downstream agents with a stale classification tier.
-    if printf '%s' "$wl_content" | grep -q '## Drift Log' \
-       && printf '%s' "$wl_content" | grep -qiE '^[[:space:]]*-[[:space:]]+Reclassif'; then
-      cls_hdr="$(printf '%s' "$wl_content" | grep -m1 -iE '^-[[:space:]]*\*?\*?Classification\*?\*?:' \
+    if <<< "$wl_content" grep -q '## Drift Log' \
+       && <<< "$wl_content" grep -qiE '^[[:space:]]*-[[:space:]]+Reclassif'; then
+      cls_hdr="$(<<< "$wl_content" grep -m1 -iE '^-[[:space:]]*\*?\*?Classification\*?\*?:' \
         | sed 's/.*Classification[^:]*:[[:space:]]*//' | tr -d '`\r' | tr '[:upper:]' '[:lower:]' | xargs)" || true
       if [[ -n "$cls_hdr" && "$cls_hdr" != "classified" ]]; then
         reclassify_header_not_reset=$((reclassify_header_not_reset + 1))
@@ -1711,17 +1711,17 @@ PYEOF
     # is valid and quick-win/hotfix paths are exempt from /handoff.
     # AC-6: current-branch + resume_required + (absent ## Resume OR missing subsections) → FAIL.
     #        historical or present-with-incomplete → WARN.
-    wl_phase_for_resume="$(printf '%s' "$wl_content" | grep -m1 -iE '^-[[:space:]]*\*?\*?Current Phase\*?\*?:' \
+    wl_phase_for_resume="$(<<< "$wl_content" grep -m1 -iE '^-[[:space:]]*\*?\*?Current Phase\*?\*?:' \
       | sed 's/.*Current Phase[^:]*:[[:space:]]*//' | tr -d '`\r' | tr '[:upper:]' '[:lower:]' | xargs)" || true
     resume_required=0
     if [[ "$wl_class" == "feature" || "$wl_class" == "architecture-change" ]]; then
       if [[ "$wl_phase_for_resume" == "handoff" || "$wl_phase_for_resume" == "ship" ]] \
-         || printf '%s' "$wl_content" | grep -qiE 'Gate:[[:space:]]*(handoff|ship)[[:space:]]*\|[^|]*Verdict:[[:space:]]*PASS'; then
+         || <<< "$wl_content" grep -qiE 'Gate:[[:space:]]*(handoff|ship)[[:space:]]*\|[^|]*Verdict:[[:space:]]*PASS'; then
         resume_required=1
       fi
     fi
     if [[ "$resume_required" -eq 1 ]]; then
-      if ! printf '%s' "$wl_content" | grep -q '^## Resume'; then
+      if ! <<< "$wl_content" grep -q '^## Resume'; then
         # AC-6: absent ## Resume section when required
         if [[ "$is_current_branch" -eq 1 ]]; then
           current_branch_gate_fail=$((current_branch_gate_fail + 1))
@@ -1730,7 +1730,7 @@ PYEOF
           handoff_resume_incomplete=$((handoff_resume_incomplete + 1))
         fi
       else
-        resume_body="$(printf '%s' "$wl_content" | sed -n '/^## Resume/,/^## /p')"
+        resume_body="$(<<< "$wl_content" sed -n '/^## Resume/,/^## /p')"
         missing_subsections=0
         for subsec in "Read Map" "Skip List" "Context Snapshot"; do
           if ! printf '%s' "$resume_body" | grep -qiE "^###[[:space:]]+${subsec}"; then
@@ -1751,8 +1751,8 @@ PYEOF
     # /handoff but MUST provide evidence. Warn when a hotfix reaches ship phase
     # but ## Evidence section is missing or contains only the bootstrap placeholder.
     if [[ "$wl_class" == "hotfix" ]]; then
-      if printf '%s' "$wl_content" | grep -qiE 'Gate:[[:space:]]*ship[[:space:]]*\|.*Verdict:[[:space:]]*PASS'; then
-        hotfix_evidence="$(printf '%s' "$wl_content" | sed -n '/^## Evidence/,/^## /p' | tail -n +2 | grep -v '^## ' | grep -v '^$' | head -5)" || true
+      if <<< "$wl_content" grep -qiE 'Gate:[[:space:]]*ship[[:space:]]*\|.*Verdict:[[:space:]]*PASS'; then
+        hotfix_evidence="$(<<< "$wl_content" sed -n '/^## Evidence/,/^## /p' | tail -n +2 | grep -v '^## ' | grep -v '^$' | head -5)" || true
         if [[ -z "$hotfix_evidence" || "$hotfix_evidence" == *"Pending: bootstrap only"* ]]; then
           hotfix_ship_no_evidence=$((hotfix_ship_no_evidence + 1))
         fi
@@ -1762,8 +1762,8 @@ PYEOF
     # bootstrap should have run the ADR Coverage Check and recorded the result (yes/skip)
     # in ## Drift Log. Missing record means the check was silently bypassed.
     if [[ "$wl_class" == "feature" || "$wl_class" == "architecture-change" ]]; then
-      if printf '%s' "$wl_content" | grep -qi 'Gate: plan\|Gate: implement'; then
-        if ! printf '%s' "$wl_content" | grep -qiE 'ADR.*[Cc]overage|[Cc]overage.*ADR|adr.*check|no.*adr.*found'; then
+      if <<< "$wl_content" grep -qi 'Gate: plan\|Gate: implement'; then
+        if ! <<< "$wl_content" grep -qiE 'ADR.*[Cc]overage|[Cc]overage.*ADR|adr.*check|no.*adr.*found'; then
           adr_coverage_undocumented=$((adr_coverage_undocumented + 1))
         fi
       fi
@@ -2111,11 +2111,11 @@ if [[ -d "$ARCHIVE_DIR" ]]; then
   while IFS= read -r -d '' wl; do
     wl_content="$(cat "$wl" 2>/dev/null)"
     [[ -z "$wl_content" ]] && continue
-    arc_class="$(printf '%s' "$wl_content" | grep -m1 -E '^- \*?\*?[Cc]lassification\*?\*?:' | sed -E 's/.*[Cc]lassification[^:]*:[[:space:]]*`?//; s/`.*//; s/[[:space:]]*$//' | tr '[:upper:]' '[:lower:]')" || true
+    arc_class="$(<<< "$wl_content" grep -m1 -E '^- \*?\*?[Cc]lassification\*?\*?:' | sed -E 's/.*[Cc]lassification[^:]*:[[:space:]]*`?//; s/`.*//; s/[[:space:]]*$//' | tr '[:upper:]' '[:lower:]')" || true
     [[ "$arc_class" == "tiny-fix" ]] && continue
-    if printf '%s' "$wl_content" | grep -qiE 'Gate:[[:space:]]*ship[[:space:]]*\|[^|]*Verdict:[[:space:]]*PASS'; then
-      arc_has_plan=$(printf '%s' "$wl_content" | grep -ciE 'Gate:[[:space:]]*plan[[:space:]]*\|[^|]*Verdict:[[:space:]]*PASS') || true
-      arc_has_impl=$(printf '%s' "$wl_content" | grep -ciE 'Gate:[[:space:]]*implement[[:space:]]*\|[^|]*Verdict:[[:space:]]*PASS') || true
+    if <<< "$wl_content" grep -qiE 'Gate:[[:space:]]*ship[[:space:]]*\|[^|]*Verdict:[[:space:]]*PASS'; then
+      arc_has_plan=$(<<< "$wl_content" grep -ciE 'Gate:[[:space:]]*plan[[:space:]]*\|[^|]*Verdict:[[:space:]]*PASS') || true
+      arc_has_impl=$(<<< "$wl_content" grep -ciE 'Gate:[[:space:]]*implement[[:space:]]*\|[^|]*Verdict:[[:space:]]*PASS') || true
       if [[ "$arc_has_plan" -eq 0 ]] || [[ "$arc_has_impl" -eq 0 ]]; then
         archive_gate_violations=$((archive_gate_violations + 1))
         archive_gate_violation_list="${archive_gate_violation_list}  archived gate bypass: ${wl#$ROOT/}\n"

--- a/.agentcortex/bin/validate.sh
+++ b/.agentcortex/bin/validate.sh
@@ -1616,9 +1616,14 @@ PYEOF
     # Parse classification from list form ("- Classification:") or table form ("| Classification |")
     if [[ -n "$PYTHON_BIN" ]]; then
       # Python via single-quoted heredoc -> variable (verbatim; no bash metachar parsing)
+      # (#336) sys.stdin.read() drains the pipe fully BEFORE the early `break`.
+      # Iterating `sys.stdin` line-by-line and breaking on the first match leaves
+      # printf with unwritten bytes on a >64 KB Work Log; printf then takes
+      # SIGPIPE (141), pipefail promotes it, and errexit aborts validate.sh
+      # mid-run with no Summary line. Draining first makes the break byte-safe.
       _acx_wlclass_py=$(cat <<'PYEOF'
 import re,sys
-for l in sys.stdin:
+for l in sys.stdin.read().splitlines():
     m=re.match(r'^-\s+\*{0,2}[Cc]lassification\*{0,2}\s*:\s*\x60?([a-zA-Z][\w-]*)',l)
     if not m: m=re.match(r'^\|\s*\*{0,2}[Cc]lassification\*{0,2}\s*\|\s*\x60?([a-zA-Z][\w-]*)',l)
     if m: print(m.group(1).lower()); break
@@ -1626,8 +1631,13 @@ PYEOF
 )
       wl_class="$(printf '%s' "$wl_content" | "$PYTHON_BIN" -c "$_acx_wlclass_py" 2>/dev/null)"
     else
-      # Python unavailable: list-form-only fallback
-      wl_class="$(printf '%s' "$wl_content" | sed -n 's/^- \(**\)\?Classification\1\?:[[:space:]]*//p' | head -n 1 | tr -d '\r\`')"
+      # Python unavailable: list-form-only fallback.
+      # (#336) Capture ALL matches then take the first line in bash. Piping sed
+      # into `head -n 1` closes the pipe after one line, so sed/printf take
+      # SIGPIPE (141) on a >64 KB log and pipefail aborts the run before the
+      # Summary prints. sed here reads to EOF, so nothing closes the pipe early.
+      _wl_class_all="$(printf '%s' "$wl_content" | sed -n 's/^- \(**\)\?Classification\1\?:[[:space:]]*//p' | tr -d '\r\`')"
+      wl_class="${_wl_class_all%%$'\n'*}"
     fi
     if [[ "$wl_class" == "feature" || "$wl_class" == "architecture-change" ]]; then
       if printf '%s' "$wl_content" | grep -qi 'Gate: implement'; then

--- a/tests/ci/test_validator_largelog_sigpipe.py
+++ b/tests/ci/test_validator_largelog_sigpipe.py
@@ -1,30 +1,37 @@
-"""Regression test for #336 — validate.sh SIGPIPE (exit 141) on large Work Logs.
+"""Regression test for #336 — validate.sh wrong verdicts / SIGPIPE on large Work Logs.
 
-`validate.sh` runs with `set -euo pipefail`. Its Work Log classification parse
-fed `$wl_content` through a pipe into a reader that exits on the first match:
+`validate.sh` runs with `set -euo pipefail` and fed `$wl_content` through pipes
+into readers that exit on the first match: the classification parse
+(`printf … | python … <break>`), plus ~27 sibling `printf '%s' "$wl_content" |
+grep -q` / `grep -m1` audit checks. When `$wl_content` exceeds the OS pipe buffer
+(64 KB on Linux/MSYS), `printf` still has bytes to write after the reader exits,
+takes SIGPIPE, and the pipeline returns 141.
 
-    wl_class="$(printf '%s' "$wl_content" | "$PYTHON_BIN" -c "$_acx_wlclass_py")"
+Two failure modes result:
+- The classification parse is a bare `$(…)` assignment, so `errexit` promoted the
+  141 and ABORTED the whole run mid-loop — no `Summary:` line (the reported #336).
+- The sibling readers live inside `if`/`if !` conditions, so `errexit` is
+  suppressed, but `pipefail` still returns 141 instead of grep's real 0 — which
+  INVERTS the check. A valid >64 KB Work Log then produced fabricated FAILs
+  (missing Current Phase / Gate Evidence / Phase Summary) AND hid real violations
+  (shipped-not-archived reported as "none found"). Silent wrong verdicts are the
+  worse failure mode.
 
-The embedded Python iterated `sys.stdin` line-by-line and `break`ed on the first
-`Classification:` hit. When `$wl_content` exceeds the OS pipe buffer (64 KB on
-Linux/MSYS), `printf` still has bytes to write after the reader is gone, takes
-SIGPIPE, and exits 141. `pipefail` promotes 141 to the pipeline status and
-`errexit` aborts the whole run — mid-loop, BEFORE the `Summary:` line prints. A
-truncated run with earlier `[FAIL]` lines and no summary reads as "finished, no
-failures", so a governance gate silently goes quiet. The Python-unavailable
-fallback had the same shape via `... | head -n 1`.
+Fix (#336): feed every `$wl_content` reader from a leading here-string
+(`<<< "$wl_content" reader …`) instead of `printf '%s' "$wl_content" | reader`.
+A here-string reads from a temp file — there is no writer process to SIGPIPE, so
+an early-exiting reader can neither abort nor invert. This mirrors the file's own
+`<<< "$wl_content"` / "NOT `printf | awk`" precedents. The classification parse
+also drains stdin before its break as belt-and-suspenders.
 
-Fix (#336): drain stdin fully before the early break (`sys.stdin.read()`), and in
-the fallback capture all matches then take the first line in bash instead of
-piping to `head -n 1`. Both make the writer complete before any early exit.
-
-validate.ps1 parses classification with `[regex]::Match($content, ...)` over the
-full in-memory string — no pipe, no SIGPIPE — so it was never affected and needs
-no change (parity: both validators still classify correctly).
+validate.ps1 parses over an in-memory string (`[regex]::Match`), no pipe, so it
+was never affected and needs no change (parity preserved).
 """
 
 from __future__ import annotations
 
+import os
+import re
 import shutil
 import subprocess
 import sys
@@ -54,34 +61,37 @@ requires_bash = pytest.mark.skipif(bash is None, reason="bash not available")
 
 
 # ---------------------------------------------------------------------------
-# Structural — deterministic, no subprocess. Locks the SIGPIPE-safe form so a
-# revert to the racy pipe pattern fails CI on every platform.
+# Structural — deterministic, no subprocess. Lock the SIGPIPE-safe form so a
+# revert to a `printf | reader` pipe over $wl_content fails CI on every platform.
 # ---------------------------------------------------------------------------
 
+def test_336_no_printf_pipe_over_wl_content() -> None:
+    """No `$wl_content` reader may use `printf '%s' "$wl_content" | …` — that pipe
+    SIGPIPEs an early-exiting reader on a >64 KB log. All must feed from a leading
+    here-string (`<<< "$wl_content" …`)."""
+    sh = VALIDATE_SH.read_text(encoding="utf-8")
+    offenders = [
+        i + 1 for i, line in enumerate(sh.splitlines())
+        if 'printf \'%s\' "$wl_content" |' in line
+    ]
+    assert not offenders, (
+        f"validate.sh still pipes $wl_content into a reader (SIGPIPE hazard on >64 KB "
+        f"logs) at lines {offenders} — convert to `<<< \"$wl_content\" reader` (#336)"
+    )
+    # The safe idiom must actually be in use.
+    assert '<<< "$wl_content"' in sh, "validate.sh must feed $wl_content readers via here-strings (#336)"
+
+
 def test_336_wlclass_python_drains_stdin_before_break() -> None:
-    """The Work Log classification helper must drain stdin (read()) before the
-    early break — never iterate a bare `sys.stdin` and break (SIGPIPE hazard)."""
+    """The classification helper must drain stdin (read()) before the early break —
+    never iterate a bare `sys.stdin` and break (belt-and-suspenders for #336)."""
     sh = VALIDATE_SH.read_text(encoding="utf-8")
     assert "sys.stdin.read().splitlines()" in sh, (
         "validate.sh wlclass helper must drain stdin fully before break (#336)"
     )
     assert "for l in sys.stdin:" not in sh, (
-        "validate.sh must NOT iterate a bare sys.stdin then break — printf takes "
-        "SIGPIPE (141) on a >64 KB Work Log and pipefail aborts the run (#336)"
+        "validate.sh must NOT iterate a bare sys.stdin then break (#336)"
     )
-
-
-def test_336_wlclass_fallback_does_not_head_close_the_pipe() -> None:
-    """The Python-unavailable fallback must not pipe the classification match into
-    `head -n 1` (early pipe close → SIGPIPE on a large log)."""
-    sh = VALIDATE_SH.read_text(encoding="utf-8")
-    assert "_wl_class_all=" in sh, (
-        "validate.sh fallback must capture all matches then take the first line "
-        "in bash rather than piping to head -n 1 (#336)"
-    )
-    assert (
-        "Classification\\1\\?:[[:space:]]*//p' | head -n 1" not in sh
-    ), "validate.sh fallback must not close the classification pipe early with head -n 1 (#336)"
 
 
 def test_336_marker_present() -> None:
@@ -91,41 +101,42 @@ def test_336_marker_present() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Behavioral (slow) — a >64 KB current-branch Work Log must not abort the run.
-# Pre-fix this aborts with exit 141 mid-loop and prints no Summary. Deterministic
-# green post-fix on Linux (no MSYS fork limits); the non-required Windows pytest
-# job may be noisier due to the separate MSYS fork-exhaustion issue (#336
-# "Secondary issue"), which this fix intentionally does not address.
+# Behavioral (slow). Two guarantees on a >64 KB Work Log:
+#   A) the run does not SIGPIPE-abort (exit 141) and prints its Summary;
+#   B) with the compaction size gate disabled, a large log validates IDENTICALLY
+#      to a byte-for-byte-smaller copy of the same content — no fabricated FAILs,
+#      no hidden violations (the sibling-reader inversion this fix removes).
 # ---------------------------------------------------------------------------
 
-def _write_large_worklog(target: Path, name: str) -> int:
-    """Write a valid quick-win Work Log padded past the 64 KB pipe buffer.
+_GATES = ("bootstrap", "plan", "implement", "ship")
 
-    Classification sits in the header (top of file) so the parser matches early
-    and the maximal remainder is left unwritten — the exact SIGPIPE trigger. All
-    padding is inert HTML comments appended after Evidence, so it neither adds
-    gate receipts nor breaks section parsing. Returns the byte size written."""
-    work_dir = target / ".agentcortex" / "context" / "work"
-    work_dir.mkdir(parents=True, exist_ok=True)
+
+def _worklog_text(pad_lines: int) -> str:
     gate_lines = "\n".join(
         f"- Gate: {g} | Verdict: PASS | Classification: quick-win | Timestamp: 2026-07-13T00:00:00Z"
-        for g in ("bootstrap", "plan", "implement", "ship")
+        for g in _GATES
     )
-    padding = "\n".join(f"<!-- pad line {i:05d} to exceed the 64KB pipe buffer -->" for i in range(2000))
-    body = f"""# Work Log: {name}
+    padding = "\n".join(f"<!-- pad {i:05d} -->" for i in range(pad_lines))
+    return f"""# Work Log: t
 
 ## Header
 
-- Branch: `test/{name}`
+- Branch: `t`
 - Classification: `quick-win`
 - Current Phase: `ship`
 - Checkpoint SHA: `0000000000000000000000000000000000000000`
 
 ---
 
+## Session Info
+
+- Guardrails loaded: §1
+
+---
+
 ## Phase Summary
 
-Large-log SIGPIPE regression fixture. ACX
+Large-log fixture. ACX
 
 ---
 
@@ -137,7 +148,7 @@ Large-log SIGPIPE regression fixture. ACX
 
 ## Drift Log
 
-- ADR Coverage Check: test fixture.
+- ADR Coverage Check: fixture.
 
 ---
 
@@ -149,43 +160,92 @@ none
 
 ## Evidence
 
-- Fixture evidence.
+- real evidence line.
 
 {padding}
 """
-    path = work_dir / name
-    path.write_text(body, encoding="utf-8", newline="\n")
-    return path.stat().st_size
+
+
+def _deploy(td: Path) -> Path:
+    target = td / "proj"
+    target.mkdir()
+    res = subprocess.run(
+        [bash, str(DEPLOY_SH), str(target)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", cwd=str(ROOT),
+    )
+    assert res.returncode == 0, f"deploy failed:\n{res.stderr}"
+    return target
+
+
+def _write_worklog(target: Path, pad_lines: int) -> int:
+    wd = target / ".agentcortex" / "context" / "work"
+    wd.mkdir(parents=True, exist_ok=True)
+    p = wd / "w.md"
+    p.write_text(_worklog_text(pad_lines), encoding="utf-8", newline="\n")
+    return p.stat().st_size
+
+
+def _run(target: Path, *, env_extra: dict | None = None) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [bash, str(target / ".agentcortex" / "bin" / "validate.sh")],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        cwd=str(target), env=env,
+    )
+
+
+def _summary(out: str) -> str | None:
+    m = re.search(r"Summary: pass=\d+ warn=\d+ fail=\d+ skip=\d+", out)
+    return m.group(0) if m else None
 
 
 @pytest.mark.slow
 @requires_bash
 def test_336_large_worklog_does_not_sigpipe_abort_sh(tmp_path: Path) -> None:
-    target = tmp_path / "proj"
-    target.mkdir()
-    deployed = subprocess.run(
-        [bash, str(DEPLOY_SH), str(target)],
-        capture_output=True, text=True, encoding="utf-8", errors="replace",
-        cwd=str(ROOT),
-    )
-    assert deployed.returncode == 0, f"deploy failed:\n{deployed.stderr}"
-
-    size = _write_large_worklog(target, "big-quickwin.md")
+    target = _deploy(tmp_path)
+    size = _write_worklog(target, pad_lines=4000)
     assert size > 64 * 1024, f"fixture must exceed the 64 KB pipe buffer, got {size} bytes"
-
-    proc = subprocess.run(
-        [bash, str(target / ".agentcortex" / "bin" / "validate.sh")],
-        capture_output=True, text=True, encoding="utf-8", errors="replace",
-        cwd=str(target),
-    )
+    proc = _run(target)
     out = proc.stdout + proc.stderr
-    # 141 = 128 + SIGPIPE(13): the exact abort signature this fix removes.
-    assert proc.returncode != 141, (
-        f"validate.sh aborted with SIGPIPE (141) on a {size}-byte Work Log (#336). "
-        f"Tail:\n{out[-800:]}"
+    # 141 = 128 + SIGPIPE(13): the abort signature this fix removes.
+    assert proc.returncode != 141, f"validate.sh SIGPIPE-aborted on a {size}-byte log (#336):\n{out[-800:]}"
+    assert "Summary:" in out, f"no Summary line — run truncated mid-loop (#336):\n{out[-800:]}"
+
+
+@pytest.mark.slow
+@requires_bash
+def test_336_large_worklog_verdict_parity_with_small_sh(tmp_path: Path) -> None:
+    """A >64 KB log must validate IDENTICALLY to a small copy of the same content.
+    The compaction size gate (legitimately) fails an oversized log, so it is raised
+    out of the way here to isolate the SIGPIPE-inversion regression: any remaining
+    difference is a fabricated FAIL or hidden violation from a sibling reader."""
+    no_compaction = {"WORKLOG_MAX_KB": "1000000", "WORKLOG_MAX_LINES": "1000000"}
+
+    target = _deploy(tmp_path)
+    small_size = _write_worklog(target, pad_lines=5)
+    small = _run(target, env_extra=no_compaction)
+    small_summary = _summary(small.stdout + small.stderr)
+
+    big_size = _write_worklog(target, pad_lines=4000)
+    big = _run(target, env_extra=no_compaction)
+    big_out = big.stdout + big.stderr
+    big_summary = _summary(big_out)
+
+    assert small_size < 64 * 1024 < big_size, f"sizes: small={small_size} big={big_size}"
+    assert big_summary is not None, f"large-log run printed no Summary (#336):\n{big_out[-800:]}"
+    assert big_summary == small_summary, (
+        f"large log ({big_size} B) validated DIFFERENTLY from an identical-content small "
+        f"copy ({small_size} B): small=[{small_summary}] big=[{big_summary}] — a sibling "
+        f"$wl_content reader still SIGPIPE-inverts on a >64 KB log (#336).\n{big_out[-1200:]}"
     )
-    # The run must reach its end and print the Summary — a truncated run omits it.
-    assert "Summary:" in out, (
-        f"validate.sh produced no Summary line on a {size}-byte Work Log — the run "
-        f"was truncated mid-loop (#336). Tail:\n{out[-800:]}"
-    )
+    # Explicit: none of the SIGPIPE-inverted false negatives may appear for the large log.
+    for false_verdict in (
+        "missing Current Phase field",
+        "missing gate evidence receipts",
+        "missing Phase Summary section",
+    ):
+        assert false_verdict not in big_out, (
+            f"fabricated verdict {false_verdict!r} on a valid large log (#336):\n{big_out[-800:]}"
+        )

--- a/tests/ci/test_validator_largelog_sigpipe.py
+++ b/tests/ci/test_validator_largelog_sigpipe.py
@@ -1,0 +1,191 @@
+"""Regression test for #336 — validate.sh SIGPIPE (exit 141) on large Work Logs.
+
+`validate.sh` runs with `set -euo pipefail`. Its Work Log classification parse
+fed `$wl_content` through a pipe into a reader that exits on the first match:
+
+    wl_class="$(printf '%s' "$wl_content" | "$PYTHON_BIN" -c "$_acx_wlclass_py")"
+
+The embedded Python iterated `sys.stdin` line-by-line and `break`ed on the first
+`Classification:` hit. When `$wl_content` exceeds the OS pipe buffer (64 KB on
+Linux/MSYS), `printf` still has bytes to write after the reader is gone, takes
+SIGPIPE, and exits 141. `pipefail` promotes 141 to the pipeline status and
+`errexit` aborts the whole run — mid-loop, BEFORE the `Summary:` line prints. A
+truncated run with earlier `[FAIL]` lines and no summary reads as "finished, no
+failures", so a governance gate silently goes quiet. The Python-unavailable
+fallback had the same shape via `... | head -n 1`.
+
+Fix (#336): drain stdin fully before the early break (`sys.stdin.read()`), and in
+the fallback capture all matches then take the first line in bash instead of
+piping to `head -n 1`. Both make the writer complete before any early exit.
+
+validate.ps1 parses classification with `[regex]::Match($content, ...)` over the
+full in-memory string — no pipe, no SIGPIPE — so it was never affected and needs
+no change (parity: both validators still classify correctly).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+VALIDATE_SH = ROOT / ".agentcortex" / "bin" / "validate.sh"
+DEPLOY_SH = ROOT / ".agentcortex" / "bin" / "deploy.sh"
+
+# bash discovery (mirror test_validator_false_positives.py — avoid WindowsApps stub).
+git_path = shutil.which("git")
+git_root = Path(git_path).parent.parent if git_path else None
+bash_candidates = [
+    str(git_root / "bin" / "bash.exe") if git_root else None,
+    str(git_root / "usr" / "bin" / "bash.exe") if git_root else None,
+    r"C:\Program Files\Git\bin\bash.exe",
+    r"C:\Program Files\Git\usr\bin\bash.exe",
+    shutil.which("bash"),
+]
+bash = next(
+    (c for c in bash_candidates if c and "WindowsApps" not in c and Path(c).exists()),
+    None,
+)
+requires_bash = pytest.mark.skipif(bash is None, reason="bash not available")
+
+
+# ---------------------------------------------------------------------------
+# Structural — deterministic, no subprocess. Locks the SIGPIPE-safe form so a
+# revert to the racy pipe pattern fails CI on every platform.
+# ---------------------------------------------------------------------------
+
+def test_336_wlclass_python_drains_stdin_before_break() -> None:
+    """The Work Log classification helper must drain stdin (read()) before the
+    early break — never iterate a bare `sys.stdin` and break (SIGPIPE hazard)."""
+    sh = VALIDATE_SH.read_text(encoding="utf-8")
+    assert "sys.stdin.read().splitlines()" in sh, (
+        "validate.sh wlclass helper must drain stdin fully before break (#336)"
+    )
+    assert "for l in sys.stdin:" not in sh, (
+        "validate.sh must NOT iterate a bare sys.stdin then break — printf takes "
+        "SIGPIPE (141) on a >64 KB Work Log and pipefail aborts the run (#336)"
+    )
+
+
+def test_336_wlclass_fallback_does_not_head_close_the_pipe() -> None:
+    """The Python-unavailable fallback must not pipe the classification match into
+    `head -n 1` (early pipe close → SIGPIPE on a large log)."""
+    sh = VALIDATE_SH.read_text(encoding="utf-8")
+    assert "_wl_class_all=" in sh, (
+        "validate.sh fallback must capture all matches then take the first line "
+        "in bash rather than piping to head -n 1 (#336)"
+    )
+    assert (
+        "Classification\\1\\?:[[:space:]]*//p' | head -n 1" not in sh
+    ), "validate.sh fallback must not close the classification pipe early with head -n 1 (#336)"
+
+
+def test_336_marker_present() -> None:
+    assert "(#336)" in VALIDATE_SH.read_text(encoding="utf-8"), (
+        "validate.sh must carry the (#336) fix marker for traceability"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Behavioral (slow) — a >64 KB current-branch Work Log must not abort the run.
+# Pre-fix this aborts with exit 141 mid-loop and prints no Summary. Deterministic
+# green post-fix on Linux (no MSYS fork limits); the non-required Windows pytest
+# job may be noisier due to the separate MSYS fork-exhaustion issue (#336
+# "Secondary issue"), which this fix intentionally does not address.
+# ---------------------------------------------------------------------------
+
+def _write_large_worklog(target: Path, name: str) -> int:
+    """Write a valid quick-win Work Log padded past the 64 KB pipe buffer.
+
+    Classification sits in the header (top of file) so the parser matches early
+    and the maximal remainder is left unwritten — the exact SIGPIPE trigger. All
+    padding is inert HTML comments appended after Evidence, so it neither adds
+    gate receipts nor breaks section parsing. Returns the byte size written."""
+    work_dir = target / ".agentcortex" / "context" / "work"
+    work_dir.mkdir(parents=True, exist_ok=True)
+    gate_lines = "\n".join(
+        f"- Gate: {g} | Verdict: PASS | Classification: quick-win | Timestamp: 2026-07-13T00:00:00Z"
+        for g in ("bootstrap", "plan", "implement", "ship")
+    )
+    padding = "\n".join(f"<!-- pad line {i:05d} to exceed the 64KB pipe buffer -->" for i in range(2000))
+    body = f"""# Work Log: {name}
+
+## Header
+
+- Branch: `test/{name}`
+- Classification: `quick-win`
+- Current Phase: `ship`
+- Checkpoint SHA: `0000000000000000000000000000000000000000`
+
+---
+
+## Phase Summary
+
+Large-log SIGPIPE regression fixture. ACX
+
+---
+
+## Gate Evidence
+
+{gate_lines}
+
+---
+
+## Drift Log
+
+- ADR Coverage Check: test fixture.
+
+---
+
+## Resume
+
+none
+
+---
+
+## Evidence
+
+- Fixture evidence.
+
+{padding}
+"""
+    path = work_dir / name
+    path.write_text(body, encoding="utf-8", newline="\n")
+    return path.stat().st_size
+
+
+@pytest.mark.slow
+@requires_bash
+def test_336_large_worklog_does_not_sigpipe_abort_sh(tmp_path: Path) -> None:
+    target = tmp_path / "proj"
+    target.mkdir()
+    deployed = subprocess.run(
+        [bash, str(DEPLOY_SH), str(target)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        cwd=str(ROOT),
+    )
+    assert deployed.returncode == 0, f"deploy failed:\n{deployed.stderr}"
+
+    size = _write_large_worklog(target, "big-quickwin.md")
+    assert size > 64 * 1024, f"fixture must exceed the 64 KB pipe buffer, got {size} bytes"
+
+    proc = subprocess.run(
+        [bash, str(target / ".agentcortex" / "bin" / "validate.sh")],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        cwd=str(target),
+    )
+    out = proc.stdout + proc.stderr
+    # 141 = 128 + SIGPIPE(13): the exact abort signature this fix removes.
+    assert proc.returncode != 141, (
+        f"validate.sh aborted with SIGPIPE (141) on a {size}-byte Work Log (#336). "
+        f"Tail:\n{out[-800:]}"
+    )
+    # The run must reach its end and print the Summary — a truncated run omits it.
+    assert "Summary:" in out, (
+        f"validate.sh produced no Summary line on a {size}-byte Work Log — the run "
+        f"was truncated mid-loop (#336). Tail:\n{out[-800:]}"
+    )


### PR DESCRIPTION
## Summary

Fixes #336. Under `set -euo pipefail`, `validate.sh` fed `$wl_content` through **39** `printf '%s' "$wl_content" | reader` pipes in the Work Log audit loop. On a Work Log larger than the 64 KB OS pipe buffer, `printf` still has bytes to write after an early-exiting reader (`grep -q`, `grep -m1`, the classification `python … <break>`) is gone — so `printf` takes SIGPIPE and the pipeline returns **141**. That surfaced two ways:

1. **Whole-run abort (the reported symptom).** The classification parse is a bare `$(…)` assignment, so `errexit` promoted the 141 and killed the script mid-loop — no `Summary:` line.
2. **Silent wrong verdicts (found in review, worse).** The ~27 sibling readers live inside `if`/`if !` conditions, so `errexit` is suppressed — but `pipefail` returns 141 instead of grep's real 0, which **inverts** the check. A valid >64 KB Work Log produced fabricated FAILs (missing Current Phase / Gate Evidence / Phase Summary) **and hid a real violation** (shipped-not-archived reported as "none found"). #336's own note — "a governance gate silently going quiet is worse than one that fails loudly" — is exactly this.

## Fix

Feed every `$wl_content` reader from a **leading here-string** — `printf '%s' "$wl_content" | reader` → `<<< "$wl_content" reader`. A here-string reads from a temp file: there is no writer process to SIGPIPE, so an early-exiting reader can neither abort nor invert, at any log size. This mirrors the file's own existing precedents (`<<< "$wl_content"` at the gate-progression check; the explicit "feed awk via here-string, NOT `printf | awk`" comment). All 39 sites converted uniformly. The classification helper also drains stdin before its break (`sys.stdin.read().splitlines()`) as belt-and-suspenders.

`validate.ps1` parses over an in-memory string (`[regex]::Match`) — no pipe, never affected, no change (parity preserved).

## Review-driven scope

This PR originally patched only the classification parse (the crash). An adversarial re-review reproduced that large logs still yielded **wrong verdicts** through the sibling readers — a verified blocker — so the fix was expanded to the systemic here-string conversion and the test strengthened to prove verdict parity, not just "doesn't crash."

## Adopter delta

Before: any downstream repo whose Work Log crossed 64 KB got either a validator that aborted with no summary, or (for logs that didn't hit the abort path first) a completed run with fabricated FAILs and hidden real violations. After: `validate.sh` validates a large Work Log identically to a small one. Engine/gate semantics unchanged; the legitimate compaction gate (300 lines / 12 KB) still flags oversized logs as before.

## Evidence

- **A/B verdict parity** (compaction gate raised out of the way via `WORKLOG_MAX_KB`/`WORKLOG_MAX_LINES`): a 76 KB log and a byte-smaller copy of identical content now both yield `Summary: pass=99 warn=4 fail=0 skip=4`. Pre-fix the 76 KB copy gave `fail=2` with fabricated FAILs + a hidden violation.
- New/updated `tests/ci/test_validator_largelog_sigpipe.py`: 3 structural (no `printf | $wl_content` idiom remains; drain form; `(#336)` marker) + 2 behavioral (no SIGPIPE-abort/Summary present; **large==small verdict parity** + explicit false-verdict absence). **5 passed.**
- Framework repo `validate.sh`: `Summary: pass=113 warn=4 fail=0 skip=2` — unchanged from baseline (transform is behavior-preserving on normal logs).
- CI-equivalent fast suite (`pytest tests/ci/ tests/guard/ .agentcortex/tests/ -m "not slow"`): **620 passed**.
- Slow validator behavioral suite (AC-6 / reverse-edge / receipt-schema / ADR-010 / large-log): **44 passed**.

Closes #336
