### PR TITLE
fix(tools): #162 — lesson-chain strict/loose parity guard

### DIFF
--- a/.agentcortex/tests/test_lesson_chain_archival.py
+++ b/.agentcortex/tests/test_lesson_chain_archival.py
@@ -225,6 +225,77 @@ class LessonChainArchivalTests(unittest.TestCase):
             self.assertEqual(res.returncode, 1, "HIGH archival must be refused")
             self.assertIn("HIGH", res.stderr)
 
+    # ---- Backlog #162: format-mangled tail bullet must not be cemented ----
+    def _mangled_tail_fixture(self, tmp: Path) -> tuple[Path, Path, Path, int]:
+        """Build a fixture whose tail bullet is tag-mangled: its [Severity:]
+        token is deleted entirely. The line still starts with '- [Category:'
+        (loose prefix match) but fails strict LESSON_RE (no [Severity:] token
+        between [Category:] and [Trigger:]) -- the exact backlog #162
+        mechanism. Its own [prev:] is set to chain correctly from the last
+        well-formed entry, so it is invisible-but-plausible: a naive next
+        append would silently anchor past it. Returns (cs, idx, arc_md,
+        mangled_line_no).
+        """
+        ctx = tmp / ".agentcortex" / "context"
+        arc = ctx / "archive"
+        arc.mkdir(parents=True, exist_ok=True)
+        cs = ctx / "current_state.md"
+
+        entries = self._entries()
+        text = build_current_state(entries)
+        last_cat, last_sev, last_trig, last_body = entries[-1]
+        tail_prev = chain_sha(last_cat, last_sev, last_trig, last_body)
+        mangled = (
+            f"- [Category: cat-mangled][Trigger: trig-mangled]"
+            f"[prev: {tail_prev}] Tail bullet with its Severity tag deleted."
+        )
+        text = text.replace("\n## Ship History", f"\n{mangled}\n\n## Ship History")
+        cs.write_text(text, encoding="utf-8")
+
+        mangled_line_no = next(
+            i + 1 for i, ln in enumerate(text.splitlines()) if ln == mangled
+        )
+
+        idx = arc / "INDEX.jsonl"
+        arc_md = arc / "global-lessons-archive.md"
+        return cs, idx, arc_md, mangled_line_no
+
+    def test_mangled_tail_append_refused(self):
+        """(a) A mangled tail must refuse the next append rather than silently
+        anchoring [prev:] past it (which would cement it outside the chain)."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            cs, _idx, _arc_md, mangled_line_no = self._mangled_tail_fixture(tmp)
+            before = cs.read_text(encoding="utf-8")
+
+            res = run(
+                APPEND_LESSON, "--path", str(cs),
+                "--category", "cat-new", "--severity", "LOW",
+                "--trigger", "trig-new", "--body", "Should be refused: tail is mangled.",
+            )
+            self.assertEqual(res.returncode, 1, "append past a mangled tail must be refused")
+            self.assertIn(str(mangled_line_no), res.stderr)
+            self.assertIn("check_lesson_chain.py", res.stderr)
+            # Refusal happens before the cap/prev computation or any write.
+            self.assertEqual(cs.read_text(encoding="utf-8"), before, "refused append must not touch the file")
+
+    def test_mangled_tail_chain_check_reports_broken(self):
+        """(b) check_lesson_chain.py must report the mangled tail as broken
+        instead of silently skipping it and re-verifying intact."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            cs, idx, _arc_md, mangled_line_no = self._mangled_tail_fixture(tmp)
+
+            chk = self._check(cs, idx)
+            self.assertEqual(chk.returncode, 1, "chain check must report broken, not intact")
+            combined = chk.stdout + chk.stderr
+            self.assertIn(f"line {mangled_line_no}", combined)
+            self.assertIn("BROKEN", chk.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.agentcortex/tools/append_lesson.py
+++ b/.agentcortex/tools/append_lesson.py
@@ -58,6 +58,7 @@ from check_lesson_chain import (  # noqa: E402
     LESSON_ARCHIVE_TYPE,
     canonical,
     chain_sha,
+    find_malformed_lesson_lines,
     lesson_body_sha,
     parse_lessons,
 )
@@ -106,6 +107,30 @@ def append_lesson(
         raise ValueError("category, trigger, body all required (non-empty)")
 
     lessons = parse_lessons(path)
+
+    # Strict/loose parity guard (backlog #162). parse_lessons() is a STRICT
+    # parser: a format-mangled bullet (e.g. a deleted [Severity:] token) still
+    # matches the loose "- [Category:" prefix but silently drops out of
+    # `lessons`. Left unchecked, the `prev` computed below would anchor past
+    # the mangled bullet -- cementing it outside the hash chain forever even
+    # though it stays physically in the file -- and the cap check right below
+    # would under-count the section (strict count < physical bullet count),
+    # letting an append through that the cap should refuse. Refuse fail-closed
+    # on any mismatch, before computing `prev` or evaluating the cap.
+    malformed = find_malformed_lesson_lines(path)
+    if malformed:
+        loose_count = len(lessons) + len(malformed)
+        raise ValueError(
+            f"Global Lessons section has {loose_count} bullet-prefixed line(s) "
+            f"but only {len(lessons)} parse strictly -- line {malformed[0]} is "
+            f"format-mangled (e.g. a missing [Severity:] or [Trigger:] token) "
+            f"and would be silently skipped, permanently cementing it outside "
+            f"the hash chain once this append's [prev:] anchors past it. "
+            f"Refusing to append. Run "
+            f"`python .agentcortex/tools/check_lesson_chain.py` to diagnose, "
+            f"fix the malformed bullet, then retry."
+        )
+
     if len(lessons) >= GLOBAL_LESSONS_CAP:
         raise ValueError(
             f"Global Lessons at cap ({len(lessons)} >= {GLOBAL_LESSONS_CAP}); "

--- a/.agentcortex/tools/check_lesson_chain.py
+++ b/.agentcortex/tools/check_lesson_chain.py
@@ -96,10 +96,43 @@ def parse_lessons(path: Path) -> list[tuple[str, str, str, str | None, str, int]
             continue
         m = LESSON_RE.match(stripped.lstrip())
         if not m:
-            continue  # skip malformed bullets (will be caught elsewhere)
+            continue  # skip malformed bullets -- surfaced by find_malformed_lesson_lines()
         cat, sev, trig, prev, body = m.groups()
         lessons.append((cat, sev, trig, prev, body, line_no))
     return lessons
+
+
+def find_malformed_lesson_lines(path: Path) -> list[int]:
+    """Return 1-based line numbers of bullets inside ## Global Lessons that match
+    the loose `- [Category:` prefix but fail the strict LESSON_RE (backlog #162).
+
+    parse_lessons() silently drops these lines (a format-mangled bullet, e.g. one
+    missing its `[Severity:]` or `[Trigger:]` token). Without this check that drop
+    is invisible: the chain walk in check_chain() never sees the line at all, so it
+    cannot flag a break, and a later append_lesson.py append would anchor its
+    `[prev:]` to the strict parser's last surviving entry -- PAST the mangled
+    bullet -- permanently cementing it outside the chain while it stays physically
+    in the file. This function makes the drop itself the detected failure.
+    """
+    bad: list[int] = []
+    if not path.is_file():
+        return bad
+    text = path.read_text(encoding="utf-8")
+    in_section = False
+    for line_no, raw in enumerate(text.splitlines(), start=1):
+        stripped = raw.rstrip("\n")
+        if stripped.startswith("## Global Lessons"):
+            in_section = True
+            continue
+        if in_section and stripped.startswith("## "):
+            break
+        if not in_section:
+            continue
+        if not stripped.lstrip().startswith("- [Category:"):
+            continue
+        if not LESSON_RE.match(stripped.lstrip()):
+            bad.append(line_no)
+    return bad
 
 
 def load_archive_bridges(index_jsonl: Path) -> dict[tuple[str, str], dict]:
@@ -216,8 +249,22 @@ def check_chain(path: Path, index_jsonl: Path | None = None) -> tuple[bool, list
     """
     errors: list[str] = []
     lessons = parse_lessons(path)
+
+    # Malformed-bullet detection (backlog #162): a line that matches the loose
+    # "- [Category:" bullet prefix but fails strict LESSON_RE parsing is dropped
+    # silently by parse_lessons() and would otherwise never appear as a chain
+    # error at all. Report it directly so the drop itself is fail-closed.
+    for bad_line in find_malformed_lesson_lines(path):
+        errors.append(
+            f"line {bad_line}: bullet matches '- [Category:' prefix but fails to "
+            f"parse (malformed tag structure, e.g. a missing [Severity:] or "
+            f"[Trigger:] token) -- this bullet would be silently skipped by the "
+            f"chain walk and permanently cemented outside the chain by the next "
+            f"append_lesson.py append; fix the bullet's tag structure"
+        )
+
     if not lessons:
-        return True, []
+        return (len(errors) == 0), errors
     if index_jsonl is None:
         index_jsonl = path.parent / "archive" / "INDEX.jsonl"
     bridges = load_archive_bridges(index_jsonl)


### PR DESCRIPTION
## What

Backlog **#162** (audit finding F5, whose original "self-healing" close was **refuted by experiment** in a tenth-man pass): a format-mangled tail bullet in `## Global Lessons` (e.g. `[Severity:]` token deleted) was skipped by `check_lesson_chain.py`'s strict `LESSON_RE`, and the next `append_lesson.py` append anchored its `[prev:]` to the strict parser's `lessons[-1]` — **past** the mangled bullet — permanently cementing it outside the hash chain while it physically remained in the file. A mangled tail also desynced the cap gate (strict count) from the section bounds (loose prefix count), unblocking appends the 20-cap should refuse.

Fix, fail-closed on both sides:

- `check_lesson_chain.py`: new `find_malformed_lesson_lines()` — any line that loose-matches `- [Category:` but fails the strict regex is now reported as a chain error (`line N: … malformed tag structure …`) through the **existing** errors/exit-1 path, so both validators pick it up as the existing lesson-chain FAIL with zero validator changes and zero ADR-006 cost.
- `append_lesson.py`: refuses the append (exit 1) when the loose/strict counts diverge, naming the first malformed line and pointing at `check_lesson_chain.py`.

## Adopter delta

Hand-mangled lesson bullets (the only entry path — the tool always writes well-formed ones) now surface as a broken chain instead of silently leaving the tamper-evidence net. Well-formed repos see no change: the real 20-lesson SSoT still verifies `intact`.

## Evidence

- Red→green: with the two tool changes stashed (new tests kept) → `2 failed` reproducing the exact defect (append silently succeeded; chain reported intact); restored → **7 passed**. Full `.agentcortex/tests/`: 208 passed.
- Primary acceptance re-run: 7 passed; branch validator run `pass=117 warn=3 fail=0 skip=2` with `[PASS] lesson chain integrity (Global Lessons)` on the real SSoT.
- Diff: 3 files, +145/−2.

## Reviewer guidance

- Key property to check: the detector must fire only on *loose-match-but-strict-fail* lines — a well-formed 20/20 section must stay `intact` (the acceptance run shows it does).
- The mid-chain case was already caught pre-fix (successor `[prev:]` mismatch, fail-closed) — this PR closes the tail case; don't ask for mid-chain changes.
- A **separate** PR (`fix/160-compact-index-lf`) touches `append_lesson.py` write-mechanics; whichever merges second gets a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
