### PR TITLE
chore(ship): guard receipts for the #392 SSoT write (follow-up)

### DIFF
--- a/.agentcortex/context/.guard_receipt.json
+++ b/.agentcortex/context/.guard_receipt.json
@@ -1,7 +1,7 @@
 {
-  "expected_sha": "7587ab8cf05425cf62c31dfed74a9b6668b5a8146b97e8b68b61469a882f5333",
+  "expected_sha": "587aaf4e21d59b1a5e7d8a2ae3115b09bb29126b53bcb98f544cb8f7f981a969",
   "mode": "replace",
-  "new_sha": "8fbe1b1a9e39785ff3beebe81a0c7b6e330abb54d71feb64f98bf9be7ca68557",
+  "new_sha": "1ac430d402784dbe1494cfaca39d29e1f6b5338d0b25f4c40214b6ce66ef8d73",
   "target": ".agentcortex/context/current_state.md",
-  "timestamp": 1785310947
+  "timestamp": 1786185392
 }

--- a/.agentcortex/context/.guard_receipts/337ffd90d88a8b4f.json
+++ b/.agentcortex/context/.guard_receipts/337ffd90d88a8b4f.json
@@ -1,7 +1,7 @@
 {
-  "expected_sha": "7587ab8cf05425cf62c31dfed74a9b6668b5a8146b97e8b68b61469a882f5333",
+  "expected_sha": "587aaf4e21d59b1a5e7d8a2ae3115b09bb29126b53bcb98f544cb8f7f981a969",
   "mode": "replace",
-  "new_sha": "8fbe1b1a9e39785ff3beebe81a0c7b6e330abb54d71feb64f98bf9be7ca68557",
+  "new_sha": "1ac430d402784dbe1494cfaca39d29e1f6b5338d0b25f4c40214b6ce66ef8d73",
   "target": ".agentcortex/context/current_state.md",
-  "timestamp": 1785310947
+  "timestamp": 1786185392
 }


### PR DESCRIPTION
tiny-fix follow-up: the #392 guarded SSoT write's receipt mirror files, which ship records routinely commit (72ab8ef precedent) and #392 omitted. 2 files, no semantic change. Verification: git diff shows only the receipt JSON payloads for the seq-144 write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)