### PR TITLE
fix(windows-deploy): reject a bash launcher that cannot run deploy.sh

### DIFF
--- a/.agentcortex/bin/deploy.ps1
+++ b/.agentcortex/bin/deploy.ps1
@@ -38,6 +38,13 @@ function Resolve-BashLauncher {
     $bashCmd = Get-Command bash -ErrorAction SilentlyContinue
     if ($bashCmd) { $candidates += $bashCmd.Source }
 
+    # `bash --version` proves only that a bash binary exists, not that it can run
+    # deploy.sh. A bare <git>\usr\bin\bash.exe answers --version with exit 0 while
+    # carrying no /usr/bin on PATH, so the script dies at `dirname` (line 4) with
+    # exit 127 and never writes a manifest. Probe the utilities deploy.sh actually
+    # needs so an unusable candidate falls through to the next one.
+    $probe = 'command -v dirname >/dev/null 2>&1 && command -v mktemp >/dev/null 2>&1'
+
     foreach ($candidate in $candidates | Select-Object -Unique) {
         if (-not (Test-Path -Path $candidate -PathType Leaf)) {
             continue
@@ -45,8 +52,16 @@ function Resolve-BashLauncher {
         if ($candidate -like '*\WindowsApps\bash.exe') {
             continue
         }
-        & $candidate --version *> $null
-        if ($LASTEXITCODE -eq 0) {
+        $usable = $false
+        try {
+            & $candidate -c $probe *> $null
+            $usable = ($LASTEXITCODE -eq 0)
+        } catch {
+            # A broken app-execution alias can fail at process start. Skip this
+            # candidate instead of aborting the whole search.
+            $usable = $false
+        }
+        if ($usable) {
             return $candidate
         }
     }
@@ -71,6 +86,8 @@ if (-not $bashLauncher) {
     Write-Host '[ERROR] Bash is required for deployment.' -ForegroundColor Red
     Write-Host ''
     Write-Host 'Agentic OS deploy uses a bash script under the hood.'
+    Write-Host 'A bash that cannot resolve dirname/mktemp is skipped on purpose:'
+    Write-Host 'the script needs a Git Bash tool environment, not just a bash binary.'
     Write-Host 'Install one of the following to get bash on Windows:'
     Write-Host ''
     Write-Host '  1. Git for Windows (recommended): https://gitforwindows.org/'

--- a/.agentcortex/tests/test_ssot_completeness.py
+++ b/.agentcortex/tests/test_ssot_completeness.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+from unittest import mock
 
 import pytest
 from pathlib import Path
@@ -19,29 +20,54 @@ def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(args, cwd=cwd, capture_output=True, text=True, encoding="utf-8", errors="replace", check=False)
 
 
-def has_bash_launcher() -> bool:
-    candidates: list[str] = []
-    if shutil.which("bash"):
-        candidates.append(shutil.which("bash") or "")
-    candidates.extend(
-        [
-            "C:/Program Files/Git/bin/bash.exe",
-            "C:/Program Files/Git/usr/bin/bash.exe",
-            "C:/Program Files (x86)/Git/bin/bash.exe",
-        ]
-    )
-    for candidate in candidates:
-        if not candidate or not Path(candidate).is_file():
-            continue
-        probe = subprocess.run(
-            [candidate, "--version"],
-            cwd=ROOT,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            check=False,
+# The utilities the shipped shell scripts need at startup (deploy.sh calls
+# `dirname` on line 4 and `mktemp` on line 549). Mirrors the acceptance probe in
+# .agentcortex/bin/deploy.ps1 — see has_bash_launcher for why --version is not
+# a sufficient test.
+BASH_LAUNCHER_PROBE = "command -v dirname >/dev/null 2>&1 && command -v mktemp >/dev/null 2>&1"
+
+
+def has_bash_launcher(candidates: list[str] | None = None) -> bool:
+    """True when a bash that can actually run the shipped shell scripts exists.
+
+    Two candidate classes answer `bash --version` with exit 0 yet cannot run
+    deploy.sh: a WindowsApps `bash.exe` (a WSL placeholder when no distro is
+    installed) and a bare `<git>/usr/bin/bash.exe` (no /usr/bin on PATH, so
+    `dirname` and `mktemp` do not resolve). A broken app-execution alias can also
+    fail at process start, raising OSError. This function is evaluated at import
+    time by `skipUnless` decorators here and in test_backlog_validation.py, so an
+    uncaught raise aborts collection for both modules instead of skipping one
+    candidate.
+    """
+    if candidates is None:
+        candidates = []
+        which_bash = shutil.which("bash")
+        if which_bash:
+            candidates.append(which_bash)
+        candidates.extend(
+            [
+                "C:/Program Files/Git/bin/bash.exe",
+                "C:/Program Files/Git/usr/bin/bash.exe",
+                "C:/Program Files (x86)/Git/bin/bash.exe",
+            ]
         )
+    for candidate in candidates:
+        if not candidate or "WindowsApps" in candidate:
+            continue
+        if not Path(candidate).is_file():
+            continue
+        try:
+            probe = subprocess.run(
+                [candidate, "-c", BASH_LAUNCHER_PROBE],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                check=False,
+            )
+        except OSError:
+            continue
         if probe.returncode == 0:
             return True
     return False
@@ -367,6 +393,60 @@ class SSOTCompletenessTests(unittest.TestCase):
 
             validate = run_validate(target)
             self.assertEqual(validate.returncode, 0, validate.stderr or validate.stdout)
+
+
+class BashLauncherProbeTests(unittest.TestCase):
+    """has_bash_launcher is evaluated at import time by skipUnless decorators in
+    this module and in test_backlog_validation.py. A candidate that cannot be
+    started, or that starts but cannot run the shipped scripts, must be skipped
+    — never propagated as a collection error, never accepted."""
+
+    @staticmethod
+    def _touch(directory: str, name: str) -> str:
+        path = Path(directory) / name
+        path.write_bytes(b"")
+        return str(path)
+
+    def test_process_start_failure_falls_through_to_next_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            broken = self._touch(tmpdir, "broken-alias.exe")
+            usable = self._touch(tmpdir, "real-bash.exe")
+            probed: list[str] = []
+
+            def fake_run(args, **kwargs):  # noqa: ANN001, ANN003 - test double
+                probed.append(args[0])
+                if args[0] == broken:
+                    # The WindowsApps alias signature: OSError at process start.
+                    raise OSError(1312, "A specified logon session does not exist")
+                return subprocess.CompletedProcess(args, 0, "", "")
+
+            with mock.patch.object(subprocess, "run", side_effect=fake_run):
+                self.assertTrue(has_bash_launcher([broken, usable]))
+            self.assertEqual(probed, [broken, usable], "search must continue past the raising candidate")
+
+    def test_windowsapps_alias_is_never_started(self) -> None:
+        alias = "C:/Users/x/AppData/Local/Microsoft/WindowsApps/bash.exe"
+        with mock.patch.object(subprocess, "run") as runner:
+            self.assertFalse(has_bash_launcher([alias]))
+        runner.assert_not_called()
+
+    def test_launcher_without_coreutils_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bare = self._touch(tmpdir, "bare-bash.exe")
+            probes: list[list[str]] = []
+
+            def fake_run(args, **kwargs):  # noqa: ANN001, ANN003 - test double
+                probes.append(list(args))
+                # A bare <git>/usr/bin/bash.exe: bash runs, coreutils do not.
+                return subprocess.CompletedProcess(args, 127, "", "dirname: command not found")
+
+            with mock.patch.object(subprocess, "run", side_effect=fake_run):
+                self.assertFalse(has_bash_launcher([bare]))
+            self.assertEqual(probes, [[bare, "-c", BASH_LAUNCHER_PROBE]])
+
+    def test_all_candidates_failing_returns_false(self) -> None:
+        self.assertFalse(has_bash_launcher([]))
+        self.assertFalse(has_bash_launcher(["", "C:/nonexistent/bash.exe"]))
 
 
 if __name__ == "__main__":

--- a/docs/reviews/2026-08-13-govern-audit-drift-core-health.md
+++ b/docs/reviews/2026-08-13-govern-audit-drift-core-health.md
@@ -1,0 +1,238 @@
+# Governance Audit Handoff — Drift and Core Health (2026-08-13)
+
+## Executive verdict
+
+**HEALTHY WITH ONE CONFIRMED CORE WINDOWS DEFECT AND LOCALIZED DRIFT.**
+
+The repository is not broadly unhealthy: local `HEAD`, `origin/main`, the remote
+`refs/heads/main`, and tag `v1.8.20` all resolve to
+`3faae10b801d001e82c7883d9145ade33c4e9813`; ADR/spec indexes, version surfaces,
+the audit chain, and the PowerShell structural validator are internally
+consistent. The latest validator run reported `118 PASS / 4 WARN / 0 FAIL /
+2 SKIP`.
+
+That validator result is a positive signal, not a complete health proof. Its
+PASS count changes with gitignored active Work Logs, and the Windows test suite
+currently cannot complete on this machine. Direct behavioral probes confirmed
+that the PowerShell deployment entry point fails in this supported Windows
+environment. Therefore the accurate top-line is not "all green"; it is
+"governance structure intact, Windows deployment path broken, plus two smaller
+state-contract drifts."
+
+Method: read-only governance audit plus a three-seat roundtable (core health,
+state/document drift, adversarial tenth-man). All subagent claims were treated
+as hypotheses and rechecked against the real code path. External-signal status:
+`same-vendor-only`; architecture conclusions should receive independent human
+or different-vendor review before implementation is accepted.
+
+## Baseline
+
+| Check | Result |
+|---|---|
+| `git rev-list --left-right --count origin/main...HEAD` | `0  0` |
+| `git ls-remote origin refs/heads/main refs/tags/v1.8.20` | both `3faae10...` |
+| `.agentcortex/bin/validate.ps1` | `118 PASS / 4 WARN / 0 FAIL / 2 SKIP` |
+| Active backlog | 64 `Pending`, 0 `In Progress` |
+| Worktree | one pre-existing local diff: `.claude/settings.local.json` |
+| Full pytest | not completed; two independently reproducible Windows launcher failures below |
+
+The four validator warning groups are understood: one stale pending
+`routing_actions` snapshot already tracked by backlog #103, one stale local Work
+Log lock, historical archived receipt debt, and the 28-section eval-coverage
+advisory already tracked by #143. They do not establish a new system-wide
+failure.
+
+## Verified findings
+
+### F1 — HIGH — The supported PowerShell deployment entry point fails on Windows
+
+This is the only new finding that changes the core-health verdict.
+
+`Resolve-BashLauncher` selects a real Git Bash executable, but the wrapper then
+invokes the canonical shell script and forwards a native Windows target without
+establishing a reliable Git-for-Windows execution environment or translating
+the target (`.agentcortex/bin/deploy.ps1:14-50,85`). Two real entry-point probes
+failed in different manifestations:
+
+1. Direct wrapper run to a newly created `%TEMP%` directory returned exit 1,
+   created no `.agentcortex-manifest`, and attempted
+   `mkdir 'C:\\Users/wen'` from the repository because the Windows target was
+   consumed as a shell-relative path.
+2. The repository's own behavioral test
+   `tests/ci/test_deploy_tiering.py::test_deploy_ps1_entrypoint_resolves_real_bash`
+   returned exit 127 because the selected `Git\\bin\\bash.exe` process could not
+   resolve `dirname` or `mktemp`.
+
+The roundtable initially disagreed: the core-health seat called this an
+environment false alarm, while the tenth-man called it a core entry-point
+failure. The primary probe of the actual wrapper and the repository's own
+behavioral test resolve the dispute in favor of the tenth-man. Reading only the
+test's `os.name == 'nt'` branch was insufficient; executing that branch fails.
+
+Impact: a documented Windows deployment path can fail before producing a
+manifest. This is a core portability defect, even though Linux CI and
+`validate.ps1` remain healthy.
+
+Claude direction: treat as a `hotfix`, not a documentation tweak. Reproduce
+first, then make one canonical launcher/path-conversion design shared by
+`.agentcortex/bin/deploy.ps1` and `installers/deploy_brain.ps1`. Preserve spaces
+and Unicode in paths. Add discriminating Windows tests for: a native absolute
+target, a target containing spaces, a broken WindowsApps alias before a valid
+Git Bash candidate, and availability of required Unix utilities. Do not merely
+switch from `bin\\bash.exe` to `usr\\bin\\bash.exe` without proving target-path
+translation and both entry points.
+
+### F2 — MEDIUM — Bash availability probing can abort pytest collection
+
+`.agentcortex/tests/test_ssot_completeness.py:22-47` treats the first existing
+`bash` candidate as safely startable. On this machine `shutil.which("bash")`
+returns the WindowsApps WSL alias. `subprocess.run()` raises `OSError [WinError
+1312]`; the exception is uncaught, so module import and collection abort before
+the later valid Git Bash candidates can be tried. The same helper is imported
+by `test_backlog_validation.py`.
+
+Reproduction:
+
+```text
+python -m pytest .agentcortex/tests/test_ssot_completeness.py --collect-only -q -p no:cacheprovider
+ERROR at test_ssot_completeness.py:36 — OSError [WinError 1312]
+```
+
+This is not proof that hundreds of tests regressed; it is one shared launcher
+failure that prevents the suite from discovering them. It is nevertheless a
+real test-startability defect and masks other regressions.
+
+Claude direction: after F1 establishes the canonical launcher behavior, make
+the probe reject WindowsApps aliases, catch `OSError`, continue to the next
+candidate, and return false only after all candidates fail. Add a unit test
+where candidate 1 raises and candidate 2 succeeds. Avoid a broad test-helper
+refactor unless duplicate behavior is first inventoried and covered.
+
+### F3 — MEDIUM — A file declared user-local is tracked as project state
+
+`.claude/settings.json:2` says user-local permissions live in
+`settings.local.json`, but `.claude/settings.local.json` is tracked and absent
+from `.gitignore`. Its current diff adds local `gh issue`/`gh pr` permissions.
+At least five archived Work Logs explicitly exclude this same file as local
+permission noise, demonstrating repeated operational cost rather than a
+one-off dirty tree.
+
+This is a contract drift: Git behavior says shared project artifact while the
+canonical comment and repeated workflow behavior say local-only.
+
+Claude direction: this requires an owner-confirmed migration. Preferred shape:
+ignore `.claude/settings.local.json`, move any intentional seed to a clearly
+named example, and stop tracking the local file without deleting the operator's
+working copy. Document how existing contributors retain their permissions.
+Do not rewrite history; do not silently remove local permissions during pull.
+
+### F4 — LOW — The SSoT embeds a stale volatile backlog count
+
+`.agentcortex/context/current_state.md:30` says `59 Pending as of 2026-08-09`,
+while strict row parsing of `docs/specs/_product-backlog.md` yields 64 Pending.
+The SSoT was updated on 2026-08-12, so the old count survived later state writes.
+The validator correctly checks the canonical backlog path but does not validate
+this prose number.
+
+This is document drift, not runtime corruption: the backlog remains canonical
+and structurally valid.
+
+Claude direction: prefer deleting the volatile count and linking only to the
+canonical backlog. If the owner wants a dashboard count in SSoT, generate and
+machine-check it; do not continue manual carry-forward.
+
+## Known findings excluded from new scope
+
+- Backlog #103 owns the four stale `routing_actions` in the 2026-07-01
+  premortem. The current 43-day warning is expected pressure, not a new finding.
+- #121 remains genuinely Pending. README contains earlier partial material, but
+  still lacks the requested enforced/wire-up/advisory matrix, ACX/gate-block
+  FAQ, and Traditional Chinese caveat parity. Do not close it by inference.
+- #143 owns tier-blind governance eval coverage (`28` uncovered MUST-bearing
+  sections).
+- #148 owns the latent hyphenated-verdict parser fail-open; the canonical
+  `NOT READY` spelling is verified to fail progression correctly.
+- #169 owns the higher-priority decision-disposition fail-open for noncanonical
+  bullet-form Decisions. It remains the highest known localized governance
+  correctness debt.
+- #170 is the owner's PII disposition decision; this audit does not recommend a
+  destructive history rewrite.
+- #171 owns the TruffleHog Lob-detector false-positive class.
+- `.agentcortex/context/work/chore-archive-codex-review-log.{md,lock.json}` is a
+  real stale local residue, but `_product-backlog.md` already records it as a
+  reviewer adherence/setup gap under an existing rule. Archive or remove the
+  local residue through the normal chain-aware workflow; do not add machinery.
+
+## Roundtable and tenth-man adjudication
+
+| Candidate | Final verdict | Reason |
+|---|---|---|
+| Repository broadly unhealthy | Refuted | Core indexes, chain, versions, refs, and PowerShell validator are consistent. |
+| `118 PASS / 4 WARN` proves full health | Refuted | PASS count is active-log-sensitive; full tests did not complete; behavioral deployment probe fails. |
+| Windows PowerShell deploy defect | Confirmed after dispute | Actual wrapper and its own behavioral test both fail. |
+| Windows pytest probe defect | Confirmed | Import-time `OSError` is reproducible and blocks collection. |
+| Tracked `settings.local.json` is drift | Confirmed | Local-only declaration conflicts with Git tracking and repeated operational handling. |
+| `59` vs `64` means core corruption | Narrowed | Real stale prose; canonical backlog remains correct. |
+| Stale Work Log is a new product defect | Refuted | Known adherence residue with an existing rule and recorded disposition. |
+| Remote main is ahead of local | Refuted | `ls-remote` and all local refs agree on `3faae10...`; webpage commit counts are not ref evidence. |
+| Backlog #121 is already implemented | Refuted | Existing README content predates the row and does not satisfy its remaining deltas. |
+
+## Recommended execution order for Claude
+
+1. **Hotfix F1 + F2 as one Windows startability unit.** F1 is the required red
+   test; F2 prevents the suite from honestly exercising it. Run the focused
+   PowerShell deploy test, collection regression, both validators, then the CI
+   structural suite on Windows. Keep this separate from documentation cleanup.
+2. **Fix known #169 next.** It is a real localized fail-open with an existing
+   fixture shape and higher governance correctness value than cosmetic drift.
+3. **Resolve F3 only after the owner selects the migration behavior.** No
+   history rewrite.
+4. **Remove F4's volatile count** as a separate governance quick-win, using the
+   guarded SSoT write path.
+5. Continue existing product priority #121 after correctness work, unless the
+   owner deliberately prioritizes adoption conversion over P2 hardening.
+
+Owner decisions required before implementation:
+
+- F3: retain a tracked example or have no seed file; confirm contributor
+  migration wording.
+- #170: accept and close the already-public email copies (recommended) or
+  authorize a repository-history rewrite with full audit-chain consequences.
+- #171: exclude the Lob detector and document the workaround, tolerate the
+  false-positive class, or pursue upstream correction.
+
+## Claude pickup prompt
+
+```text
+Read docs/reviews/2026-08-13-govern-audit-drift-core-health.md in full.
+Start a new classified work unit for F1+F2 only. Treat F1 as a Windows deploy
+hotfix, reproduce both recorded failures before editing, and preserve the
+pre-existing .claude/settings.local.json diff. Use the repository's normal
+bootstrap/plan/implement/review/test flow; do not mark the audit routing_actions
+merged until the corresponding Domain Log receives the verified decision.
+Do not implement F3 until the owner selects the migration behavior. Keep F4,
+#121, #169, #170, and #171 as separate work units; do not opportunistically
+bundle them into the Windows patch.
+```
+
+## routing_actions
+
+```yaml
+routing_actions:
+  - finding: "The Windows PowerShell deployment entry points must invoke Git Bash with a usable tool environment and lossless native-target path conversion."
+    target_doc: "docs/architecture/tooling.log.md"
+    status: pending
+    owner: "claude-handoff"
+  - finding: "Windows shell availability probes must reject unusable aliases and continue after process-start errors instead of aborting pytest collection."
+    target_doc: "docs/architecture/testing.log.md"
+    status: pending
+    owner: "claude-handoff"
+  - finding: "Claude user-local permission state must not remain ambiguously tracked as shared project configuration."
+    target_doc: "docs/architecture/governance.log.md"
+    status: pending
+    owner: "claude-handoff"
+  - finding: "SSoT summaries should not manually duplicate volatile backlog counts without a freshness check."
+    target_doc: "docs/architecture/document-governance.log.md"
+    status: pending
+    owner: "claude-handoff"
+```

--- a/installers/deploy_brain.ps1
+++ b/installers/deploy_brain.ps1
@@ -44,11 +44,24 @@ function Resolve-BashLauncher {
     $bashCmd = Get-Command bash -ErrorAction SilentlyContinue
     if ($bashCmd) { $candidates += $bashCmd.Source }
 
+    # 4. Acceptance probe. `bash --version` proves only that a bash binary exists:
+    # a bare ($gitRoot)\usr\bin\bash.exe answers it with exit 0 while carrying no
+    # /usr/bin on PATH, so deploy.sh dies at `dirname` (line 4) with exit 127 and
+    # writes no manifest. Probe the utilities the script actually needs, and treat
+    # a process-start failure as an unusable candidate rather than aborting.
+    $probe = 'command -v dirname >/dev/null 2>&1 && command -v mktemp >/dev/null 2>&1'
+
     foreach ($candidate in $candidates | Select-Object -Unique) {
         if (-not (Test-Path -Path $candidate -PathType Leaf)) { continue }
         if ($candidate -like '*\WindowsApps\bash.exe') { continue }
-        & $candidate --version *> $null
-        if ($LASTEXITCODE -eq 0) { return $candidate }
+        $usable = $false
+        try {
+            & $candidate -c $probe *> $null
+            $usable = ($LASTEXITCODE -eq 0)
+        } catch {
+            $usable = $false
+        }
+        if ($usable) { return $candidate }
     }
 
     return $null
@@ -69,6 +82,8 @@ if (-not $bashLauncher) {
     Write-Host '[ERROR] Bash is required for deployment.' -ForegroundColor Red
     Write-Host ''
     Write-Host 'Agentic OS deploy uses a bash script under the hood.'
+    Write-Host 'A bash that cannot resolve dirname/mktemp is skipped on purpose:'
+    Write-Host 'the script needs a Git Bash tool environment, not just a bash binary.'
     Write-Host 'Install one of the following to get bash on Windows:'
     Write-Host ''
     Write-Host '  1. Git for Windows (recommended): https://gitforwindows.org/'

--- a/tests/ci/test_bash_resolver_parity.py
+++ b/tests/ci/test_bash_resolver_parity.py
@@ -1,0 +1,60 @@
+"""Ratchet: every test module that resolves a bash launcher must reject the
+WindowsApps WSL placeholder.
+
+On Windows, PATH commonly exposes `%LOCALAPPDATA%\\Microsoft\\WindowsApps\\bash.exe`.
+It answers `shutil.which("bash")` and it starts, but with no distro installed it
+prints `wsl --install <Distro>` and exits 1 — so any test that hands it a shipped
+`.sh` script fails for a reason that has nothing to do with the code under test.
+
+Eleven of the twelve bash-using modules already carried the guard. The twelfth
+(`test_validator_worklog_family_skip.py`) did not, and its recurring Windows red
+was written off across more than one ship as a local environment artifact rather
+than as the missing guard it was. This test exists so the population cannot drift
+back apart silently.
+
+Scope note: the guard checked here is the WindowsApps exclusion. The candidate
+lists also list `<git>/usr/bin/bash.exe`, which starts fine but resolves no
+coreutils; that is a latent second hazard, live only on a Git layout with no
+`bin/bash.exe`, and is deliberately not widened into this ratchet.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCAN_DIRS = (ROOT / "tests", ROOT / ".agentcortex" / "tests")
+
+# Population size at the time this ratchet was written. The floor is an
+# anti-vacuity guard: a broken glob would otherwise scan nothing and pass.
+KNOWN_POPULATION_FLOOR = 10
+
+
+def _modules_resolving_bash() -> list[tuple[Path, str]]:
+    found: list[tuple[Path, str]] = []
+    for base in SCAN_DIRS:
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("test_*.py")):
+            text = path.read_text(encoding="utf-8")
+            if 'which("bash")' in text:
+                found.append((path, text))
+    return found
+
+
+def test_every_bash_resolving_test_module_rejects_the_windowsapps_alias() -> None:
+    modules = _modules_resolving_bash()
+    assert len(modules) >= KNOWN_POPULATION_FLOOR, (
+        f"scan reached only {len(modules)} modules under {[str(d) for d in SCAN_DIRS]} — "
+        "the glob is wrong, so a pass here would prove nothing"
+    )
+
+    unguarded = [
+        str(path.relative_to(ROOT)).replace("\\", "/")
+        for path, text in modules
+        if "WindowsApps" not in text
+    ]
+    assert not unguarded, (
+        "these test modules resolve bash without excluding the WindowsApps WSL "
+        f"placeholder, so they go red on Windows for the wrong reason: {unguarded}"
+    )

--- a/tests/ci/test_deploy_tiering.py
+++ b/tests/ci/test_deploy_tiering.py
@@ -115,7 +115,7 @@ def _deploy_dry_run(target: Path) -> subprocess.CompletedProcess:
     )
 
 
-def _deploy_ps1(target: Path) -> subprocess.CompletedProcess:
+def _deploy_ps1(target: Path, env: dict | None = None) -> subprocess.CompletedProcess:
     return subprocess.run(
         [
             powershell,
@@ -126,7 +126,7 @@ def _deploy_ps1(target: Path) -> subprocess.CompletedProcess:
             str(target),
         ],
         capture_output=True, text=True, encoding="utf-8", errors="replace",
-        cwd=str(ROOT),
+        cwd=str(ROOT), env={**os.environ, **env} if env else None,
     )
 
 
@@ -444,6 +444,89 @@ def test_deploy_ps1_entrypoint_resolves_real_bash() -> None:
         assert stub_ids == canonical_ids
         assert metadata_ids == canonical_ids
         assert all(path.read_bytes().startswith(b"---\n") for path in skill_files)
+
+
+@requires_powershell
+def test_deploy_ps1_rejects_a_bash_that_cannot_run_deploy_sh() -> None:
+    """`bash --version` does not prove a candidate can run deploy.sh.
+
+    A bare `<git>/usr/bin/bash.exe` answers --version with exit 0 but resolves no
+    coreutils, so deploy.sh dies at `dirname` (line 4) with exit 127 and writes no
+    manifest. Resolve-BashLauncher lists that path second, so any Git layout
+    without `bin/bash.exe` selects it. Build a Git-shaped root whose ONLY bash is
+    the bare one, put its `cmd` directory first on PATH so the resolver derives it
+    ahead of the static fallbacks, and assert the wrapper still deploys — i.e. it
+    rejected the unusable candidate and fell through instead of selecting it.
+
+    Red before the fix: exit 127, no manifest.
+    """
+    bare = Path(r"C:\Program Files\Git\usr\bin\bash.exe")
+    good = Path(r"C:\Program Files\Git\bin\bash.exe")
+    if not bare.is_file() or not good.is_file():
+        pytest.skip("standard Git for Windows layout required")
+
+    # Premise: the bare launcher really is unusable for the shipped scripts.
+    premise = subprocess.run(
+        [str(bare), "-c", "command -v dirname"],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    if premise.returncode == 0:
+        pytest.skip("this Git build resolves coreutils from usr/bin/bash — hazard absent")
+
+    with tempfile.TemporaryDirectory() as td:
+        fake_root = Path(td) / "FakeGit"
+        (fake_root / "cmd").mkdir(parents=True)
+        (fake_root / "usr").mkdir()
+        # A junction, not a copy: the bare bash needs its sibling msys DLLs to run
+        # at all, and `<fake>/bin/bash.exe` must stay absent so the resolver falls
+        # to the usr/bin candidate.
+        junction = fake_root / "usr" / "bin"
+        subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(junction), str(bare.parent)],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+        )
+        try:
+            if not (junction / "bash.exe").is_file():
+                pytest.skip("could not create a directory junction to build the fake Git root")
+            # Get-Command git must resolve INTO the fake root so $gitRoot derives from it.
+            (fake_root / "cmd" / "git.cmd").write_bytes(
+                b'@echo off\r\n"%ProgramFiles%\\Git\\cmd\\git.exe" %*\r\n'
+            )
+
+            target = Path(td) / "proj"
+            target.mkdir()
+            result = _deploy_ps1(target, env={"PATH": f"{fake_root / 'cmd'}{os.pathsep}{os.environ['PATH']}"})
+
+            assert result.returncode == 0, (
+                "deploy.ps1 selected a bash that cannot run deploy.sh\n"
+                f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+            )
+            assert (target / ".agentcortex-manifest").exists(), "no manifest — the unusable candidate was used"
+        finally:
+            # Drop the reparse point BEFORE TemporaryDirectory cleanup. A recursive
+            # delete that follows the junction would wipe the real Git usr/bin;
+            # os.path.islink() reports False for junctions, and only Python >=3.12
+            # shutil.rmtree recognises them, so this cannot be left to the runtime.
+            # os.rmdir removes the junction itself and never touches its target.
+            if junction.is_dir():
+                os.rmdir(junction)
+
+
+def test_both_powershell_entrypoints_share_the_launcher_acceptance_probe() -> None:
+    """`installers/deploy_brain.ps1` carries its own copy of Resolve-BashLauncher.
+    The e2e test above can only exercise `.agentcortex/bin/deploy.ps1`, so fixing
+    one copy and leaving the other is a silent regression. Pin both to the same
+    acceptance probe."""
+    probe = "command -v dirname >/dev/null 2>&1 && command -v mktemp >/dev/null 2>&1"
+    for entrypoint in (
+        ROOT / ".agentcortex" / "bin" / "deploy.ps1",
+        ROOT / "installers" / "deploy_brain.ps1",
+    ):
+        text = entrypoint.read_text(encoding="utf-8")
+        assert probe in text, f"{entrypoint.name}: launcher acceptance probe missing"
+        assert "& $candidate --version" not in text, (
+            f"{entrypoint.name}: `bash --version` accepts a launcher that cannot run deploy.sh"
+        )
 
 
 @requires_bash

--- a/tests/ci/test_validator_worklog_family_skip.py
+++ b/tests/ci/test_validator_worklog_family_skip.py
@@ -36,7 +36,24 @@ DEPLOY_SH = ROOT / ".agentcortex" / "bin" / "deploy.sh"
 # is a parity bug, and the assertion below is what catches it.
 SKIP_MARKER = "active work-log checks -- no active work logs"
 
-bash = shutil.which("bash")
+# Prefer a real Git Bash over PATH `bash`: on Windows, PATH commonly exposes the
+# WindowsApps WSL placeholder, which answers `which` but cannot run deploy.sh —
+# it prints "wsl --install <Distro>" and exits 1. This module was the only one of
+# the twelve bash-using test modules without the guard, and the resulting red was
+# repeatedly written off as a local environment artifact.
+git_path = shutil.which("git")
+git_root = Path(git_path).parent.parent if git_path else None
+bash_candidates = [
+    str(git_root / "bin" / "bash.exe") if git_root else None,
+    str(git_root / "usr" / "bin" / "bash.exe") if git_root else None,
+    r"C:\Program Files\Git\bin\bash.exe",
+    r"C:\Program Files\Git\usr\bin\bash.exe",
+    shutil.which("bash"),
+]
+bash = next(
+    (c for c in bash_candidates if c and "WindowsApps" not in c and Path(c).exists()),
+    None,
+)
 requires_bash = pytest.mark.skipif(bash is None, reason="bash not available")
 
 


### PR DESCRIPTION
## What

`Resolve-BashLauncher` accepted any candidate that answered `bash --version` with exit 0. A bare `<git>\usr\bin\bash.exe` answers exactly that while carrying no `/usr/bin` on PATH, so `deploy.sh` dies at `dirname` (line 4) with **exit 127** and writes no manifest. That candidate is listed **second** in both PowerShell entry points, so any Git layout without `bin\bash.exe` silently selects an unusable shell.

The fix probes what the script actually needs — `command -v dirname && command -v mktemp` — instead of merely proving a bash binary exists. **The candidate list and its order are unchanged**, so no working install can lose its currently selected launcher unless that launcher already could not run the script.

## Origin, and a correction to it

This started from an external ChatGPT governance audit (preserved in this PR at `docs/reviews/2026-08-13-govern-audit-drift-core-health.md`; it was untracked and existed on one machine only). Its headline — "the supported PowerShell deployment entry point fails on Windows" — **does not reproduce**: on a standard Git for Windows install `deploy.ps1` exits 0, writes the manifest, and `test_deploy_ps1_entrypoint_resolves_real_bash` passes in 39.61s. The *mechanism* it found is real and is what this PR fixes.

## The finding the audit did not have

The full CI-equivalent suite returned `1 failed, 883 passed`, and the failure was the one this repo has written off **across more than one ship** as "this box's WSL-`bash`-stub artifact". It is not an artifact. `tests/ci/test_validator_worklog_family_skip.py:39` was a bare `shutil.which("bash")` — no WindowsApps exclusion, no Git Bash preference, no probe — so it handed `deploy.sh` to the WSL placeholder, which prints `wsl --install <Distro>` and exits 1.

Inventory before fixing, per the audit's own warning against a blind test-helper refactor: of the **twelve** bash-resolving test modules, **eleven already carried the guard and exactly one did not**. So this is a single-file alignment plus a ratchet, not a refactor.

## Changes

| File | Change |
|---|---|
| `.agentcortex/bin/deploy.ps1` | Discriminating acceptance probe; `try/catch` so a process-start failure skips the candidate instead of aborting the search; the no-launcher error now says *why* a present bash was skipped |
| `installers/deploy_brain.ps1` | Same (it carries a byte-divergent copy of the function) |
| `.agentcortex/tests/test_ssot_completeness.py` | `has_bash_launcher()`: WindowsApps exclusion, `OSError` handler, same probe, injectable candidate list; + 4 unit tests |
| `tests/ci/test_validator_worklog_family_skip.py` | Aligned to the candidate pattern its eleven siblings already use |
| `tests/ci/test_deploy_tiering.py` | Windows e2e + entry-point parity test |
| `tests/ci/test_bash_resolver_parity.py` | New ratchet pinning the WindowsApps guard across the whole test population |

## Evidence

- **e2e proven red before the fix**: with the probe reverted to `--version` — `AssertionError: deploy.ps1 selected a bash that cannot run deploy.sh`, `dirname: command not found`, `mktemp: command not found`, returncode 127, no manifest. With the fix: `1 passed in 22.74s`.
- The e2e builds a Git-shaped root whose only bash is the bare one — a **directory junction**, since a plain copy of `bash.exe` cannot run without its sibling msys DLLs. The junction is dropped with `os.rmdir` in a `finally` block: `os.path.islink()` reports **False** for junctions and only Python >= 3.12 `shutil.rmtree` recognises them, so on the 3.9 floor a recursive cleanup could follow it into the real Git `usr/bin`.
- Helper unit tests: `4 passed in 0.29s`. Post-fix targeted re-run of the previously-failing module + new ratchet: `6 passed in 54.48s`.
- Full CI-equivalent suite: `1 failed, 883 passed in 1:48:52` — the one failure being the mislabelled artifact above, green after its fix.
- `validate.ps1`: **integrity check passed**, no FAIL.

## Not in scope

F3 (`.claude/settings.local.json` tracked while declared user-local) and F4 (stale `59 Pending` count in SSoT) from the same audit are deliberately excluded. `installers/deploy_brain.cmd:59` has a third, unprobed `where bash` path, reachable only when `deploy_brain.ps1` is absent — recorded, unchanged. The other eleven test modules still list `<git>/usr/bin/bash.exe` as a candidate; latent, fires only on a layout where those tests are unrunnable anyway, and named in the ratchet's docstring.

## Rollback

`git revert` this PR. Additive guards inside one function per entry point plus test-side changes; no state migration, no manifest change, no downstream engine behaviour change for adopters whose launcher already worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
