### PR TITLE
docs: point the custom-* skills row at its activation on-ramp

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -203,7 +203,7 @@ However you adopt Agentic OS — **fork** the repo, or **clone + `deploy_brain.s
 | You want to… | Put it here | Why it survives upgrades |
 |---|---|---|
 | Add project governance (narrow/disable a directive) | `AGENTS.override.md` (project root) or `~/.agentcortex/AGENTS.override.md` (personal) | Loaded present-only at session start; framework never ships these files. MAY narrow/disable directives but **cannot** relax delivery gates. |
-| Add your own skills | `.agents/skills/custom-<name>/SKILL.md` (+ `.agent/skills/custom-<name>` metadata) | `custom-*` is a reserved namespace the framework never ships → zero collision, never overwritten. |
+| Add your own skills | `.agents/skills/custom-<name>/SKILL.md` (+ `.agent/skills/custom-<name>` metadata) | `custom-*` is a reserved namespace the framework never ships → zero collision, never overwritten. **Survival is not activation:** an undeclared `custom-*` skill stays inert — it is never auto-recommended and cannot be pinned. To make it activatable, declare its id under `skills:` in `.agentcortex/context/private/downstream-capabilities.yaml` (opt-in, capped at `load_policy: on-match`; see [ADR-007](adr/ADR-007-downstream-capability-declaration-seam.md)). |
 | Adjust skill activation (pin/exclude) | `.agentcortex/context/private/user-preferences.yaml` | Gitignored, personal, loaded by bootstrap. |
 | Connect an external knowledge base (read-only) | `knowledge_sources:` in `.agentcortex/context/private/downstream-capabilities.yaml` — see [Connecting a knowledge base](../.agentcortex/docs/guides/connecting-a-knowledge-base.md) | Present-only opt-in; **absent = zero cost**. Lives in the never-shipped private dir; consumed as DATA to enrich `/plan` + `/review`. |
 


### PR DESCRIPTION
## Summary

Closes the documentation half of #292 — the split the issue's own triage analysis recommended shipping standalone as a `tiny-fix`.

`docs/INSTALL.md`'s "Customizing without conflicts" table had a one-cell asymmetry between two sibling extension seams:

- **"Connect an external knowledge base"** points at `knowledge_sources:` in `.agentcortex/context/private/downstream-capabilities.yaml`.
- **"Add your own skills"** told the adopter where to *put* a `custom-*` skill and that it survives upgrades — but not that **survival is not activation**.

Verified against the code, an undeclared `custom-*` skill is genuinely second-class:

- `.agent/workflows/bootstrap.md:405` — a skill id resolves only via the §3.6 rule table, the compact index, **or** a `custom-*` id declared in `downstream-capabilities.yaml §skills`; anything else is "unknown → ignore". So an undeclared `custom-*` id is never auto-recommended and cannot be pinned from `user-preferences.yaml`.
- `docs/adr/ADR-007-...:33-38` states the same outright ("Custom skills are second-class … cannot auto-activate").

The row now says so and points at the existing opt-in on-ramp, mirroring the shape of its sibling row (pointer + ADR link + the `on-match` cap).

**Adopter delta:** an adopter reading INSTALL now learns from the same table that a `custom-*` skill needs a one-line declaration to become activatable. **Engine behaviour is unchanged** — no new detector, no auto-discovery (still rejected by ADR-007), no always-on cost.

This deliberately does **not** build the runtime bootstrap detector the issue proposes; that half stays demand-gated per the issue's own report-trigger framing, so #292 is referenced, not closed.

## Evidence

Validator — `bash .agentcortex/bin/validate.sh`:

```
[PASS] token lifecycle drift: within slack
Summary: pass=99 warn=4 fail=0 skip=3
Agentic OS integrity check passed
[exited with code 0]
```

Pinned test module (`docs/INSTALL.md` carries substring assertions in this file, so it was re-run rather than assumed doc-safe):

```
$ python -m pytest tests/ci/test_deploy_tiering.py -q
38 passed, 1 skipped in 343.50s (0:05:43)
```

Table integrity re-checked after the edit (14 table rows before and after; single-line diff, no merged rows). Link target `docs/adr/ADR-007-downstream-capability-declaration-seam.md` confirmed to exist.

Scope: 1 file, 1 line changed, doc-only.

Refs #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)
