### PR TITLE
fix(tools): #160 — generate_compact_index LF-stable output on Windows

### DIFF
--- a/.agentcortex/tests/test_trigger_metadata_tools.py
+++ b/.agentcortex/tests/test_trigger_metadata_tools.py
@@ -213,6 +213,29 @@ agentcortex:
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("compact index is fresh", result.stdout)
 
+    def test_generate_compact_index_emits_lf_only_bytes(self) -> None:
+        """Backlog #160: output_path.write_text(rendered, encoding="utf-8") with no
+        newline= control lets Windows text-mode translate \\n -> os.linesep (CRLF)
+        into a tracked eol=lf JSON artifact. MUST assert on the emitted BYTES from a
+        scratch run: asserting on the checked-out repo file is vacuous, because git
+        normalizes the checkout to LF regardless of whether the generator itself is
+        LF-stable. Proven red pre-fix / green post-fix on a real Windows box: the
+        unfixed pattern (`path.write_text(rendered, encoding="utf-8")`) wrote 475
+        CRLF pairs into this fixture's rendered content; the fixed pattern
+        (`.open("w", encoding="utf-8", newline="\\n")`) wrote zero."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            registry_dir = root / ".agentcortex" / "metadata"
+            registry_dir.mkdir(parents=True)
+            (registry_dir / "trigger-registry.yaml").write_text(
+                "version: 1\nentries: []\n", encoding="utf-8"
+            )
+            result = run_tool(".agentcortex/tools/generate_compact_index.py", "--root", str(root))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            output_bytes = (registry_dir / "trigger-compact-index.json").read_bytes()
+        self.assertNotIn(b"\r", output_bytes, "generator must emit LF-only bytes on every platform")
+        self.assertTrue(output_bytes.endswith(b"\n"))
+
     def test_query_returns_compact_skill_slice(self) -> None:
         result = run_tool(
             ".agentcortex/tools/query_trigger_metadata.py",

--- a/.agentcortex/tests/test_trigger_metadata_tools.py
+++ b/.agentcortex/tests/test_trigger_metadata_tools.py
@@ -930,5 +930,82 @@ class SnapshotRootPathFormTests(unittest.TestCase):
             self.assertIn("beta-skill", ids)
 
 
+class AppendLessonLfBytesTests(unittest.TestCase):
+    """External-review follow-up to the #160 LF fix: byte-level regression
+    coverage for the OTHER fixed writers — append_lesson.py's append path
+    (rewrites current_state.md) and archive path (rewrites current_state.md,
+    creates + appends global-lessons-archive.md). Same rationale as the
+    generator test: assert emitted bytes into a tmp tree; asserting on
+    committed files is vacuous (git checks them out LF regardless), and the
+    bug only manifests where os.linesep is CRLF."""
+
+    @staticmethod
+    def _chain_fixture(tmp: Path) -> tuple[Path, Path, Path]:
+        from check_lesson_chain import chain_sha
+
+        entries = [
+            ("cat-a", "MEDIUM", "trig-a", "First entry (genesis-anchored)."),
+            ("cat-b", "LOW", "trig-b", "Second entry, oldest LOW."),
+        ]
+        lines = [
+            "# Project Current State (vNext)",
+            "",
+            "- **Project Intent**: test fixture.",
+            "",
+            "## Global Lessons (AI Error Pattern Registry)",
+            "",
+        ]
+        prev = "GENESIS"
+        for cat, sev, trig, body in entries:
+            lines.append(
+                f"- [Category: {cat}][Severity: {sev}][Trigger: {trig}][prev: {prev}] {body}"
+            )
+            prev = chain_sha(cat, sev, trig, body)
+        lines += ["", "## Ship History", "", "### Ship-fixture", "- Feature shipped: none", ""]
+        ctx = tmp / ".agentcortex" / "context"
+        arc = ctx / "archive"
+        arc.mkdir(parents=True, exist_ok=True)
+        cs = ctx / "current_state.md"
+        # 3.9-safe fixture write (write_text gained newline= only in 3.10 — #164);
+        # fixture EOL is irrelevant anyway: the tool rewrites the whole file.
+        with cs.open("w", encoding="utf-8", newline="\n") as fh:
+            fh.write("\n".join(lines) + "\n")
+        return cs, arc / "INDEX.jsonl", arc / "global-lessons-archive.md"
+
+    @staticmethod
+    def _run_tool(*args: str) -> subprocess.CompletedProcess:
+        tool = ROOT / ".agentcortex" / "tools" / "append_lesson.py"
+        return subprocess.run(
+            [sys.executable, str(tool), *args],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+        )
+
+    def test_append_path_emits_lf_only_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            cs, _idx, _arc = self._chain_fixture(Path(td))
+            res = self._run_tool(
+                "--path", str(cs),
+                "--category", "cat-c", "--severity", "LOW",
+                "--trigger", "trig-c", "--body", "Appended by LF byte test.",
+            )
+            self.assertEqual(res.returncode, 0, res.stderr)
+            self.assertNotIn(b"\r", cs.read_bytes())
+
+    def test_archive_path_emits_lf_only_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            cs, idx, arc_md = self._chain_fixture(Path(td))
+            res = self._run_tool(
+                "--archive", "--index", "2",
+                "--path", str(cs), "--archive-path", str(arc_md),
+                "--index-jsonl", str(idx), "--date", "2026-08-08",
+            )
+            self.assertEqual(res.returncode, 0, res.stderr)
+            self.assertNotIn(b"\r", cs.read_bytes())
+            self.assertNotIn(b"\r", arc_md.read_bytes())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.agentcortex/tools/append_lesson.py
+++ b/.agentcortex/tools/append_lesson.py
@@ -142,7 +142,10 @@ def append_lesson(
     # Insert with surrounding blank handling: the existing pattern is
     # `<lesson>\n<lesson>\n\n## Ship History`. Preserve the trailing blank.
     new_lines = lines[:insert_at] + [new_bullet] + lines[insert_at:]
-    path.write_text("\n".join(new_lines) + ("\n" if text.endswith("\n") else ""), encoding="utf-8")
+    # newline="\n" forces LF on all platforms (path is tracked eol=lf); plain
+    # write_text() text-mode would translate \n -> CRLF on Windows.
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write("\n".join(new_lines) + ("\n" if text.endswith("\n") else ""))
 
     return {
         "status": "ok",
@@ -237,23 +240,29 @@ def archive_lesson(
             )
 
     del lines[target_line_idx]
-    path.write_text("\n".join(lines) + ("\n" if text.endswith("\n") else ""), encoding="utf-8")
+    # newline="\n": same LF-stability rationale as append_lesson() above.
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write("\n".join(lines) + ("\n" if text.endswith("\n") else ""))
 
     # ---- 2) Move the removed bullet to the archive surface ----
     when = date or datetime.date.today().isoformat()
     archive_path.parent.mkdir(parents=True, exist_ok=True)
     header = "# Global Lessons Archive\n"
+    # newline="\n" on both opens below: archive_path is tracked eol=lf. The
+    # create-on-first-use write and the very next append below both write
+    # into the same file, so both need LF control -- fixing only the first
+    # would be immediately undone by an unguarded second write.
     if not archive_path.exists():
-        archive_path.write_text(
-            header
-            + "\n> Chain-aware archival target for §Global Lessons overflow "
-            "(config.yaml §document_lifecycle.global_lessons_max_entries).\n"
-            "> Each entry below was removed from current_state.md by "
-            "`append_lesson.py --archive` and is authorized by a matching "
-            "`lesson_archive` record in `INDEX.jsonl`.\n",
-            encoding="utf-8",
-        )
-    with archive_path.open("a", encoding="utf-8") as fh:
+        with archive_path.open("w", encoding="utf-8", newline="\n") as handle:
+            handle.write(
+                header
+                + "\n> Chain-aware archival target for §Global Lessons overflow "
+                "(config.yaml §document_lifecycle.global_lessons_max_entries).\n"
+                "> Each entry below was removed from current_state.md by "
+                "`append_lesson.py --archive` and is authorized by a matching "
+                "`lesson_archive` record in `INDEX.jsonl`.\n"
+            )
+    with archive_path.open("a", encoding="utf-8", newline="\n") as fh:
         fh.write(f"\n## Archived {when} (prev: {bridge_prev}, body-sha: {archived_body_sha})\n\n")
         fh.write(removed_line.rstrip() + "\n")
 

--- a/.agentcortex/tools/generate_compact_index.py
+++ b/.agentcortex/tools/generate_compact_index.py
@@ -39,7 +39,13 @@ def main() -> int:
         return 0
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(rendered, encoding="utf-8")
+    # newline="\n" forces LF on all platforms; Path.write_text()'s own `newline=`
+    # kwarg needs Python >=3.10 and this repo's CI floor is 3.9 (validate.yml),
+    # so control it via .open() instead. Without this, Windows text-mode write
+    # translates \n -> CRLF into a tracked eol=lf JSON artifact (repo-gotchas
+    # class: the 2026-08-03 ship.md CRLF incident had the same root cause).
+    with output_path.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(rendered)
     print(f"wrote compact index: {output_path.relative_to(root).as_posix()}")
     return 0
 


### PR DESCRIPTION
## What

Backlog **#160**: `generate_compact_index.py` wrote `trigger-compact-index.json` with CRLF line endings on Windows (`Path.write_text` with no `newline=` → `os.linesep` translation; 475/475 lines). Fixed by writing through `.open("w", encoding="utf-8", newline="\n")` — chosen over `write_text(newline=...)` because that parameter is Python ≥3.10 and this repo carries a 3.9 CI floor (`validate.yml`).

The mandated sweep found 4 more writers of tracked `eol=lf` targets with the same pattern in `append_lesson.py` (two `current_state.md` sites; `global-lessons-archive.md` creation + append — both needed together) — fixed identically. Non-targets found and deliberately left (gitignored targets, scratch tempfiles, already-correct sites) are listed in the audit trail.

Severity honesty (tenth-man-corrected): `.gitattributes` filters the CRLF out at the commit boundary — `git hash-object` is identical, `git diff` empty, validators unmoved. The real-world impact is a spurious ` M` in `git status` plus the hand-fix effort agents burn on it (a sim agent did exactly that). Small defect, small fix.

## Adopter delta

Windows adopters regenerating the compact index (the mandatory companion step after editing `AGENTS.md`/`bootstrap.md`/`routing.md`) no longer get a phantom-dirty working tree. No behavior change on other platforms (LF was already emitted there).

## Evidence

- New test `test_generate_compact_index_emits_lf_only_bytes` (asserts **emitted bytes** into a tmp path — an assertion on the committed file would be vacuous since git checks it out LF regardless). **Red→green proven on this Windows box**: pre-fix revert → `1 failed` (`b'\r' unexpectedly found…`); fix restored → `1 passed`.
- `test_trigger_metadata_tools.py`: 46 passed. `test_lesson_chain_archival.py` (append_lesson's own suite): 5 passed.
- Primary acceptance re-run: regenerating the index in this branch's tree on Windows emits **0 CR bytes** (was 475 pre-fix).
- Final validator (after last Work Log write): `pass=116 warn=4 fail=0 skip=2` (populated fingerprint; extra WARN = own unarchived work log, by design pre-merge).

## Follow-up surfaced (not in this PR)

`update_lifecycle_baseline.py:78` already uses `write_text(..., newline=)` — the ≥3.10 API — a latent `TypeError` on the 3.9 floor, CI-invisible because only `--dry-run` runs in CI. Routed as backlog **#164**.

## Reviewer guidance

- Confirm every fixed site targets a **tracked** file with `eol=lf` (`git check-attr`), and no gitignored/scratch writer was churned.
- The append_lesson.py hunks here are write-mechanics only; a **separate** PR (`fix/162-lesson-chain-parity-guard`) touches the same file's parse logic — whichever merges second gets a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
