### PR TITLE
fix(ship): de-nest six always-applicable rules from the No-Python fallback

### DIFF
--- a/.agent/workflows/ship.md
+++ b/.agent/workflows/ship.md
@@ -181,19 +181,19 @@ Before proceeding with ship, check `docs/reviews/` for any review snapshots that
 - Update `.agentcortex/context/current_state.md` Spec Index statuses (mutable snapshot) via `.agentcortex/tools/guard_context_write.py`.
 - Use the helper as documented in `.agentcortex/docs/guides/guarded-context-writes.md`. In Stage 1, missing guard receipts are a validation warning, not a hard runtime block.
 - **No-Python fallback** (all SSoT writes here incl. §8 heartbeat): direct write + Drift Log entry (AGENTS.md §Write Isolation).
-   - **Spec Index Cap**: on the `check_ssot_caps.py` over-cap WARN, move the oldest `shipped` **index lines** into the single `## Spec Index Archive` section at the bottom of `current_state.md`, keeping cap-many inline (over-folding re-WARNs). Spec bodies stay in `docs/specs/` — moving one makes the entry a phantom and FAILs.
-   - MUST add the completion record at the **top** of the `## Ship History` section — immediately after the `## Ship History` header, newest-first, matching the established convention (the most recent ship is the first entry; older entries follow below). Use `.agentcortex/tools/guard_context_write.py --mode replace` (snapshot → insert the entry right after the header → write with `--expected-sha`), or a surgical anchored Edit. **Do NOT use `--mode append`**: it is `O_APPEND` (writes at file-end), which drops the entry at the *bottom* — the oldest position — silently breaking newest-first ordering. See `.agentcortex/docs/guides/guarded-context-writes.md`. **Note**: The Work Log `SSoT Sequence` header field is a bootstrap-time snapshot and is NOT incremented at ship — do not attempt to update it.
-   - Use the format:
+- **Spec Index Cap**: on the `check_ssot_caps.py` over-cap WARN, move the oldest `shipped` **index lines** into the single `## Spec Index Archive` section at the bottom of `current_state.md`, keeping cap-many inline (over-folding re-WARNs). Spec bodies stay in `docs/specs/` — moving one makes the entry a phantom and FAILs.
+- MUST add the completion record at the **top** of the `## Ship History` section — immediately after the `## Ship History` header, newest-first, matching the established convention (the most recent ship is the first entry; older entries follow below). Use `.agentcortex/tools/guard_context_write.py --mode replace` (snapshot → insert the entry right after the header → write with `--expected-sha`), or a surgical anchored Edit. **Do NOT use `--mode append`**: it is `O_APPEND` (writes at file-end), which drops the entry at the *bottom* — the oldest position — silently breaking newest-first ordering. See `.agentcortex/docs/guides/guarded-context-writes.md`. **Note**: The Work Log `SSoT Sequence` header field is a bootstrap-time snapshot and is NOT incremented at ship — do not attempt to update it.
+- Use the format:
 
-     ```markdown
-     ### Ship-<branch_name>-<YYYY-MM-DD>
-     - Feature shipped: [summary]
-     - Tests: Pass
-     ```
+  ```markdown
+  ### Ship-<branch_name>-<YYYY-MM-DD>
+  - Feature shipped: [summary]
+  - Tests: Pass
+  ```
 
-   - NEVER edit, reorder, or delete previous entries in the `## Ship History`.
-   - If Ship History exceeds 10 entries, archive older entries to `.agentcortex/context/archive/ship-history-YYYY.md` and keep only the latest 10 in `current_state.md`.
-   - **Relative-link depth hazard**: content copied from `current_state.md` (depth 2) into `archive/` (depth 3) shifts `../` links one level shallow — broken links are CI-caught; M8 also WARNs. **Strip/convert them to plain text or absolute URLs before committing archived content.**
+- NEVER edit, reorder, or delete previous entries in the `## Ship History`.
+- If Ship History exceeds 10 entries, archive older entries to `.agentcortex/context/archive/ship-history-YYYY.md` and keep only the latest 10 in `current_state.md`.
+- **Relative-link depth hazard**: content copied from `current_state.md` (depth 2) into `archive/` (depth 3) shifts `../` links one level shallow — broken links are CI-caught; M8 also WARNs. **Strip/convert them to plain text or absolute URLs before committing archived content.**
 2b. **Decision Disposition** (all tiers except `tiny-fix`; skip if `## Decisions` absent/empty): append one marker per entry — `→ promoted: ADR-<id>` (project-wide impact, new precedent, or reversal → author/amend that ADR + its Index line this ship) / `→ consolidated: L2 <domain>` (the ship L2 entry) / `→ local`. `→ local` is illegal for an entry naming an `ADR-<n>` or reversing a durable decision — use promoted/consolidated. Populate step-3 `decisions[]` with each entry's title. Headless: self-mark; `check_decision_disposition` WARNs on unmarked logs and ADR-naming locals.
 3. **Move** (not copy) `.agentcortex/context/work/<worklog-key>.md` to `.agentcortex/context/archive/<worklog-key>-<YYYYMMDD>.md` (the **root** of `archive/`, if task complete) — delete the `work/` original, else the validator WARNs "shipped work logs still in active work/ directory". This is **final archival** of the whole log — distinct from `/handoff §6` compaction, which offloads stale detail of a *still-active* log into the `archive/work/` subdir. The `-<YYYYMMDD>` suffix is required: it prevents a reused branch (e.g. a downstream that does all work on `main`) from overwriting its own prior archive on the next ship. Record the resulting filename in the `INDEX.jsonl` `log` field below.
     - Do NOT duplicate `/retro`-promoted Global Lessons during ship. `/retro` owns structured Global Lesson promotion.


### PR DESCRIPTION
## Summary

Backlog **#152**. `.agent/workflows/ship.md` had `- **No-Python fallback**` at column 0 with six rules indented three spaces beneath it. By markdown list semantics those six are *children of the fallback bullet* — so an agent that has Python can legitimately read the entire block as not applicable and skip it.

The six rules apply on **every** ship, regardless of Python availability:

- the Spec Index Cap remedy
- *"MUST add the completion record at the **top** of `## Ship History`"* — including the "do **NOT** use `--mode append`" warning
- *"NEVER edit, reorder, or delete previous entries"*
- the 10-entry rotation to `archive/ship-history-YYYY.md`
- the relative-link depth hazard

The Ship History ordering rule is not hypothetical: this repo has already been bitten by it once, which is what the `--mode append` warning exists to prevent.

## What changed

Whitespace only. The six bullets move from 3-space to 0-space indent, becoming siblings of the fallback bullet; the fenced example moves from 5-space to 2-space so it stays attached to its parent bullet (`- Use the format:`). **No wording is changed.**

## Evidence

The decisive check — indentation-only, nothing else touched:

```
git diff -w -- .agent/workflows/ship.md   →  (empty)
```

Token ceiling moves in the right direction, since this only removes characters:

```
aggregate  354,277 → 354,229   (headroom 723 → 771)
ship.md     24,458 → 24,425 chars = exactly the 33 whitespace chars removed
```

Targeted suites — every test that pins `ship.md` content, plus the token and directive ratchets:

```
pytest tests/guard/test_ssot_heartbeat_contract.py tests/guard/test_ssot_caps_check.py \
       .agentcortex/tests/test_skill_notes_contract.py .agentcortex/tests/test_lifecycle_contract.py \
       .agentcortex/tests/test_lifecycle_token_consumption.py \
       tests/ci/test_directive_count_ratchet.py tests/ci/test_lifecycle_baseline_drift.py
→ 89 passed

validate.sh              pass=117 warn=3 fail=0 skip=2
check_command_sync.py    30/30
```

The full 838-test sweep is delegated to this PR's CI rather than run locally — see the note below.

## Notes

- **A defect I introduced and caught mid-task**, recorded rather than quietly fixed: `Path.write_text` on Windows rewrote the whole file as CRLF (+275 bytes), violating the `eol=lf` attribute in `.gitattributes`. It surfaced because `wc -c` reported growth while the token aggregate reported shrinkage — two numbers that cannot both be right. Fixed by rewriting the bytes with CRLF→LF; `git ls-files --eol` now reports `w/lf`.
- Found while working #143 (PR #381) and deliberately excluded from it so a focused correctness fix stayed focused. Filed as backlog #152 at that time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
