### PR TITLE
docs(rules): record the archival-flips-visibility trap in gotcha #3

### DIFF
--- a/.agent/rules/repo-gotchas.md
+++ b/.agent/rules/repo-gotchas.md
@@ -56,6 +56,19 @@ Clear them by **archiving tracked logs**, not by editing the validator. `/ship` 
 MOVE, not a copy. Before assuming a validator bug, check whether the offending path is
 gitignored.
 
+The inverse bites harder, because it turns CI red rather than green. **Archiving flips a log
+from gitignored to tracked**, so checks that skipped it while it lived in `work/` start
+judging it — `check_decision_disposition.py` is the one that catches people, since it excludes
+`work/` entirely and enforces a date cutoff on the archive. A `## Decisions` entry that never
+received its ship-time disposition marker (`ship.md` 2b: `→ promoted: ADR-<id>` /
+`→ consolidated: L2 <domain>` / `→ local`) passes every local run right up until the moment
+you archive it.
+
+Consequence for ordering: a full-suite run taken **before** archival does not cover the
+archived state. Run it after the move, or at minimum re-run the guard suite. Confirmed
+2026-07-27 — a green 813-test local run preceded the archival, and CI went red on `main`
+immediately after (PR #374 → #375).
+
 ## 4. The 355k lifecycle ceiling does not count `AGENTS.md` or `CLAUDE.md`
 
 A widely-assumed premise that is false. `.agentcortex/tests/test_lifecycle_token_consumption.py`


### PR DESCRIPTION
## Summary

Gotcha #3 covered one direction: gitignored work logs make local `validate` FAILs invisible to CI. **The inverse is what turned `main` red today**, and it was not written down anywhere.

Archiving flips a log from gitignored to **tracked**, so checks that skipped it while it lived in `work/` start judging it. `check_decision_disposition.py` is the one that catches people — it excludes `work/` entirely and enforces a date cutoff on the archive, so a `## Decisions` entry that never received its ship-time disposition marker (`ship.md` 2b) passes every local run right up until the moment you archive it.

The actionable half is the ordering consequence: **a full-suite run taken before archival does not cover the archived state.** A green 813-test local run preceded the archival in [#374](https://github.com/KbWen/agentic-os/pull/374), and CI went red on `main` immediately after; [#375](https://github.com/KbWen/agentic-os/pull/375) fixed it.

## Why #3 and not a new #15

Same mechanism read in the other direction. Splitting it would let a reader who hits one direction miss the other, which is precisely how this one got missed — #3 was in context the whole time and reads as "gitignored means CI can't see it", full stop.

## Evidence

- Gotchas invariants re-verified: **0** hard-directive keywords, **0** tool-path references (the checker is named bare, matching how entry #4 names the token analyzer).
- `tests/ci/test_repo_gotchas_discoverability.py` + `tests/guard/test_decision_disposition_check.py` → **29 passed**.
- Doc-only diff in `.agent/rules/`, +13/−0. No validator or shared check touched, so the targeted suite is the correct scope rather than the full CI-equivalent run.
- Rollback = revert the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
