### PR TITLE
feat(validate): advisory WARN when archive directory exceeds size cap (#141)

### DIFF
--- a/.agent/config.yaml
+++ b/.agent/config.yaml
@@ -164,6 +164,14 @@ document_lifecycle:
   # all features from the intake are Shipped or Cancelled.
   raw_intake_cleanup: must_delete
 
+  # Archive directory growth advisory (#141). Count of top-level `*.md` files in
+  # .agentcortex/context/archive/ above which the validators emit a WARN. The
+  # archive accumulates one file per ship/handoff with no rotation; unbounded
+  # growth inflates the read cost of every archive-scanning check. Advisory only
+  # -- WARN, never FAIL. Body rotation/compaction is deferred to the lifecycle
+  # engine (#140); INDEX.jsonl is append-only (witness integrity) and NOT counted.
+  archive_max_files: 50
+
 # Governance Exemption Scope
 # Directories considered production code where Design-First and Error Observability rules apply.
 # All other directories (e.g., tools/, scripts/, scratch/, tests/) are exempt.

--- a/.agentcortex/bin/deploy.sh
+++ b/.agentcortex/bin/deploy.sh
@@ -736,7 +736,7 @@ if $DRY_RUN; then
     _dry_count=0
     # Enumerate only the files that are actually deployed (mirrors real deploy logic).
     # Runtime Python tools are a whitelist — NOT all *.py in tools/.
-    _runtime_tools="guard_context_write.py _yaml_loader.py check_command_sync.py check_text_integrity.py check_text_integrity.ps1 text_integrity_baseline.txt sync_skills.sh lint_governed_writes.py check_lifecycle_frontmatter.py check_lesson_chain.py check_ssot_caps.py check_decision_disposition.py check_adr_coverage.py append_chain_entry.py append_lesson.py recover_worklog_lock.py lint_spec_drift.py run_governance_eval.py scan_credentials.py credential_floor.sh credential_floor.ps1 generate_safety_nucleus.py validate_downstream_capabilities.py"
+    _runtime_tools="guard_context_write.py _yaml_loader.py check_command_sync.py check_text_integrity.py check_text_integrity.ps1 text_integrity_baseline.txt sync_skills.sh lint_governed_writes.py check_lifecycle_frontmatter.py check_lesson_chain.py check_ssot_caps.py check_decision_disposition.py check_archive_growth.py check_adr_coverage.py append_chain_entry.py append_lesson.py recover_worklog_lock.py lint_spec_drift.py run_governance_eval.py scan_credentials.py credential_floor.sh credential_floor.ps1 generate_safety_nucleus.py validate_downstream_capabilities.py"
     _dry_print_file() {
         local src="$1"
         local rel="$2"
@@ -938,6 +938,7 @@ runtime_tools=(
   check_lesson_chain.py
   check_ssot_caps.py
   check_decision_disposition.py
+  check_archive_growth.py
   check_adr_coverage.py
   append_chain_entry.py
   append_lesson.py

--- a/.agentcortex/bin/validate.ps1
+++ b/.agentcortex/bin/validate.ps1
@@ -771,6 +771,11 @@ Invoke-PythonCheck -Label 'ssot section caps (ship history + spec index)' -Missi
 # entries missing a ship-time marker). WARN-tier / never-FAIL (tool ALWAYS exits 0);
 # silent no-op until a fork sets document_lifecycle.decision_disposition_since.
 Invoke-PythonCheck -Label 'decision disposition (archived work logs)' -MissingPythonLevel 'WARN' -ScriptPath (Join-NormalPath $root '.agentcortex/tools/check_decision_disposition.py') -Arguments @('--root', $root)
+# ADR-006: advisory archive-growth check (issue #141). WARN-tier / never-FAIL
+# (tool ALWAYS exits 0); counts top-level *.md bodies in the archive dir vs
+# document_lifecycle.archive_max_files. INDEX.jsonl (append-only witness) excluded;
+# body rotation deferred to the lifecycle engine (#140).
+Invoke-PythonCheck -Label 'archive directory growth' -MissingPythonLevel 'WARN' -ScriptPath (Join-NormalPath $root '.agentcortex/tools/check_archive_growth.py') -Arguments @('--root', $root)
 $phaseSkillFiles = @(
     (Join-NormalPath $workflowsDir 'plan.md'),
     (Join-NormalPath $workflowsDir 'implement.md'),

--- a/.agentcortex/bin/validate.sh
+++ b/.agentcortex/bin/validate.sh
@@ -641,6 +641,13 @@ run_python_check "ssot section caps (ship history + spec index)" WARN "$ROOT/.ag
 # document_lifecycle.decision_disposition_since. No-python -> WARN; tool absent -> SKIP.
 run_python_check "decision disposition (archived work logs)" WARN "$ROOT/.agentcortex/tools/check_decision_disposition.py" --root "$ROOT"
 
+# ADR-006: advisory archive-growth check (issue #141) as a Python tool behind
+# run_python_check. WARN-tier / never-FAIL (tool ALWAYS exits 0); counts top-level
+# *.md bodies in .agentcortex/context/archive/ vs document_lifecycle.archive_max_files.
+# INDEX.jsonl (append-only witness) is excluded; body rotation is deferred to the
+# lifecycle engine (#140). No-python -> WARN; tool absent -> SKIP.
+run_python_check "archive directory growth" WARN "$ROOT/.agentcortex/tools/check_archive_growth.py" --root "$ROOT"
+
 ACTIVE_CODEX_RULES="$ROOT/codex/rules/default.rules"
 [[ -f "$ACTIVE_CODEX_RULES" ]] || ACTIVE_CODEX_RULES="$CODEX_RULES"
 if [[ -f "$ACTIVE_CODEX_RULES" ]]; then

--- a/.agentcortex/tools/check_archive_growth.py
+++ b/.agentcortex/tools/check_archive_growth.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Advisory growth checker for the archive directory (ADR-006, issue #141).
+
+Counts the top-level `*.md` bodies in `.agentcortex/context/archive/` and, when
+the count exceeds its configured cap, prints a WARN-style advisory naming the
+rotation/GC procedure. The archive accumulates one file per ship/handoff with no
+rotation; unbounded growth silently inflates the read cost of every
+archive-scanning check (audit chain, decision-disposition, Phase-Summary audit).
+
+Only top-level `*.md` bodies are counted. `INDEX.jsonl` is the append-only,
+hash-chained audit witness — compacting it would break tamper-evidence — so it
+is deliberately excluded; body rotation/compaction itself is deferred to the
+lifecycle engine (#140). This tool is only the cheap early-signal half.
+
+ADVISORY-ONLY contract (mirrors the run_python_check / Invoke-PythonCheck
+WARN-tier wiring used by check_ssot_caps.py): this tool ALWAYS exits 0 so the
+validator never FAILs on an over-cap count. The finding is surfaced in the
+validator's indented output; a genuine over-cap state is fixed by the documented
+rotation, not by the validator. Capability-by-presence: a missing archive
+directory exits 0 silently.
+
+Exit codes:
+  0  always (advisory — never fails the validator). Findings, if any, are
+     printed to stdout as `WARN: ...` lines.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Default mirrors .agent/config.yaml §document_lifecycle.archive_max_files. Used
+# when the config file or key is absent (downstream / zero-config) so the tool
+# degrades safely.
+DEFAULT_ARCHIVE_MAX_FILES = 50
+
+
+def _read_cap(config_path: Path) -> int:
+    """Read archive_max_files from .agent/config.yaml with a safe default."""
+    cap = DEFAULT_ARCHIVE_MAX_FILES
+    if not config_path.is_file():
+        return cap
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from _yaml_loader import load_data  # type: ignore  # noqa: E402
+
+        data = load_data(config_path)
+        lifecycle = data.get("document_lifecycle") or {}
+        cap = int(lifecycle.get("archive_max_files", cap))
+    except Exception:
+        # Any parse/import failure → keep default (advisory tool, never fail).
+        return DEFAULT_ARCHIVE_MAX_FILES
+    return cap
+
+
+def count_archive_md(archive_dir: Path) -> int:
+    """Count top-level `*.md` files directly under the archive directory.
+
+    Non-recursive by design: subdirectories (e.g. `archive/work/`) are separate
+    surfaces, and this mirrors the count the issue evidence was gathered with.
+    """
+    return sum(
+        1 for p in archive_dir.iterdir() if p.is_file() and p.suffix == ".md"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Advisory growth checker for .agentcortex/context/archive/. Always "
+            "exits 0; prints a WARN line when the top-level *.md count exceeds "
+            "the config cap."
+        )
+    )
+    ap.add_argument("--root", default=".", help="Repo root (default: cwd)")
+    ap.add_argument(
+        "--path",
+        default=None,
+        help="Archive directory to inspect (default: <root>/.agentcortex/context/archive)",
+    )
+    ap.add_argument(
+        "--config",
+        default=None,
+        help="Config file for the cap (default: <root>/.agent/config.yaml)",
+    )
+    return ap.parse_args()
+
+
+def main() -> int:
+    # Force UTF-8 stdout so the em-dash in advisory messages survives a cp950
+    # Windows console (child processes default to the console codepage). Both
+    # validators and the pytest capture read this as UTF-8.
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
+    args = parse_args()
+    root = Path(args.root).resolve()
+    archive_dir = (
+        Path(args.path) if args.path else root / ".agentcortex/context/archive"
+    )
+    config_path = Path(args.config) if args.config else root / ".agent/config.yaml"
+
+    if not archive_dir.is_dir():
+        # Capability-by-presence: no archive to check.
+        return 0
+
+    cap = _read_cap(config_path)
+
+    try:
+        count = count_archive_md(archive_dir)
+    except OSError as exc:
+        print(f"WARN: could not scan {archive_dir}: {exc}")
+        return 0
+
+    if count > cap:
+        print(
+            f"WARN: archive directory has {count} top-level *.md files (cap {cap}); "
+            f"rotate/GC the oldest {count - cap} into a yearly summary index "
+            f"(rotation/GC pending #141; INDEX.jsonl is append-only and excluded)."
+        )
+    else:
+        print(f"archive growth OK — {count}/{cap} top-level *.md files.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/fixtures/deploy_manifest_golden.txt
+++ b/tests/ci/fixtures/deploy_manifest_golden.txt
@@ -81,6 +81,7 @@ core .agentcortex/tools/_yaml_loader.py
 core .agentcortex/tools/append_chain_entry.py
 core .agentcortex/tools/append_lesson.py
 core .agentcortex/tools/check_adr_coverage.py
+core .agentcortex/tools/check_archive_growth.py
 core .agentcortex/tools/check_command_sync.py
 core .agentcortex/tools/check_decision_disposition.py
 core .agentcortex/tools/check_lesson_chain.py

--- a/tests/guard/test_archive_growth_check.py
+++ b/tests/guard/test_archive_growth_check.py
@@ -1,0 +1,131 @@
+"""Guard tests for check_archive_growth.py — the advisory archive-growth checker.
+
+The tool is WARN-tier / never-FAIL (ADR-006 run_python_check contract, issue
+#141): it ALWAYS exits 0 and prints a `WARN: ...` line only when the top-level
+`*.md` count in the archive directory exceeds its cap. These tests drive the
+pure-Python tool directly against synthetic archive dirs — deterministic, fast,
+no bash/PowerShell, no `slow` marker.
+
+Coverage:
+  * over-cap archive        -> WARN with count/cap and remediation pointer
+  * at-cap archive          -> no WARN, OK line
+  * under-cap archive       -> no WARN, OK line
+  * over-cap                -> still exit 0 (never fails the validator)
+  * INDEX.jsonl + subdirs   -> excluded from the count (only top-level *.md)
+  * missing archive dir     -> exit 0, silent (capability-by-presence)
+  * cap read from config    -> custom cap honored; absent config -> default (50)
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / ".agentcortex" / "tools" / "check_archive_growth.py"
+
+STD_CONFIG = "document_lifecycle:\n  archive_max_files: 50\n"
+
+
+def make_archive(dir_path: Path, md_n: int, *, with_index: bool = True, subdir_md: int = 0) -> None:
+    """Populate an archive dir with md_n top-level *.md files (+ optional noise)."""
+    dir_path.mkdir(parents=True, exist_ok=True)
+    for i in range(md_n):
+        (dir_path / f"entry-{i:03d}.md").write_text(f"# entry {i}\n", encoding="utf-8")
+    if with_index:
+        # The append-only witness ledger must NOT be counted.
+        (dir_path / "INDEX.jsonl").write_text('{"n":0}\n', encoding="utf-8")
+    if subdir_md:
+        sub = dir_path / "work"
+        sub.mkdir(exist_ok=True)
+        for i in range(subdir_md):
+            (sub / f"log-{i}.md").write_text("# log\n", encoding="utf-8")
+
+
+def run_tool(tmp_path: Path, archive: Path, config: str | None = STD_CONFIG):
+    args = [sys.executable, str(TOOL), "--path", str(archive)]
+    if config is not None:
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(config, encoding="utf-8")
+        args += ["--config", str(cfg)]
+    else:
+        # Point --config at a non-existent path -> exercises the default-cap
+        # fallback (50) inside the tool.
+        args += ["--config", str(tmp_path / "absent-config.yaml")]
+    return subprocess.run(args, capture_output=True, text=True, encoding="utf-8")
+
+
+def test_over_cap_warns(tmp_path):
+    archive = tmp_path / "archive"
+    make_archive(archive, md_n=52)
+    r = run_tool(tmp_path, archive)
+    assert r.returncode == 0
+    assert "archive directory has 52 top-level *.md files (cap 50)" in r.stdout
+    assert "rotate/GC the oldest 2" in r.stdout
+    assert "#141" in r.stdout
+
+
+def test_at_cap_no_warn(tmp_path):
+    archive = tmp_path / "archive"
+    make_archive(archive, md_n=50)
+    r = run_tool(tmp_path, archive)
+    assert r.returncode == 0
+    assert "WARN:" not in r.stdout
+    assert "archive growth OK — 50/50" in r.stdout
+
+
+def test_under_cap_no_warn(tmp_path):
+    archive = tmp_path / "archive"
+    make_archive(archive, md_n=13)
+    r = run_tool(tmp_path, archive)
+    assert r.returncode == 0
+    assert "WARN:" not in r.stdout
+    assert "archive growth OK — 13/50" in r.stdout
+
+
+def test_over_cap_never_fails(tmp_path):
+    archive = tmp_path / "archive"
+    make_archive(archive, md_n=200)
+    r = run_tool(tmp_path, archive)
+    # Wildly over cap: the advisory tool must still exit 0 (never FAIL).
+    assert r.returncode == 0
+    assert "archive directory has 200 top-level *.md files (cap 50)" in r.stdout
+
+
+def test_index_jsonl_and_subdirs_excluded(tmp_path):
+    # 49 top-level *.md + INDEX.jsonl + 10 *.md under work/ must count as 49
+    # (under cap 50) — only top-level *.md bodies are counted.
+    archive = tmp_path / "archive"
+    make_archive(archive, md_n=49, with_index=True, subdir_md=10)
+    r = run_tool(tmp_path, archive)
+    assert r.returncode == 0
+    assert "WARN:" not in r.stdout
+    assert "archive growth OK — 49/50" in r.stdout
+
+
+def test_missing_archive_dir_exits_zero_silent(tmp_path):
+    args = [sys.executable, str(TOOL), "--path", str(tmp_path / "does-not-exist")]
+    r = subprocess.run(args, capture_output=True, text=True, encoding="utf-8")
+    assert r.returncode == 0
+    assert r.stdout.strip() == ""
+
+
+def test_config_cap_is_honored(tmp_path):
+    # Custom cap of 5 -> 6 md files must warn against cap 5, proving the tool
+    # reads document_lifecycle.archive_max_files from config.
+    archive = tmp_path / "archive"
+    make_archive(archive, md_n=6)
+    custom = "document_lifecycle:\n  archive_max_files: 5\n"
+    r = run_tool(tmp_path, archive, config=custom)
+    assert r.returncode == 0
+    assert "archive directory has 6 top-level *.md files (cap 5)" in r.stdout
+
+
+def test_absent_config_uses_default(tmp_path):
+    # No config file -> default cap 50. 51 md files warns against cap 50.
+    archive = tmp_path / "archive"
+    make_archive(archive, md_n=51)
+    r = run_tool(tmp_path, archive, config=None)
+    assert r.returncode == 0
+    assert "archive directory has 51 top-level *.md files (cap 50)" in r.stdout


### PR DESCRIPTION
## Summary

Adds an advisory validator check that WARNs when the archive directory grows past a configurable cap — the **unblocked "early-signal" increment of #141**. Body rotation/compaction and `INDEX.jsonl` rotation stay deferred to the lifecycle engine (#140), which this does not touch.

**Why now:** the archive has grown from ~13 files (when #141 was filed) to **126 top-level `*.md` files (~1.7 MB)** today — ~2.5× over the proposed 50 cap. It accumulates one file per ship/handoff with no rotation, silently inflating the read cost of every archive-scanning check (audit chain, decision-disposition, Phase-Summary audit). This is a present pain point, not a forecast.

**Adopter delta:** downstream projects now get a validator WARN once their archive crosses `document_lifecycle.archive_max_files` (default 50), pointing at the pending rotation/GC work. Advisory only — never FAILs, never blocks a ship. Zero effect below the cap.

## Design notes

- **ADR-006 compliant.** Implemented as a single Python tool (`check_archive_growth.py`) behind `run_python_check` / `Invoke-PythonCheck` — **no native `record_result`/`Add-Result` sites**, so the native-check ratchet stays flat and there is no bash/PowerShell parity tax. Mirrors `check_ssot_caps.py` exactly (always exits 0; advisory findings surface in indented output).
- **`INDEX.jsonl` is excluded** from the count. It is the append-only, hash-chained audit witness — compacting it would break tamper-evidence. Only top-level `*.md` bodies are counted.
- Ships **core** (added to both `deploy.sh` runtime-tools whitelist spots + registered in the deploy-manifest golden) so downstream `validate.sh` can actually run it — matching its `check_ssot_caps.py` sibling.

## Changes

| File | Change |
|---|---|
| `.agentcortex/tools/check_archive_growth.py` | **new** advisory tool (always exits 0) |
| `.agent/config.yaml` | `document_lifecycle.archive_max_files: 50` |
| `.agentcortex/bin/validate.sh` / `validate.ps1` | wire the check next to the ssot-caps advisory |
| `.agentcortex/bin/deploy.sh` | add tool to both runtime-tools whitelist spots |
| `tests/ci/fixtures/deploy_manifest_golden.txt` | register the new core tool |
| `tests/guard/test_archive_growth_check.py` | **new** — 8 focused unit tests |

## Evidence

- `validate.sh` **and** `validate.ps1`: `pass=100 warn=3 fail=0 skip=2` (byte-identical — parity holds). Archive check surfaces as `[PASS] archive directory growth` with the advisory WARN in indented output.
- Full CI pytest suite (`tests/ci/ tests/guard/ .agentcortex/tests/`): **771 passed, 0 failed**.
- New guard tests: 8 passed · native-check ratchet: 5 passed · deploy-tiering (incl. golden snapshot): 32 passed.

## Scope

Does **not** close #141 — this is only increment 3 (the WARN). The rotation + compaction increments remain open and blocked by #140. See the [triage analysis on #141](https://github.com/KbWen/agentic-os/issues/141#issuecomment-5018215379) for the full split.

Part of #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
