### PR TITLE
feat(validator): #161 — Work-Log external-references existence check (WARN, source-only)

### DIFF
--- a/.agentcortex/bin/validate.ps1
+++ b/.agentcortex/bin/validate.ps1
@@ -796,7 +796,7 @@ Invoke-PythonCheck -Label 'decision disposition (archived work logs)' -MissingPy
 # network call). WARN-tier / never-FAIL (tool ALWAYS exits 0); silent no-op when
 # no active Work Log exists. Backlog #161 (2026-08-08 govern-audit F7): a log
 # citing a nonexistent spec path or PR previously passed both validators untouched.
-Invoke-PythonCheck -Label 'worklog external references (spec/ADR existence)' -MissingPythonLevel 'WARN' -ScriptPath (Join-NormalPath $root '.agentcortex/tools/check_worklog_references.py') -Arguments @('--root', $root)
+Invoke-PythonCheck -Label 'worklog external references (spec/ADR existence, advisory)' -MissingPythonLevel 'WARN' -ScriptPath (Join-NormalPath $root '.agentcortex/tools/check_worklog_references.py') -Arguments @('--root', $root)
 $phaseSkillFiles = @(
     (Join-NormalPath $workflowsDir 'plan.md'),
     (Join-NormalPath $workflowsDir 'implement.md'),

--- a/.agentcortex/bin/validate.ps1
+++ b/.agentcortex/bin/validate.ps1
@@ -791,6 +791,12 @@ Invoke-PythonCheck -Label 'ssot section caps (ship history + spec index)' -Missi
 # entries missing a ship-time marker). WARN-tier / never-FAIL (tool ALWAYS exits 0);
 # silent no-op until a fork sets document_lifecycle.decision_disposition_since.
 Invoke-PythonCheck -Label 'decision disposition (archived work logs)' -MissingPythonLevel 'WARN' -ScriptPath (Join-NormalPath $root '.agentcortex/tools/check_decision_disposition.py') -Arguments @('--root', $root)
+# ADR-006: advisory Work Log `## External References` existence check (Spec/ADR
+# referents must exist on disk; PR/Issue referents are format-checked only, no
+# network call). WARN-tier / never-FAIL (tool ALWAYS exits 0); silent no-op when
+# no active Work Log exists. Backlog #161 (2026-08-08 govern-audit F7): a log
+# citing a nonexistent spec path or PR previously passed both validators untouched.
+Invoke-PythonCheck -Label 'worklog external references (spec/ADR existence)' -MissingPythonLevel 'WARN' -ScriptPath (Join-NormalPath $root '.agentcortex/tools/check_worklog_references.py') -Arguments @('--root', $root)
 $phaseSkillFiles = @(
     (Join-NormalPath $workflowsDir 'plan.md'),
     (Join-NormalPath $workflowsDir 'implement.md'),

--- a/.agentcortex/bin/validate.sh
+++ b/.agentcortex/bin/validate.sh
@@ -662,7 +662,7 @@ run_python_check "decision disposition (archived work logs)" WARN "$ROOT/.agentc
 # (docs/reviews/2026-08-08-govern-audit-task-simulation.md F7): a log citing a
 # nonexistent spec path or PR previously passed both validators untouched.
 # No-python -> WARN; tool absent -> SKIP.
-run_python_check "worklog external references (spec/ADR existence)" WARN "$ROOT/.agentcortex/tools/check_worklog_references.py" --root "$ROOT"
+run_python_check "worklog external references (spec/ADR existence, advisory)" WARN "$ROOT/.agentcortex/tools/check_worklog_references.py" --root "$ROOT"
 
 ACTIVE_CODEX_RULES="$ROOT/codex/rules/default.rules"
 [[ -f "$ACTIVE_CODEX_RULES" ]] || ACTIVE_CODEX_RULES="$CODEX_RULES"

--- a/.agentcortex/bin/validate.sh
+++ b/.agentcortex/bin/validate.sh
@@ -655,6 +655,15 @@ run_python_check "ssot section caps (ship history + spec index)" WARN "$ROOT/.ag
 # document_lifecycle.decision_disposition_since. No-python -> WARN; tool absent -> SKIP.
 run_python_check "decision disposition (archived work logs)" WARN "$ROOT/.agentcortex/tools/check_decision_disposition.py" --root "$ROOT"
 
+# ADR-006: advisory Work Log `## External References` existence check (Spec/ADR
+# referents must exist on disk; PR/Issue referents are format-checked only, no
+# network call) as a Python tool behind run_python_check. WARN-tier / never-FAIL
+# (tool ALWAYS exits 0); silent no-op when no active Work Log exists. Backlog #161
+# (docs/reviews/2026-08-08-govern-audit-task-simulation.md F7): a log citing a
+# nonexistent spec path or PR previously passed both validators untouched.
+# No-python -> WARN; tool absent -> SKIP.
+run_python_check "worklog external references (spec/ADR existence)" WARN "$ROOT/.agentcortex/tools/check_worklog_references.py" --root "$ROOT"
+
 ACTIVE_CODEX_RULES="$ROOT/codex/rules/default.rules"
 [[ -f "$ACTIVE_CODEX_RULES" ]] || ACTIVE_CODEX_RULES="$CODEX_RULES"
 if [[ -f "$ACTIVE_CODEX_RULES" ]]; then

--- a/.agentcortex/tests/test_worklog_references_check.py
+++ b/.agentcortex/tests/test_worklog_references_check.py
@@ -1,0 +1,259 @@
+"""Guard tests for check_worklog_references.py — the advisory Work Log
+`## External References` existence checker (backlog #161).
+
+The tool is WARN-tier / never-FAIL (ADR-006 run_python_check contract): it
+ALWAYS exits 0 and prints `WARN: ...` lines only for a Spec/ADR referent that
+does not exist on disk, or a PR/Issue referent whose format is neither a URL,
+a `#NNN` shorthand, nor the `—` placeholder. These tests drive the pure-Python
+tool directly via subprocess against synthetic Work Log fixtures — deterministic,
+fast, no bash/PowerShell, no `slow` marker.
+
+Coverage:
+  * nonexistent Spec / ADR path         -> WARN, names the missing path
+  * valid Spec path                     -> silent
+  * `—` / blank placeholder             -> silent (exempt)
+  * http(s):// URL in a Spec row        -> silent (exempt, no network call)
+  * backtick-wrapped valid path         -> silent (wrapping stripped)
+  * malformed PR/Issue reference        -> WARN, format-only wording
+  * `#NNN` shorthand PR/Issue reference -> silent
+  * URL PR/Issue reference              -> silent
+  * tool always exits 0, even with multiple WARNs present
+  * dotfile logs (e.g. `.gitkeep.md`) ignored
+  * no active logs / missing dir        -> exit 0, silent
+  * multiple logs                       -> findings aggregate with filename prefix
+  * default --worklog-dir resolution    -> matches the real validator invocation
+    (validate.sh/.ps1 pass only --root, relying on the default)
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / ".agentcortex" / "tools" / "check_worklog_references.py"
+
+TABLE_HEADER = "## External References\n\n| Type | Path / URL | Notes |\n|---|---|---|\n"
+
+
+def write_log(work_dir: Path, name: str, rows: str) -> Path:
+    """Write one Work Log fixture with an External References table."""
+    work_dir.mkdir(parents=True, exist_ok=True)
+    content = TABLE_HEADER + rows + "\n## Known Risk\n\nnone\n"
+    p = work_dir / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def run_tool(root: Path, worklog_dir: Path | None = None):
+    args = [sys.executable, str(TOOL), "--root", str(root)]
+    if worklog_dir is not None:
+        args += ["--worklog-dir", str(worklog_dir)]
+    return subprocess.run(args, capture_output=True, text=True, encoding="utf-8")
+
+
+def test_nonexistent_spec_path_warns(tmp_path):
+    work = tmp_path / "work"
+    write_log(work, "a.md", "| Spec | docs/specs/nonexistent.md | fabricated |\n")
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert "WARN:" in r.stdout
+    assert "a.md" in r.stdout
+    assert "Spec path 'docs/specs/nonexistent.md' does not exist" in r.stdout
+
+
+def test_nonexistent_adr_path_warns(tmp_path):
+    work = tmp_path / "work"
+    write_log(work, "a.md", "| ADR | docs/adr/ADR-999-fake.md | fabricated |\n")
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert "ADR path 'docs/adr/ADR-999-fake.md' does not exist" in r.stdout
+
+
+def test_valid_spec_path_is_silent(tmp_path):
+    (tmp_path / "docs" / "specs").mkdir(parents=True)
+    (tmp_path / "docs" / "specs" / "real.md").write_text("real\n", encoding="utf-8")
+    work = tmp_path / "work"
+    write_log(work, "a.md", "| Spec | docs/specs/real.md | ok |\n")
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert "WARN:" not in r.stdout
+    assert "OK" in r.stdout
+
+
+def test_backtick_wrapped_valid_path_is_silent(tmp_path):
+    (tmp_path / "docs" / "specs").mkdir(parents=True)
+    (tmp_path / "docs" / "specs" / "real.md").write_text("real\n", encoding="utf-8")
+    work = tmp_path / "work"
+    write_log(work, "a.md", "| Spec | `docs/specs/real.md` | ok |\n")
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert "WARN:" not in r.stdout
+
+
+def test_placeholder_rows_are_silent(tmp_path):
+    work = tmp_path / "work"
+    rows = "| Spec | — | — |\n| ADR | — | — |\n| Issue | — | — |\n| PR | — | — |\n"
+    write_log(work, "a.md", rows)
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert "WARN:" not in r.stdout
+    assert "OK" in r.stdout
+
+
+def test_blank_path_cell_is_silent(tmp_path):
+    work = tmp_path / "work"
+    write_log(work, "a.md", "| Spec |  |  |\n")
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert "WARN:" not in r.stdout
+
+
+def test_url_spec_path_exempt_no_existence_check(tmp_path):
+    work = tmp_path / "work"
+    write_log(work, "a.md", "| Spec | https://example.com/spec-does-not-exist.md | ok |\n")
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert "WARN:" not in r.stdout
+
+
+def test_malformed_pr_reference_warns(tmp_path):
+    work = tmp_path / "work"
+    write_log(work, "a.md", "| PR | see slack channel | malformed |\n")
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert "WARN:" in r.stdout
+    assert "not a URL, #NNN reference, or" in r.stdout
+    assert "no network call" in r.stdout
+
+
+def test_malformed_issue_reference_warns(tmp_path):
+    work = tmp_path / "work"
+    write_log(work, "a.md", "| Issue | not-a-url-or-hash | malformed |\n")
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert "WARN:" in r.stdout
+    assert "Issue reference" in r.stdout
+
+
+def test_hash_shorthand_pr_reference_is_silent(tmp_path):
+    work = tmp_path / "work"
+    write_log(work, "a.md", "| PR | #385 | ok |\n")
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert "WARN:" not in r.stdout
+
+
+def test_multiple_hash_shorthand_with_extra_text_is_silent(tmp_path):
+    """Real-world shape (chore-v1.8.18-release worklog): several `#NNN` tokens
+    plus free text ('+ 4 ship records') in one PR cell must not false-WARN."""
+    work = tmp_path / "work"
+    write_log(work, "a.md", "| PR | #379 #381 #383 + 4 ship records | packaged |\n")
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert "WARN:" not in r.stdout
+
+
+def test_url_pr_reference_is_silent(tmp_path):
+    work = tmp_path / "work"
+    write_log(work, "a.md", "| PR | https://github.com/KbWen/agentic-os/pull/999 | unverified |\n")
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert "WARN:" not in r.stdout
+    # Honest limitation, not asserted as a finding: PR existence itself is not
+    # network-checked, so a fabricated-but-well-formed PR URL is expected silent.
+
+
+def test_tool_always_exits_zero_even_with_findings(tmp_path):
+    work = tmp_path / "work"
+    rows = (
+        "| Spec | docs/specs/missing1.md | x |\n"
+        "| ADR | docs/adr/missing2.md | x |\n"
+        "| Issue | garbage | x |\n"
+        "| PR | garbage | x |\n"
+    )
+    write_log(work, "a.md", rows)
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert r.stdout.count("WARN:") == 4
+
+
+def test_dotfile_logs_are_ignored(tmp_path):
+    work = tmp_path / "work"
+    write_log(work, ".gitkeep.md", "| Spec | docs/specs/nonexistent.md | fabricated |\n")
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert r.stdout.strip() == ""
+
+
+def test_no_active_logs_is_silent(tmp_path):
+    work = tmp_path / "work"
+    work.mkdir(parents=True)
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert r.stdout.strip() == ""
+
+
+def test_missing_worklog_dir_exits_zero_silent(tmp_path):
+    r = run_tool(tmp_path, tmp_path / "does-not-exist")
+    assert r.returncode == 0
+    assert r.stdout.strip() == ""
+
+
+def test_no_external_references_section_is_silent(tmp_path):
+    """No `## External References` heading at all -> 0 rows found for an
+    otherwise-active log. The log itself was still checked (hence the OK
+    summary, same as any other zero-finding run) -- "silent" here means no
+    WARN, not empty stdout; only zero ACTIVE LOGS produces empty stdout."""
+    work = tmp_path / "work"
+    work.mkdir(parents=True)
+    (work / "a.md").write_text("# Work Log: a\n\n## Known Risk\n\nnone\n", encoding="utf-8")
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert "WARN:" not in r.stdout
+    assert "0 row(s) checked" in r.stdout
+
+
+def test_multiple_logs_aggregate_with_filename_prefix(tmp_path):
+    work = tmp_path / "work"
+    write_log(work, "a.md", "| Spec | docs/specs/missing-a.md | x |\n")
+    write_log(work, "b.md", "| Spec | docs/specs/missing-b.md | x |\n")
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert "a.md" in r.stdout and "missing-a.md" in r.stdout
+    assert "b.md" in r.stdout and "missing-b.md" in r.stdout
+
+
+def test_default_worklog_dir_resolution_matches_real_invocation(tmp_path):
+    """No --worklog-dir override: resolves <root>/.agentcortex/context/work —
+    the exact invocation validate.sh / validate.ps1 use (--root only)."""
+    work = tmp_path / ".agentcortex" / "context" / "work"
+    write_log(work, "a.md", "| Spec | docs/specs/missing.md | x |\n")
+    r = run_tool(tmp_path)
+    assert r.returncode == 0
+    assert "WARN:" in r.stdout
+    assert "docs/specs/missing.md" in r.stdout
+
+
+def test_leading_slash_path_treated_as_repo_relative(tmp_path):
+    """Deterministic cross-platform resolution: a leading `/` must resolve
+    repo-relative on both Windows and POSIX, not via Path.is_absolute()
+    (which disagrees between platforms for a bare leading slash)."""
+    (tmp_path / "docs" / "specs").mkdir(parents=True)
+    (tmp_path / "docs" / "specs" / "real.md").write_text("real\n", encoding="utf-8")
+    work = tmp_path / "work"
+    write_log(work, "a.md", "| Spec | /docs/specs/real.md | ok |\n")
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert "WARN:" not in r.stdout
+
+
+def test_unknown_row_type_is_ignored(tmp_path):
+    """Forward compatibility: a future template row type is neither
+    existence-checked nor format-checked, and must not crash the tool."""
+    work = tmp_path / "work"
+    write_log(work, "a.md", "| Design | some free text | future row type |\n")
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert "WARN:" not in r.stdout

--- a/.agentcortex/tests/test_worklog_references_check.py
+++ b/.agentcortex/tests/test_worklog_references_check.py
@@ -257,3 +257,67 @@ def test_unknown_row_type_is_ignored(tmp_path):
     r = run_tool(tmp_path, work)
     assert r.returncode == 0
     assert "WARN:" not in r.stdout
+
+
+def write_raw_log(work_dir: Path, name: str, content: str) -> Path:
+    """Write a Work Log fixture with full content control (fence tests)."""
+    work_dir.mkdir(parents=True, exist_ok=True)
+    p = work_dir / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def test_fenced_decoy_heading_does_not_shadow_real_section(tmp_path):
+    """External-review P1 (backlog #156 decoy family): a fenced example
+    containing the heading + a plausible table must NOT bind the parser —
+    the REAL section's bogus path is the one that has to WARN, and the
+    decoy's path must not be reported at all."""
+    work = tmp_path / "work"
+    write_raw_log(
+        work,
+        "a.md",
+        "# Work Log: decoy\n\nExample of the section format:\n\n"
+        "```\n## External References\n\n| Type | Path / URL | Notes |\n"
+        "|---|---|---|\n| Spec | docs/specs/decoy-only.md | fenced example |\n```\n\n"
+        "## External References\n\n| Type | Path / URL | Notes |\n|---|---|---|\n"
+        "| Spec | docs/specs/does-not-exist.md | real section |\n\n## Known Risk\n\nnone\n",
+    )
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert "Spec path 'docs/specs/does-not-exist.md' does not exist" in r.stdout
+    assert "decoy-only.md" not in r.stdout
+
+
+def test_fenced_example_rows_inside_real_section_are_ignored(tmp_path):
+    """A fenced example table INSIDE the real section is documentation,
+    not live rows — only the unfenced row may WARN."""
+    work = tmp_path / "work"
+    write_raw_log(
+        work,
+        "a.md",
+        "## External References\n\nFormat example:\n\n"
+        "```\n| Spec | docs/specs/fenced-example.md | doc |\n```\n\n"
+        "| Type | Path / URL | Notes |\n|---|---|---|\n"
+        "| Spec | docs/specs/really-missing.md | live |\n\n## Known Risk\n\nnone\n",
+    )
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert "really-missing.md" in r.stdout
+    assert "fenced-example.md" not in r.stdout
+
+
+def test_fenced_only_heading_yields_no_findings(tmp_path):
+    """A log whose ONLY `## External References` heading sits inside a fence
+    has no real section — the tool must stay silent, not scan the fence."""
+    work = tmp_path / "work"
+    write_raw_log(
+        work,
+        "a.md",
+        "# Work Log: fenced only\n\n"
+        "```\n## External References\n\n| Type | Path / URL | Notes |\n"
+        "|---|---|---|\n| Spec | docs/specs/ghost.md | fenced |\n```\n\n"
+        "## Known Risk\n\nnone\n",
+    )
+    r = run_tool(tmp_path, work)
+    assert r.returncode == 0
+    assert "WARN:" not in r.stdout

--- a/.agentcortex/tools/check_worklog_references.py
+++ b/.agentcortex/tools/check_worklog_references.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Advisory existence checker for Work Log `## External References` referents.
+
+Verified gap (backlog #161; docs/reviews/2026-08-08-govern-audit-task-simulation.md
+F7): `## External References` (templates/worklog.md §External References) appears
+zero times in either validator, so a Work Log that cites a nonexistent spec path or
+a nonexistent PR passes both validators untouched (probe P1a, 2026-08-08). The
+needed primitive already exists for another SSoT field -- `validate.sh:2452-2453`
+FAILs when the SSoT's Active-Backlog reference names a missing file -- this tool
+applies the same existence check to the `## External References` table of every
+ACTIVE Work Log.
+
+For each `.agentcortex/context/work/*.md` log (dotfiles excluded -- both validators
+already exclude the gitignored `.gitkeep.md` placeholder and any other dotfile from
+this directory; see repo-gotchas #14 / backlog #149), this tool parses the
+`## External References` table and WARNs when:
+
+  * a `Spec` or `ADR` row's Path/URL cell names a repo-relative file that does not
+    exist on disk (`—`/blank and `http(s)://` URLs are exempt -- no network call);
+  * a `PR` or `Issue` row's Path/URL cell is present but looks like neither a URL,
+    a `#NNN` GitHub-shorthand reference, nor the `—` placeholder (format-presence
+    only -- this does NOT verify the referenced PR/issue actually exists; that
+    would need a network call and is deliberately out of scope per the backlog row).
+
+SHA header fields (Diff Base SHA / Checkpoint SHA) are already existence-checked
+elsewhere as commits (`git rev-parse --verify`, validate.sh:1338) and are not
+duplicated here.
+
+ADVISORY-ONLY contract (mirrors check_ssot_caps.py / run_python_check /
+Invoke-PythonCheck WARN-tier wiring, ADR-006): this tool ALWAYS exits 0. A missing
+Work Log directory, zero active logs, or a log with no `## External References`
+section are all silent no-ops (capability-by-presence) -- a genuine finding is
+fixed by correcting the Work Log, not by this tool.
+
+Exit codes:
+  0  always (advisory -- never fails the validator). Findings, if any, are printed
+     to stdout as `WARN: ...` lines.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+EXTERNAL_REFS_HEADER_RE = re.compile(r"^##\s+External References\b")
+SECTION_BOUNDARY_RE = re.compile(r"^(##\s|---\s*$)")
+TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
+SEPARATOR_CELL_RE = re.compile(r"^[:\-\s]*$")
+# Only an unambiguous OS-absolute syntax counts as absolute (see _resolve_candidate).
+WINDOWS_ABS_RE = re.compile(r"^[A-Za-z]:[\\/]|^\\\\")
+URL_RE = re.compile(r"^https?://", re.IGNORECASE)
+ISSUE_REF_RE = re.compile(r"#\d+")
+
+PLACEHOLDER_VALUES = {"", "-", "--", "—"}
+EXISTENCE_CHECKED_TYPES = {"spec", "adr"}
+FORMAT_ONLY_TYPES = {"issue", "pr"}
+
+
+def _split_row(line: str) -> list[str] | None:
+    """Split one `| a | b | c |` markdown table line into stripped cells."""
+    m = TABLE_ROW_RE.match(line.rstrip("\n"))
+    if not m:
+        return None
+    return [cell.strip() for cell in m.group(1).split("|")]
+
+
+def _is_separator_row(cells: list[str]) -> bool:
+    return bool(cells) and all(SEPARATOR_CELL_RE.match(c) for c in cells)
+
+
+def find_external_references_rows(lines: list[str]) -> list[list[str]]:
+    """Return data rows (as [Type, Path/URL, ...]) from the External References table.
+
+    Header prefix-matched (`## External References...`) rather than exact-matched:
+    this tool is the SOLE parser invoked by both validators (no sh/ps1 split to
+    diverge, unlike the backlog #140 class of bug), but staying prefix-tolerant of
+    a suffixed heading costs nothing.
+    """
+    rows: list[list[str]] = []
+    in_section = False
+    header_row_seen = False
+    for raw in lines:
+        line = raw.rstrip("\n")
+        if not in_section:
+            if EXTERNAL_REFS_HEADER_RE.match(line):
+                in_section = True
+            continue
+        if SECTION_BOUNDARY_RE.match(line):
+            break
+        cells = _split_row(line)
+        if cells is None:
+            continue
+        if not header_row_seen and cells and cells[0].strip("*` ").lower() == "type":
+            header_row_seen = True
+            continue
+        if _is_separator_row(cells):
+            continue
+        rows.append(cells)
+    return rows
+
+
+def _strip_wrapping(value: str) -> str:
+    v = value.strip()
+    if len(v) >= 2 and v[0] == "`" and v[-1] == "`":
+        v = v[1:-1].strip()
+    return v
+
+
+def _resolve_candidate(root: Path, path_cell: str) -> Path:
+    """Resolve a Path/URL cell to a filesystem path, repo-relative by default.
+
+    Deliberately NOT using Path.is_absolute() to decide: it is platform-dependent
+    (a leading `/` is absolute on POSIX but drive-relative on Windows), which would
+    make the same Work Log cell resolve differently in a Windows-local run vs Linux
+    CI -- the [cross-platform-eol]-class of bug this repo treats as HIGH severity.
+    Only an unambiguous OS-absolute syntax (Windows drive letter or UNC prefix) is
+    treated as absolute; everything else, including a leading slash, is repo-root
+    relative.
+    """
+    if WINDOWS_ABS_RE.match(path_cell):
+        return Path(path_cell)
+    return root / path_cell.lstrip("/\\")
+
+
+def check_log(path: Path, root: Path) -> tuple[list[str], int]:
+    """Return (WARN findings, row_count) for one Work Log's External References."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return ([f"WARN: {path.name} -- could not read External References ({exc})"], 0)
+
+    rows = find_external_references_rows(text.splitlines())
+    findings: list[str] = []
+    for cells in rows:
+        if not cells:
+            continue
+        ref_type_raw = cells[0].strip()
+        ref_type = ref_type_raw.strip("*` ").lower()
+        path_cell = _strip_wrapping(cells[1]) if len(cells) > 1 else ""
+
+        if ref_type in EXISTENCE_CHECKED_TYPES:
+            if path_cell in PLACEHOLDER_VALUES or URL_RE.match(path_cell):
+                continue
+            candidate = _resolve_candidate(root, path_cell)
+            if not candidate.is_file():
+                findings.append(
+                    f"WARN: {path.name} -- External References: {ref_type_raw} path "
+                    f"'{path_cell}' does not exist"
+                )
+        elif ref_type in FORMAT_ONLY_TYPES:
+            if path_cell in PLACEHOLDER_VALUES:
+                continue
+            if URL_RE.match(path_cell) or ISSUE_REF_RE.search(path_cell):
+                continue
+            findings.append(
+                f"WARN: {path.name} -- External References: {ref_type_raw} reference "
+                f"'{path_cell}' is not a URL, #NNN reference, or `—` placeholder "
+                f"(format check only -- referenced-item existence is not verified, "
+                f"no network call)"
+            )
+        # Unknown ref types (future template rows) are ignored -- forward compatible.
+    return (findings, len(rows))
+
+
+def iter_active_worklogs(worklog_dir: Path):
+    if not worklog_dir.is_dir():
+        return
+    for p in sorted(worklog_dir.glob("*.md")):
+        # Dotfile exclusion parity with both validators (bash `*.md` glob does not
+        # match a leading dot; validate.ps1:1114 filters `-notlike '.*'`). Python's
+        # pathlib.glob does NOT exclude dotfiles by default -- explicit filter is
+        # required (confirmed the hard way per the backlog #149 ship record: "the
+        # test's first draft failed on exactly that").
+        if p.name.startswith("."):
+            continue
+        if p.is_file():
+            yield p
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Advisory existence checker for Work Log `## External References` rows. "
+            "Always exits 0; prints WARN lines for Spec/ADR referents that do not "
+            "exist and malformed PR/Issue reference formats."
+        )
+    )
+    ap.add_argument("--root", default=".", help="Repo root (default: cwd)")
+    ap.add_argument(
+        "--worklog-dir",
+        default=None,
+        help="Work Log directory to scan (default: <root>/.agentcortex/context/work)",
+    )
+    return ap.parse_args()
+
+
+def main() -> int:
+    # Force UTF-8 stdout so `—`/`§` survive a cp950 Windows console (mirrors
+    # check_ssot_caps.py / check_decision_disposition.py).
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
+    args = parse_args()
+    root = Path(args.root).resolve()
+    worklog_dir = (
+        Path(args.worklog_dir) if args.worklog_dir else root / ".agentcortex/context/work"
+    )
+
+    logs = list(iter_active_worklogs(worklog_dir))
+    if not logs:
+        return 0  # capability-by-presence: no active logs to check
+
+    all_findings: list[str] = []
+    total_rows = 0
+    for log in logs:
+        findings, row_count = check_log(log, root)
+        all_findings.extend(findings)
+        total_rows += row_count
+
+    if all_findings:
+        for f in all_findings:
+            print(f)
+    else:
+        print(
+            f"worklog external references OK -- {len(logs)} log(s), "
+            f"{total_rows} row(s) checked."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agentcortex/tools/check_worklog_references.py
+++ b/.agentcortex/tools/check_worklog_references.py
@@ -35,6 +35,16 @@ fixed by correcting the Work Log, not by this tool.
 Exit codes:
   0  always (advisory -- never fails the validator). Findings, if any, are printed
      to stdout as `WARN: ...` lines.
+
+Nested-advisory contract (external-review clarification): run_python_check /
+Invoke-PythonCheck map tool exit codes 0->PASS and nonzero->FAIL only -- the seam
+has NO WARN exit mapping (validate.sh:192-196), so findings from this tool appear
+as indented `WARN:` lines under a `[PASS] ... advisory` wrapper line and do NOT
+increment the summary's warn count. The counted-WARN lines in the summary all come
+from grandfathered native `record_result WARN` sites (e.g. governance eval
+coverage, validate.sh:~2853). Promoting seam-check findings into counted WARNs is
+the WARN-taxonomy design decision tracked as backlog #103(d) -- deliberately not
+decided unilaterally here.
 """
 
 from __future__ import annotations
@@ -77,12 +87,24 @@ def find_external_references_rows(lines: list[str]) -> list[list[str]]:
     this tool is the SOLE parser invoked by both validators (no sh/ps1 split to
     diverge, unlike the backlog #140 class of bug), but staying prefix-tolerant of
     a suffixed heading costs nothing.
+
+    Fence-aware (external-review fix, backlog #156 decoy family): lines inside
+    ``` / ~~~ fenced blocks are invisible — a fenced example containing the
+    heading cannot open (or shadow) the section, and fenced example tables are
+    never scanned as live rows. Fence markers toggle regardless of info string.
     """
     rows: list[list[str]] = []
     in_section = False
+    in_fence = False
     header_row_seen = False
     for raw in lines:
         line = raw.rstrip("\n")
+        stripped = line.lstrip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
         if not in_section:
             if EXTERNAL_REFS_HEADER_RE.match(line):
                 in_section = True


### PR DESCRIPTION
## What

Backlog **#161** (audit finding F7): Work Log `## External References` referents were never checked — a probe log citing a nonexistent spec file and a nonexistent PR passed both validators untouched (the section appears zero times in either validator; only SHA fields were value-checked).

New **WARN-tier** check, ADR-006-compliant:

- `.agentcortex/tools/check_worklog_references.py` (236 lines, dependency-free, always exits 0): for each active work log (dotfiles excluded, matching both validators' convention), Spec/ADR rows with repo-relative paths are existence-checked; PR/Issue rows get a **format-only** check (URL / `#NNN` / `—`) with an explicit no-network note in the message.
- Wired into both validators **only** through the existing `run_python_check` / `Invoke-PythonCheck` seam, label-parity'd: `worklog external references (spec/ADR existence)`. **Zero new native `record_result`/`Add-Result` sites** — the ADR-006 ratchet test passes unmoved.
- **Source/CI-only**: deliberately not added to `deploy.sh` whitelists or the manifest golden, mirroring the #137/`check_routing_actions` precedent (downstream promotion is its own tracked decision). The deploy-manifest test passes precisely because of this.

## Adopter delta (source repo / CI)

A work log citing a moved or never-created spec now draws a WARN naming the log and path, instead of sailing through. Downstream deployed validators are unchanged (`tool not present` skip, consistent with the existing source-only tool family).

## Evidence

- 21 new tests (`test_worklog_references_check.py`): red rows (nonexistent spec/ADR path → WARN; malformed issue ref → format WARN), green rows (valid path, `—`, URL, `#NNN` all silent), always-exit-0, dotfile exclusion. All passed.
- `test_validator_native_check_ratchet.py`: 5 passed (native counts unmoved). `test_deploy_tiering -k manifest`: 2 passed. `tests/guard/`: 332 passed. `.agentcortex/tests/`: 227 passed.
- Both validators, foreground, after the final Work Log write: **`pass=118 warn=3 fail=0 skip=2`** each, with the identical new line `[PASS] worklog external references (spec/ADR existence)` — sh/ps1 parity confirmed; the agent's own work log passes its own check honestly.
- Diff: 4 files, +510/−0 (tool 236 + tests 259 + validate.sh 9 + validate.ps1 6).

## Reviewer guidance

- The load-bearing constraints are the three **zeros**: zero new native check sites (ratchet), zero deploy-manifest movement, zero non-seam validator changes — each is test-pinned; check the pins rather than the prose.
- WARN-tier means always exit 0 — confirm no code path can flip the validators' exit code.
- Table parsing is intentionally conservative (unparseable tables are skipped silently rather than guessed at) — flag if any WARN path could false-positive on the template's placeholder rows (`—`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
